### PR TITLE
fix: preserve independent reader bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.1.1 - 2026-08-10
+
+- Preserve the extracted reader's independent scan, partition, and prefetch bounds.
+
 ## 0.1.0 - 2026-08-10
 
 - Add the read-only direct Delta Lake to Arrow streaming API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "delta-arrow-reader"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delta-arrow-reader"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Read-only Delta Lake to Apache Arrow reader"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ whole result in memory.
 
 ## Installation
 
-The 0.1.0 package declaration is:
+The 0.1.1 package declaration is:
 
 ```toml
 [dependencies]
-delta-arrow-reader = "0.1.0"
+delta-arrow-reader = "0.1.1"
 futures-util = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
@@ -22,7 +22,7 @@ you need SQL integration:
 ```toml
 [dependencies]
 datafusion = { version = "54.1.0", default-features = false, features = ["sql"] }
-delta-arrow-reader = { version = "0.1.0", features = ["datafusion"] }
+delta-arrow-reader = { version = "0.1.1", features = ["datafusion"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,25 +186,6 @@ impl DeltaReaderExecutionOptions {
             "parquet_full_file_read_threshold_must_be_positive",
         )?;
 
-        if self
-            .max_concurrent_file_reads_per_scan
-            .is_some_and(|scan_limit| self.max_concurrent_file_reads_per_partition > scan_limit)
-        {
-            return InvalidConfigurationSnafu {
-                reason: "partition_file_read_limit_exceeds_scan_limit",
-            }
-            .fail();
-        }
-
-        if self.native_async_prefetch_file_count_per_partition
-            > self.max_concurrent_file_reads_per_partition
-        {
-            return InvalidConfigurationSnafu {
-                reason: "native_async_prefetch_exceeds_partition_file_read_limit",
-            }
-            .fail();
-        }
-
         Ok(())
     }
 
@@ -308,9 +289,6 @@ mod tests {
             DeltaReaderExecutionOptions::new().with_output_buffer_capacity_per_partition(0),
             DeltaReaderExecutionOptions::new().with_parquet_metadata_size_hint(Some(0)),
             DeltaReaderExecutionOptions::new().with_parquet_full_file_read_threshold(Some(0)),
-            DeltaReaderExecutionOptions::new().with_max_concurrent_file_reads_per_scan(Some(2)),
-            DeltaReaderExecutionOptions::new()
-                .with_native_async_prefetch_file_count_per_partition(4),
         ];
 
         for result in invalid {
@@ -318,6 +296,19 @@ mod tests {
             assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
             assert_eq!(error.as_str(), "invalid_configuration");
         }
+    }
+
+    #[test]
+    fn independent_bounds_preserve_the_frozen_reader_behavior()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let options = DeltaReaderExecutionOptions::new()
+            .with_max_concurrent_file_reads_per_scan(Some(2))?
+            .with_native_async_prefetch_file_count_per_partition(4)?;
+
+        assert_eq!(options.max_concurrent_file_reads_per_scan(), Some(2));
+        assert_eq!(options.max_concurrent_file_reads_per_partition(), 3);
+        assert_eq!(options.native_async_prefetch_file_count_per_partition(), 4);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove two execution-option rejections that were not present in the frozen Delta Funnel reader
- retain all existing positive-bound validation and runtime semaphore limits
- add focused parity coverage and prepare patch release 0.1.1

This is the paired compatibility correction discovered by Delta Funnel issue #474. It does not change reader algorithms, defaults, dependencies, or public signatures.

## Validation

- full repository feature-matrix CI passed locally
- `cargo package --locked`
- `cargo publish --dry-run --locked`
- `git diff --check`