### PR TITLE
Prepare the 0.1.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,9 @@
 
 ## Unreleased
 
-- Add the temporary standalone-ready crate scaffold.
-- Add the DataFusion-independent Delta-to-Arrow streaming reader API.
+## 0.1.0 - Release candidate
+
+- Add the read-only direct Delta Lake to Arrow streaming API.
+- Add NativeAsync and OfficialKernel data-file reader backends.
+- Add projections, predicates, deletion vectors, bounded scheduling, and scan metrics.
+- Add the optional DataFusion provider, registration, filtering, execution, and metrics API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,18 @@ name = "delta-arrow-reader"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
+description = "Read-only Delta Lake to Apache Arrow reader"
 license = "Apache-2.0"
+documentation = "https://docs.rs/delta-arrow-reader"
+homepage = "https://github.com/mag1cfrog/delta-arrow-reader"
+repository = "https://github.com/mag1cfrog/delta-arrow-reader"
+readme = "README.md"
+keywords = ["delta-lake", "arrow", "parquet", "datafusion"]
+categories = ["asynchronous", "database"]
 publish = false
 exclude = [
+    ".github/**",
+    ".gitignore",
     "benches/reader.rs",
     "tests/benchmark_harness.rs",
     "tests/datafusion_provider.rs",
@@ -24,6 +33,9 @@ default = ["native-async"]
 native-async = []
 official-kernel = []
 datafusion = ["dep:datafusion"]
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,25 +1,38 @@
 # delta-arrow-reader
 
-This is the temporary staging crate for extracting Delta Funnel's read-only
-Delta Lake to Arrow implementation. It contains the reader foundation, snapshot
-and protocol loading, deletion-vector handling, predicates, scan planning,
-partition grouping, backend-neutral scheduling, NativeAsync and OfficialKernel
-file executors, the public DataFusion-independent streaming reader, and an
-optional public DataFusion provider with registration, filtering, execution,
-dynamic partition pruning, and metrics support. It is not published or used by
-Delta Funnel production code.
+`delta-arrow-reader` is a read-only Delta Lake reader for Apache Arrow record
+batches. It provides a direct pull-driven stream API and an optional DataFusion
+table provider. The caller owns the Tokio runtime, and scans do not collect the
+whole result in memory.
 
-The crate exists only on the
-[`refactor/delta-arrow-reader-staging`](https://github.com/mag1cfrog/delta-funnel/tree/refactor/delta-arrow-reader-staging)
-branch. [Issue #460](https://github.com/mag1cfrog/delta-funnel/issues/460)
-owns this scaffold, and
-[issue #447](https://github.com/mag1cfrog/delta-funnel/issues/447) owns the
-extraction lifecycle.
+The 0.1.0 release candidate is not published while package validation is in
+progress.
 
-## Read a table without SQL
+## Installation
 
-The caller owns the Tokio runtime and pulls batches from the returned stream.
-The reader does not collect the full result in memory.
+The 0.1.0 package declaration is:
+
+```toml
+[dependencies]
+delta-arrow-reader = "0.1.0"
+futures-util = "0.3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+Enable the DataFusion adapter and add the matching DataFusion dependency when
+you need SQL integration:
+
+```toml
+[dependencies]
+datafusion = { version = "54.1.0", default-features = false, features = ["sql"] }
+delta-arrow-reader = { version = "0.1.0", features = ["datafusion"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+## Read a table directly
+
+Use `load_async` from asynchronous code. The returned stream exposes live scan
+metrics and yields batches as the caller requests them.
 
 ```rust,no_run
 use delta_arrow_reader::{DeltaComparison, DeltaPredicate, DeltaScalar, DeltaTableBuilder};
@@ -41,35 +54,96 @@ let scan = table
     .build()
     .await?;
 let mut batches = scan.execute().await?;
+let metrics = batches.metrics();
 
 while let Some(batch) = batches.try_next().await? {
     println!("rows={}", batch.num_rows());
 }
+
+println!("files={}", metrics.snapshot().files_completed);
 # Ok(())
 # }
 ```
 
-Run the deterministic local end-to-end example, which creates its own Delta
-table and reads it through only the public API:
+`DeltaTableBuilder::load` is the blocking table-load alternative. Scan building
+and execution remain asynchronous.
 
-```console
-cargo test -p delta-arrow-reader --test direct_reader local_end_to_end_example_reads_without_sql -- --exact --nocapture
+## Register a DataFusion table
+
+The `datafusion` feature exposes `DeltaTableProvider`, `register_delta_table`,
+and DataFusion execution metrics. Registration loads no data files; reads begin
+when DataFusion executes a query.
+
+```rust,no_run
+# #[cfg(feature = "datafusion")]
+# async fn query() -> Result<(), Box<dyn std::error::Error>> {
+use datafusion::prelude::SessionContext;
+use delta_arrow_reader::{
+    DeltaDataFusionScanOptions, DeltaTableBuilder, register_delta_table,
+};
+
+let context = SessionContext::new();
+let table = DeltaTableBuilder::new("/tmp/example-delta-table")
+    .load_async()
+    .await?;
+register_delta_table(
+    &context,
+    "orders",
+    table,
+    DeltaDataFusionScanOptions::default(),
+)?;
+
+let batches = context.sql("SELECT * FROM orders").await?.collect().await?;
+println!("batches={}", batches.len());
+# Ok(())
+# }
 ```
 
-## Validate the staging crate
+## Features
 
-Run these commands from the Delta Funnel repository root:
+| Feature | Default | Purpose |
+| --- | --- | --- |
+| `native-async` | Yes | Native asynchronous Parquet data-file reader and I/O metrics. |
+| `official-kernel` | No | Official Delta Kernel data-file reader backend. |
+| `datafusion` | No | DataFusion provider, registration, filtering, execution, and metrics. |
+
+At least one reader backend must be enabled to execute a scan. Select the
+backend for a scan with `DeltaReaderExecutionOptions::with_reader_backend`.
+When default features are enabled, NativeAsync is selected by default.
+
+## Runtime, errors, and metrics
+
+- The caller supplies the Tokio runtime and drives returned streams.
+- Execution limits, buffering, Parquet metadata prefetch, and optional
+  full-file reads are configured through `DeltaReaderExecutionOptions`.
+- `DeltaReaderError::phase` and `DeltaReaderError::as_str` return stable,
+  redacted categories. Dependency failures remain available through the
+  standard error source chain.
+- `DeltaReadMetrics` is a cloneable live handle. `snapshot` returns an
+  immutable point-in-time view. NativeAsync Parquet I/O counters are `None`
+  when the OfficialKernel backend is selected.
+
+## Scope
+
+The crate supports the extracted read path: snapshot selection, protocol and
+schema loading, projections, predicates, deletion vectors, partition planning,
+bounded scheduling, NativeAsync and OfficialKernel data-file reads, and the
+optional DataFusion adapter.
+
+It does not write Delta tables, manage transactions, create a Tokio runtime,
+or provide Delta Funnel orchestration, reporting, or Python APIs.
+
+See [architecture](https://github.com/mag1cfrog/delta-arrow-reader/blob/main/docs/architecture.md),
+[provenance](https://github.com/mag1cfrog/delta-arrow-reader/blob/main/docs/provenance.md),
+and the [security policy](https://github.com/mag1cfrog/delta-arrow-reader/blob/main/SECURITY.md)
+for repository details.
+
+## Development checks
+
+The repository CI runs every feature combination. The focused local checks are:
 
 ```console
-cargo fmt --all -- --check
-cargo check -p delta-arrow-reader --no-default-features --all-targets
-cargo check -p delta-arrow-reader --all-features --all-targets
-cargo clippy -p delta-arrow-reader --all-targets --all-features -- -D warnings
-cargo test -p delta-arrow-reader --no-default-features
-cargo test -p delta-arrow-reader --no-default-features --features official-kernel
-cargo test -p delta-arrow-reader --features official-kernel
-cargo test -p delta-arrow-reader --all-features
-RUSTDOCFLAGS="-D warnings" cargo doc -p delta-arrow-reader --all-features --no-deps
-cargo package -p delta-arrow-reader --allow-dirty
-git diff --check
+cargo test --locked --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
+cargo package --locked
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,12 @@
 # Security Policy
 
-This temporary crate is unpublished and supported only as part of Delta
-Funnel's extraction staging branch.
-
 ## Reporting a vulnerability
 
-Report suspected vulnerabilities privately through
-[Delta Funnel's GitHub Security Advisories](https://github.com/mag1cfrog/delta-funnel/security/advisories/new).
+Report suspected vulnerabilities privately through this repository's
+[GitHub Security Advisories](https://github.com/mag1cfrog/delta-arrow-reader/security/advisories/new).
 Do not open a public issue containing exploit details, credentials, private
-endpoint names, or sensitive logs.
+endpoint names, table locations, or sensitive logs.
 
-Include the affected commit, reproduction steps, expected impact, and any safe
-proof of concept. The independent repository will own its security policy only
-after [issue #486](https://github.com/mag1cfrog/delta-funnel/issues/486)
-transfers canonical ownership.
+Include the affected version or commit, reproduction steps, expected impact,
+and a safe proof of concept when available. Redact credentials and private
+storage details from every attachment.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,28 +2,21 @@
 
 ## Purpose
 
-This crate is a temporary validation boundary for extracting Delta Funnel's
-read-only Delta Lake to Arrow implementation. It lets maintainers prove the
-package, dependency, API, runtime, correctness, and performance boundaries
-before creating the independent repository.
+This crate owns the independently extracted, read-only Delta Lake to Arrow
+implementation. It provides direct Arrow streaming and an optional DataFusion
+adapter without depending on Delta Funnel orchestration.
 
-## Lifecycle
+## Ownership
 
-The extraction has three ownership phases:
-
-1. Delta Funnel's internal reader on `main` remains production truth.
-2. This crate receives extraction work only on
-   `refactor/delta-arrow-reader-staging`.
-3. [Issue #486](https://github.com/mag1cfrog/delta-funnel/issues/486) exports
-   one frozen validated crate subtree and transfers canonical ownership.
-
-The staging branch never merges into `main`, publishes a package, or becomes a
-Delta Funnel release. Delta Funnel later adopts only the independently
-published package.
+[Issue #486](https://github.com/mag1cfrog/delta-funnel/issues/486) exported the
+validated staging crate and transferred canonical ownership to this
+repository. Delta Funnel retains its existing internal reader until it adopts
+an independently released package. This crate remains unpublished while the
+0.1.0 candidate is validated.
 
 ## Current boundary
 
-Through #483, this crate owns reader configuration, errors, metrics, immutable
+This crate owns reader configuration, errors, metrics, immutable
 snapshot/protocol/schema loading, deletion-vector handling, exact logical
 predicates, scan metadata and transforms, deterministic partition planning,
 backend-neutral bounded scheduling, and the private NativeAsync and

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -17,12 +17,16 @@ The governing issues are
 [#459](https://github.com/mag1cfrog/delta-funnel/issues/459), and
 [#460](https://github.com/mag1cfrog/delta-funnel/issues/460).
 
-## Independent handoff
+## Independent repository
 
-[Issue #486](https://github.com/mag1cfrog/delta-funnel/issues/486) will export
-one later frozen staging SHA into the independent repository and become the
-final repository and provenance authority. This scaffold does not reserve or
-publish the candidate package.
+[Issue #486](https://github.com/mag1cfrog/delta-funnel/issues/486) exported the
+validated staging subtree to this repository with unchanged crate bytes and
+file modes. The independent import added only its Cargo lockfile, root target
+ignore rule, and CI workflow. This repository is now the canonical source.
+
+The 0.1.0 candidate remains unpublished while
+[issue #471](https://github.com/mag1cfrog/delta-funnel/issues/471) validates its
+documentation and package contents.
 
 ## Path mapping
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Read-only Delta Lake to Arrow support.
+#![doc = include_str!("../README.md")]
 
 mod config;
 #[cfg(feature = "datafusion")]


### PR DESCRIPTION
## Summary

- complete standard Cargo package metadata while keeping publication disabled
- replace staging documentation with accurate direct-reader, DataFusion, runtime, error, metrics, security, architecture, and provenance guidance
- compile README examples as crate rustdoc and keep the generated package minimal

## Validation

- full fmt, check, clippy, test, and rustdoc CI matrix
- cargo package --locked --list
- cargo package --locked
- generated-package all-feature tests
- clean external consumer across every supported feature combination
- secret, local-path, license, and diff checks

Closes mag1cfrog/delta-funnel#471