### PR TITLE
Enable delta-arrow-reader 0.1.0 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.1.0 - Release candidate
+## 0.1.0 - 2026-08-10
 
 - Add the read-only direct Delta Lake to Arrow streaming API.
 - Add NativeAsync and OfficialKernel data-file reader backends.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/mag1cfrog/delta-arrow-reader"
 readme = "README.md"
 keywords = ["delta-lake", "arrow", "parquet", "datafusion"]
 categories = ["asynchronous", "database"]
-publish = false
 exclude = [
     ".github/**",
     ".gitignore",

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ batches. It provides a direct pull-driven stream API and an optional DataFusion
 table provider. The caller owns the Tokio runtime, and scans do not collect the
 whole result in memory.
 
-The 0.1.0 release candidate is not published while package validation is in
-progress.
-
 ## Installation
 
 The 0.1.0 package declaration is:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,8 +11,8 @@ adapter without depending on Delta Funnel orchestration.
 [Issue #486](https://github.com/mag1cfrog/delta-funnel/issues/486) exported the
 validated staging crate and transferred canonical ownership to this
 repository. Delta Funnel retains its existing internal reader until it adopts
-an independently released package. This crate remains unpublished while the
-0.1.0 candidate is validated.
+the independently released package. That adoption is a separate migration
+step.
 
 ## Current boundary
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -24,9 +24,9 @@ validated staging subtree to this repository with unchanged crate bytes and
 file modes. The independent import added only its Cargo lockfile, root target
 ignore rule, and CI workflow. This repository is now the canonical source.
 
-The 0.1.0 candidate remains unpublished while
-[issue #471](https://github.com/mag1cfrog/delta-funnel/issues/471) validates its
-documentation and package contents.
+[Issue #471](https://github.com/mag1cfrog/delta-funnel/issues/471) validated the
+0.1.0 documentation and package contents. Issue #472 owns publication, tagging,
+and independent registry verification.
 
 ## Path mapping
 


### PR DESCRIPTION
## Summary

- enable Cargo publication for the already reviewed 0.1.0 package
- replace release-candidate status wording with final release wording
- keep code, APIs, dependencies, features, fixtures, and benchmarks unchanged

## Validation

- full fmt, check, clippy, test, and rustdoc matrix
- cargo package --locked --list
- cargo package --locked
- cargo publish --locked --dry-run
- clean generated-package consumer across every supported feature combination
- secret, local-path, license, and diff checks

Publication, tag, GitHub Release, registry verification, and issue closure follow only after this PR is reviewed and merged.

Part of mag1cfrog/delta-funnel#472