### PR TITLE
fix: restore Delta Funnel cutover parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.2 - 2026-08-11
+
+- Add staged snapshot loading for protocol checks before Arrow schema conversion.
+- Expose protocol and shared metrics identity needed by downstream integrations.
+- Preserve planning and object-store diagnostic context across DataFusion tasks.
+
 ## 0.1.1 - 2026-08-10
 
 - Preserve the extracted reader's independent scan, partition, and prefetch bounds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "delta-arrow-reader"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delta-arrow-reader"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Read-only Delta Lake to Apache Arrow reader"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ whole result in memory.
 
 ## Installation
 
-The 0.1.1 package declaration is:
+The 0.1.2 package declaration is:
 
 ```toml
 [dependencies]
-delta-arrow-reader = "0.1.1"
+delta-arrow-reader = "0.1.2"
 futures-util = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
@@ -22,7 +22,7 @@ you need SQL integration:
 ```toml
 [dependencies]
 datafusion = { version = "54.1.0", default-features = false, features = ["sql"] }
-delta-arrow-reader = { version = "0.1.1", features = ["datafusion"] }
+delta-arrow-reader = { version = "0.1.2", features = ["datafusion"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -134,6 +134,11 @@ impl DeltaDataFusionMetrics {
         }
     }
 
+    /// Returns whether both handles refer to the same live metrics instance.
+    pub fn same_instance(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     fn record_output_batch_size(&self, value: usize) {
         self.inner
             .output_batch_size
@@ -1228,6 +1233,8 @@ mod tests {
         assert_eq!(shared_handles.len(), 2);
         assert_eq!(shared_handles[0].source_name(), Some("first"));
         assert_eq!(shared_handles[1].source_name(), Some("second"));
+        assert!(handles[0].same_instance(&shared_handles[0]));
+        assert!(!handles[0].same_instance(&shared_handles[1]));
 
         drop(shared_metrics_union);
         drop(union);

--- a/src/datafusion_planning.rs
+++ b/src/datafusion_planning.rs
@@ -59,9 +59,23 @@ pub(crate) fn plan_datafusion_scan(
     capabilities: DataFusionFilterCapabilities,
 ) -> Result<DataFusionScanPlanning, DeltaReaderError> {
     validate_projection(schema, projection)?;
-    let filter_plan = plan_datafusion_filters(schema, partition_columns, filters, capabilities);
+    let filter_plan = {
+        let _planning = tracing::debug_span!(
+            target: "delta_arrow_reader::profile",
+            "Delta filter planning"
+        )
+        .entered();
+        plan_datafusion_filters(schema, partition_columns, filters, capabilities)
+    };
     validate_inexact_residual_projection(schema, projection, &filter_plan)?;
-    let projection_plan = plan_projection(schema, projection, &filter_plan.referenced_columns)?;
+    let projection_plan = {
+        let _planning = tracing::debug_span!(
+            target: "delta_arrow_reader::profile",
+            "Delta projection planning"
+        )
+        .entered();
+        plan_projection(schema, projection, &filter_plan.referenced_columns)?
+    };
     Ok(DataFusionScanPlanning {
         projection: projection_plan,
         filters: filter_plan,

--- a/src/datafusion_provider.rs
+++ b/src/datafusion_provider.rs
@@ -97,6 +97,11 @@ impl DeltaTableProvider {
         projection: Option<&[usize]>,
         filters: &[Expr],
     ) -> Result<(Arc<dyn ExecutionPlan>, usize), DeltaReaderError> {
+        let _planning = tracing::debug_span!(
+            target: "delta_arrow_reader::profile",
+            "Delta scan planning"
+        )
+        .entered();
         let partition_columns = self
             .table
             .partition_columns()
@@ -169,15 +174,20 @@ impl DeltaTableProvider {
             },
         )?;
         let partition_count = core.partitions.len();
-        Ok((
+        let plan = {
+            let _setup = tracing::debug_span!(
+                target: "delta_arrow_reader::profile",
+                "Delta scan execution setup"
+            )
+            .entered();
             create_datafusion_execution_plan(
                 core,
                 planning,
                 row_predicate,
                 self.source_name.clone(),
-            ),
-            partition_count,
-        ))
+            )
+        };
+        Ok((plan, partition_count))
     }
 }
 

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -27,8 +27,9 @@ use crate::{
         PartitionStream,
     },
     snapshot::{
-        LoadedDeltaTableSnapshot, load_delta_table_snapshot_async,
-        load_delta_table_snapshot_blocking,
+        LoadedDeltaTableSnapshot, StagedDeltaTableSnapshot, load_delta_table_snapshot_async,
+        load_delta_table_snapshot_blocking, load_staged_delta_table_snapshot_async,
+        load_staged_delta_table_snapshot_blocking,
     },
 };
 
@@ -126,6 +127,29 @@ impl DeltaTableBuilder {
         .await?;
         Ok(DeltaTable::new(snapshot, self.execution_options))
     }
+
+    /// Loads snapshot metadata without converting its logical Arrow schema.
+    pub fn load_snapshot(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
+        validate_direct_execution_options(self.execution_options)?;
+        let snapshot = load_staged_delta_table_snapshot_blocking(
+            &self.table_uri,
+            &self.storage_options,
+            self.snapshot_selection,
+        )?;
+        Ok(DeltaTableSnapshot::new(snapshot, self.execution_options))
+    }
+
+    /// Loads snapshot metadata through the caller-owned Tokio runtime.
+    pub async fn load_snapshot_async(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
+        validate_direct_execution_options(self.execution_options)?;
+        let snapshot = load_staged_delta_table_snapshot_async(
+            self.table_uri,
+            self.storage_options,
+            self.snapshot_selection,
+        )
+        .await?;
+        Ok(DeltaTableSnapshot::new(snapshot, self.execution_options))
+    }
 }
 
 impl fmt::Debug for DeltaTableBuilder {
@@ -137,6 +161,63 @@ impl fmt::Debug for DeltaTableBuilder {
             .field("snapshot_selection", &self.snapshot_selection)
             .field("execution_options", &self.execution_options)
             .finish()
+    }
+}
+
+/// Loaded Delta snapshot metadata awaiting logical Arrow schema conversion.
+pub struct DeltaTableSnapshot {
+    snapshot: StagedDeltaTableSnapshot,
+    execution_options: DeltaReaderExecutionOptions,
+}
+
+impl DeltaTableSnapshot {
+    fn new(
+        snapshot: StagedDeltaTableSnapshot,
+        execution_options: DeltaReaderExecutionOptions,
+    ) -> Self {
+        Self {
+            snapshot,
+            execution_options,
+        }
+    }
+
+    /// Returns the loaded Delta snapshot version.
+    pub fn version(&self) -> u64 {
+        self.snapshot.version()
+    }
+
+    /// Returns the loaded Delta protocol metadata.
+    pub fn protocol(&self) -> &DeltaProtocolInfo {
+        self.snapshot.protocol_info()
+    }
+
+    /// Returns the normalized table URI.
+    ///
+    /// This value may contain sensitive caller input. Do not log or expose it.
+    pub fn table_uri(&self) -> &str {
+        self.snapshot.table_uri()
+    }
+
+    /// Validates the loaded snapshot against the supported reader protocol.
+    pub fn validate_protocol(&self) -> Result<(), DeltaReaderError> {
+        validate_protocol(self.protocol())
+    }
+
+    /// Converts the logical Arrow schema and finishes constructing the table.
+    pub fn into_table(self) -> Result<DeltaTable, DeltaReaderError> {
+        Ok(DeltaTable::new(
+            self.snapshot.into_loaded()?,
+            self.execution_options,
+        ))
+    }
+}
+
+impl fmt::Debug for DeltaTableSnapshot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DeltaTableSnapshot")
+            .field("version", &self.version())
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,10 @@ pub use datafusion_execution::{
 pub use datafusion_provider::{
     DeltaDataFusionScanOptions, DeltaTableProvider, RegisteredDeltaTable, register_delta_table,
 };
-pub use direct::{DeltaBatchStream, DeltaScan, DeltaScanBuilder, DeltaTable, DeltaTableBuilder};
+pub use direct::{
+    DeltaBatchStream, DeltaScan, DeltaScanBuilder, DeltaTable, DeltaTableBuilder,
+    DeltaTableSnapshot,
+};
 pub use error::{DeltaReaderError, DeltaReaderPhase};
 pub use metrics::{DeltaReadMetrics, DeltaReadMetricsSnapshot};
 #[doc(hidden)]

--- a/src/metered_object_store.rs
+++ b/src/metered_object_store.rs
@@ -9,6 +9,7 @@ use object_store::{
     ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result,
     path::Path,
 };
+use tracing::Instrument;
 
 use crate::DeltaReadMetrics;
 
@@ -64,7 +65,14 @@ impl ObjectStore for MeteredParquetObjectStore {
             }
         }
 
-        let result = self.inner.get_opts(location, options).await?;
+        let result = self
+            .inner
+            .get_opts(location, options)
+            .instrument(tracing::debug_span!(
+                target: "delta_arrow_reader::profile",
+                "Object store transport"
+            ))
+            .await?;
         if should_meter_payload {
             Ok(meter_get_result(result, self.metrics.clone()))
         } else {

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -81,6 +81,11 @@ pub(crate) fn build_scan(
     predicate: Option<DeltaKernelPredicate>,
     include_stats: bool,
 ) -> Result<KernelScan, DeltaReaderError> {
+    let _planning = tracing::debug_span!(
+        target: "delta_arrow_reader::profile",
+        "Delta Kernel scan construction"
+    )
+    .entered();
     validate_protocol(snapshot.protocol_info())?;
     validate_projection(snapshot.schema().as_ref(), projection)?;
     snapshot
@@ -194,12 +199,18 @@ fn build_unpartitioned_scan_plan(
         kernel_predicate.clone(),
         include_stats,
     )?;
-    let metadata = scan
-        .file_metadata(snapshot.engine_context())
-        .boxed()
-        .context(ScanPlanningSnafu {
-            reason: "kernel_scan_metadata_failed",
-        })?;
+    let metadata = {
+        let _planning = tracing::debug_span!(
+            target: "delta_arrow_reader::profile",
+            "Delta scan metadata expansion"
+        )
+        .entered();
+        scan.file_metadata(snapshot.engine_context())
+            .boxed()
+            .context(ScanPlanningSnafu {
+                reason: "kernel_scan_metadata_failed",
+            })?
+    };
     let file_tasks = metadata
         .files
         .into_iter()
@@ -246,10 +257,17 @@ fn finalize_scan_plan(
     partition_target_diagnostic: DeltaScanPartitionTargetDiagnosticOutput,
 ) -> Result<DeltaScanPlan, DeltaReaderError> {
     let files_planned = unpartitioned.file_tasks.len();
-    let partitions = group_scan_file_tasks(
-        unpartitioned.file_tasks,
-        partition_target_diagnostic.target_partitions,
-    )?;
+    let partitions = {
+        let _planning = tracing::debug_span!(
+            target: "delta_arrow_reader::profile",
+            "Delta file task partitioning"
+        )
+        .entered();
+        group_scan_file_tasks(
+            unpartitioned.file_tasks,
+            partition_target_diagnostic.target_partitions,
+        )?
+    };
     let metrics = DeltaReadMetrics::new(DeltaReadMetricsConfig {
         snapshot_version: unpartitioned.snapshot_version,
         reader_backend: unpartitioned.execution_options.reader_backend(),
@@ -284,6 +302,11 @@ fn finalize_scan_plan(
 fn local_partition_target_diagnostic(
     options: DeltaScanPartitionTargetOptions,
 ) -> Result<DeltaScanPartitionTargetDiagnosticOutput, DeltaReaderError> {
+    let _planning = tracing::debug_span!(
+        target: "delta_arrow_reader::profile",
+        "Delta partition target selection"
+    )
+    .entered();
     let mut input = delta_scan_partition_target_local_environment_diagnostic().policy_input;
     input.explicit_target_partitions = options.explicit_target_partitions;
     if options.caller_target_partitions.is_some() {
@@ -2388,10 +2411,10 @@ mod tests {
             "datafusion::",
             "MetricBuilder",
             "ExecutionPlanMetricsSet",
-            "tracing::",
         ] {
             assert!(!planning_source.contains(forbidden), "{forbidden}");
             assert!(!transform_source.contains(forbidden), "{forbidden}");
         }
+        assert!(!transform_source.contains("tracing::"));
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -73,6 +73,14 @@ impl DeltaProtocolInfo {
     pub fn writer_features(&self) -> &[String] {
         &self.writer_features
     }
+
+    /// Returns the first required reader feature unsupported by this crate.
+    pub fn first_unsupported_reader_feature(&self) -> Option<&str> {
+        self.reader_features
+            .iter()
+            .map(String::as_str)
+            .find(|feature| !SUPPORTED_READER_FEATURES.contains(feature))
+    }
 }
 
 #[allow(dead_code)]
@@ -86,11 +94,7 @@ pub(crate) fn validate_protocol(protocol: &DeltaProtocolInfo) -> Result<(), Delt
         .fail();
     }
 
-    if protocol
-        .reader_features
-        .iter()
-        .any(|feature| !SUPPORTED_READER_FEATURES.contains(&feature.as_str()))
-    {
+    if protocol.first_unsupported_reader_feature().is_some() {
         return UnsupportedProtocolSnafu {
             reason: "unsupported_reader_feature",
         }
@@ -238,6 +242,10 @@ mod tests {
         let protocol = loaded.protocol_info();
 
         assert_eq!(protocol.reader_features(), ["madeUpFeature"]);
+        assert_eq!(
+            protocol.first_unsupported_reader_feature(),
+            Some("madeUpFeature")
+        );
         let error = validate_protocol(protocol).expect_err("unknown feature must fail");
         assert!(matches!(
             error,

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -17,6 +17,7 @@ use tokio::{
     sync::{Notify, OwnedSemaphorePermit, Semaphore, mpsc},
     task::JoinHandle,
 };
+use tracing::Instrument;
 
 use crate::{
     DeltaReadMetrics, DeltaReaderBackend, DeltaReaderError, DeltaReaderExecutionOptions,
@@ -394,13 +395,22 @@ impl PartitionStream {
         );
         let run_cancellation = cancellation.clone();
         let start = Box::new(move |output| {
-            tokio::spawn(run_partition(
-                output,
-                scheduler,
-                metrics,
-                run_cancellation,
-                prefetch_file_count,
-            ))
+            let span = tracing::debug_span!(
+                target: "delta_arrow_reader::profile",
+                parent: None,
+                "Delta partition task"
+            );
+            span.follows_from(tracing::Span::current().id());
+            tokio::spawn(
+                run_partition(
+                    output,
+                    scheduler,
+                    metrics,
+                    run_cancellation,
+                    prefetch_file_count,
+                )
+                .instrument(span),
+            )
         });
 
         Self {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -25,6 +25,41 @@ pub(crate) struct LoadedDeltaTableSnapshot {
     engine_context: Arc<DeltaKernelEngineContext>,
 }
 
+pub(crate) struct StagedDeltaTableSnapshot {
+    snapshot: KernelSnapshot,
+    protocol_info: DeltaProtocolInfo,
+    engine_context: Arc<DeltaKernelEngineContext>,
+}
+
+impl StagedDeltaTableSnapshot {
+    pub(crate) fn table_uri(&self) -> &str {
+        self.engine_context.table_url().as_str()
+    }
+
+    pub(crate) fn version(&self) -> u64 {
+        self.snapshot.version()
+    }
+
+    pub(crate) fn protocol_info(&self) -> &DeltaProtocolInfo {
+        &self.protocol_info
+    }
+
+    pub(crate) fn into_loaded(self) -> Result<LoadedDeltaTableSnapshot, DeltaReaderError> {
+        let schema =
+            snapshot_arrow_schema(&self.snapshot)
+                .boxed()
+                .context(SchemaConversionSnafu {
+                    reason: "schema_conversion_failed",
+                })?;
+        Ok(LoadedDeltaTableSnapshot {
+            snapshot: self.snapshot,
+            protocol_info: self.protocol_info,
+            schema,
+            engine_context: self.engine_context,
+        })
+    }
+}
+
 #[allow(dead_code)]
 impl LoadedDeltaTableSnapshot {
     pub(crate) fn table_uri(&self) -> &str {
@@ -67,46 +102,62 @@ pub(crate) fn load_delta_table_snapshot_blocking(
 ) -> Result<LoadedDeltaTableSnapshot, DeltaReaderError> {
     let selection_kind = snapshot_selection_kind(selection);
     trace_snapshot_load_started(selection_kind);
-    let result = (|| {
-        let table_url = normalize_delta_table_uri(table_uri)?;
-        let s3_auth_mode_hint = s3_auth_mode_hint_for_source(&table_url, storage_options);
-        let engine_context = DeltaKernelEngineContext::build(table_url, storage_options)
-            .boxed()
-            .context(StorageInitializationSnafu {
-                reason: "storage_initialization_failed",
-            })?;
-        let engine_context = Arc::new(engine_context);
-        let version = match selection {
-            DeltaSnapshotSelection::Latest => None,
-            DeltaSnapshotSelection::Version(version) => Some(version),
-        };
-        let snapshot =
-            engine_context
-                .load_snapshot(version)
-                .boxed()
-                .context(SnapshotLoadSnafu {
-                    reason: snapshot_load_failed_reason(s3_auth_mode_hint),
-                })?;
-        let protocol_info = DeltaProtocolInfo::from_snapshot(&snapshot);
-        let schema = snapshot_arrow_schema(&snapshot)
-            .boxed()
-            .context(SchemaConversionSnafu {
-                reason: "schema_conversion_failed",
-            })?;
-
-        Ok(LoadedDeltaTableSnapshot {
-            snapshot,
-            protocol_info,
-            schema,
-            engine_context,
-        })
-    })();
+    let result = stage_delta_table_snapshot(table_uri, storage_options, selection)
+        .and_then(StagedDeltaTableSnapshot::into_loaded);
 
     match &result {
         Ok(snapshot) => trace_snapshot_load_completed(selection_kind, snapshot),
         Err(error) => trace_snapshot_load_failed(selection_kind, error),
     }
     result
+}
+
+pub(crate) fn load_staged_delta_table_snapshot_blocking(
+    table_uri: &str,
+    storage_options: &DeltaStorageOptions,
+    selection: DeltaSnapshotSelection,
+) -> Result<StagedDeltaTableSnapshot, DeltaReaderError> {
+    let selection_kind = snapshot_selection_kind(selection);
+    trace_snapshot_load_started(selection_kind);
+    let result = stage_delta_table_snapshot(table_uri, storage_options, selection);
+
+    match &result {
+        Ok(snapshot) => trace_staged_snapshot_load_completed(selection_kind, snapshot),
+        Err(error) => trace_snapshot_load_failed(selection_kind, error),
+    }
+    result
+}
+
+fn stage_delta_table_snapshot(
+    table_uri: &str,
+    storage_options: &DeltaStorageOptions,
+    selection: DeltaSnapshotSelection,
+) -> Result<StagedDeltaTableSnapshot, DeltaReaderError> {
+    let table_url = normalize_delta_table_uri(table_uri)?;
+    let s3_auth_mode_hint = s3_auth_mode_hint_for_source(&table_url, storage_options);
+    let engine_context = DeltaKernelEngineContext::build(table_url, storage_options)
+        .boxed()
+        .context(StorageInitializationSnafu {
+            reason: "storage_initialization_failed",
+        })?;
+    let engine_context = Arc::new(engine_context);
+    let version = match selection {
+        DeltaSnapshotSelection::Latest => None,
+        DeltaSnapshotSelection::Version(version) => Some(version),
+    };
+    let snapshot = engine_context
+        .load_snapshot(version)
+        .boxed()
+        .context(SnapshotLoadSnafu {
+            reason: snapshot_load_failed_reason(s3_auth_mode_hint),
+        })?;
+    let protocol_info = DeltaProtocolInfo::from_snapshot(&snapshot);
+
+    Ok(StagedDeltaTableSnapshot {
+        snapshot,
+        protocol_info,
+        engine_context,
+    })
 }
 
 #[allow(dead_code)]
@@ -122,6 +173,30 @@ pub(crate) async fn load_delta_table_snapshot_async(
     let selection_kind = snapshot_selection_kind(selection);
     let result = tokio::task::spawn_blocking(move || {
         load_delta_table_snapshot_blocking(&table_uri, &storage_options, selection)
+    })
+    .await
+    .boxed()
+    .context(SnapshotLoadSnafu {
+        reason: "snapshot_load_task_failed",
+    });
+
+    match result {
+        Ok(result) => result,
+        Err(error) => {
+            trace_snapshot_load_failed(selection_kind, &error);
+            Err(error)
+        }
+    }
+}
+
+pub(crate) async fn load_staged_delta_table_snapshot_async(
+    table_uri: String,
+    storage_options: DeltaStorageOptions,
+    selection: DeltaSnapshotSelection,
+) -> Result<StagedDeltaTableSnapshot, DeltaReaderError> {
+    let selection_kind = snapshot_selection_kind(selection);
+    let result = tokio::task::spawn_blocking(move || {
+        load_staged_delta_table_snapshot_blocking(&table_uri, &storage_options, selection)
     })
     .await
     .boxed()
@@ -154,6 +229,19 @@ fn trace_snapshot_load_started(selection: &'static str) {
 }
 
 fn trace_snapshot_load_completed(selection: &'static str, snapshot: &LoadedDeltaTableSnapshot) {
+    tracing::debug!(
+        target: TRACING_TARGET,
+        event = SNAPSHOT_LOAD_COMPLETED_EVENT,
+        selection,
+        snapshot_version = snapshot.version(),
+        protocol_reader_version = snapshot.protocol_info().min_reader_version()
+    );
+}
+
+fn trace_staged_snapshot_load_completed(
+    selection: &'static str,
+    snapshot: &StagedDeltaTableSnapshot,
+) {
     tracing::debug!(
         target: TRACING_TARGET,
         event = SNAPSHOT_LOAD_COMPLETED_EVENT,
@@ -309,8 +397,8 @@ mod tests {
 
     use super::{
         S3AuthModeHint, TRACING_TARGET, load_delta_table_snapshot_async,
-        load_delta_table_snapshot_blocking, s3_auth_mode_hint_for_source,
-        snapshot_load_failed_reason,
+        load_delta_table_snapshot_blocking, load_staged_delta_table_snapshot_blocking,
+        s3_auth_mode_hint_for_source, snapshot_load_failed_reason,
     };
     use crate::{
         DeltaReaderError, DeltaReaderPhase, DeltaSnapshotSelection, DeltaStorageOptions,
@@ -323,6 +411,7 @@ mod tests {
     const SUPPORTED_TYPES_METADATA_JSON: &str = r#"{"metaData":{"id":"delta-arrow-reader-test","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"profile\",\"type\":{\"type\":\"struct\",\"fields\":[{\"name\":\"age\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"nickname\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]},\"nullable\":true,\"metadata\":{}},{\"name\":\"tags\",\"type\":{\"type\":\"array\",\"elementType\":\"integer\",\"containsNull\":false},\"nullable\":true,\"metadata\":{}},{\"name\":\"attributes\",\"type\":{\"type\":\"map\",\"keyType\":\"string\",\"valueType\":\"long\",\"valueContainsNull\":false},\"nullable\":true,\"metadata\":{}},{\"name\":\"amount\",\"type\":\"decimal(10,2)\",\"nullable\":true,\"metadata\":{}},{\"name\":\"event_ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},{\"name\":\"event_ts_ntz\",\"type\":\"timestamp_ntz\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
     const COLUMN_MAPPING_PROTOCOL_JSON: &str = r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["columnMapping"],"writerFeatures":["columnMapping"]}}"#;
     const COLUMN_MAPPING_METADATA_JSON: &str = r#"{"metaData":{"id":"delta-arrow-reader-test","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{\"delta.columnMapping.id\":1,\"delta.columnMapping.physicalName\":\"phys_id\"}},{\"name\":\"customer_name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{\"delta.columnMapping.id\":2,\"delta.columnMapping.physicalName\":\"phys_customer_name\"}}]}","partitionColumns":[],"configuration":{"delta.columnMapping.mode":"name","delta.columnMapping.maxColumnId":"2"},"createdTime":1587968585495}}"#;
+    const INVALID_ARROW_SCHEMA_METADATA_JSON: &str = r#"{"metaData":{"id":"delta-arrow-reader-test","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"bad_array\",\"type\":{\"type\":\"array\",\"elementType\":\"string\",\"containsNull\":true},\"nullable\":true,\"metadata\":{\"delta.columnMapping.nested.ids\":\"not an object\"}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
 
     static TRACING_TEST_LOCK: Mutex<()> = Mutex::new(());
     static TRACING_TEST_GLOBAL_SUBSCRIBER: Once = Once::new();
@@ -571,6 +660,32 @@ mod tests {
         assert_eq!(key_value[0].data_type(), &DataType::Utf8);
         assert_eq!(key_value[1].data_type(), &DataType::Int64);
         assert!(!key_value[1].is_nullable());
+        Ok(())
+    }
+
+    #[test]
+    fn staged_load_exposes_metadata_before_schema_conversion()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let table = DeltaLogTable::new_with_protocol_and_metadata(
+            "staged-schema-failure",
+            PROTOCOL_JSON,
+            INVALID_ARROW_SCHEMA_METADATA_JSON,
+        )?;
+        let staged = load_staged_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &DeltaStorageOptions::new(),
+            DeltaSnapshotSelection::Latest,
+        )?;
+
+        assert_eq!(staged.version(), 1);
+        assert_eq!(staged.protocol_info().min_reader_version(), 1);
+        assert!(staged.table_uri().starts_with("file://"));
+        let error = match staged.into_loaded() {
+            Ok(_) => panic!("invalid nested column metadata must fail schema conversion"),
+            Err(error) => error,
+        };
+        assert_eq!(error.phase(), DeltaReaderPhase::Schema);
+        assert!(matches!(error, DeltaReaderError::SchemaConversion { .. }));
         Ok(())
     }
 

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -8,7 +8,7 @@ use delta_arrow_reader::{
     DeltaScanPartitionTargetDiagnosticInput, DeltaScanPartitionTargetDiagnosticOutput,
     DeltaScanPartitionTargetDiagnosticSource, DeltaScanPartitionTargetLocalEnvironmentDiagnostic,
     DeltaScanPartitionTargetLocalUnixFileDescriptorLimitStatus, DeltaSnapshotSelection,
-    DeltaStorageOptions, DeltaTable, DeltaTableBuilder,
+    DeltaStorageOptions, DeltaTable, DeltaTableBuilder, DeltaTableSnapshot,
     delta_scan_partition_target_local_environment_diagnostic,
     derive_delta_scan_partition_target_diagnostic,
 };
@@ -25,12 +25,15 @@ fn configuration_and_error_contract_is_public() -> Result<(), DeltaReaderError> 
         DeltaProtocolInfo::reader_features;
     let writer_features: for<'a> fn(&'a DeltaProtocolInfo) -> &'a [String] =
         DeltaProtocolInfo::writer_features;
+    let first_unsupported_reader_feature: for<'a> fn(&'a DeltaProtocolInfo) -> Option<&'a str> =
+        DeltaProtocolInfo::first_unsupported_reader_feature;
     let _ = (
         snapshot_version,
         min_reader_version,
         min_writer_version,
         reader_features,
         writer_features,
+        first_unsupported_reader_feature,
     );
 
     let mut storage_options = DeltaStorageOptions::new();
@@ -203,7 +206,30 @@ fn direct_reader_contract_is_public() {
     assert_future::<Result<DeltaTable, DeltaReaderError>>(builder.load_async());
     let load: fn(DeltaTableBuilder) -> Result<DeltaTable, DeltaReaderError> =
         DeltaTableBuilder::load;
-    let _ = load;
+    let load_snapshot: fn(DeltaTableBuilder) -> Result<DeltaTableSnapshot, DeltaReaderError> =
+        DeltaTableBuilder::load_snapshot;
+    let snapshot_builder = DeltaTableBuilder::new("file:///tmp/table");
+    assert_future::<Result<DeltaTableSnapshot, DeltaReaderError>>(
+        snapshot_builder.load_snapshot_async(),
+    );
+    let _ = (load, load_snapshot);
+
+    let snapshot_version: fn(&DeltaTableSnapshot) -> u64 = DeltaTableSnapshot::version;
+    let snapshot_protocol: for<'a> fn(&'a DeltaTableSnapshot) -> &'a DeltaProtocolInfo =
+        DeltaTableSnapshot::protocol;
+    let snapshot_table_uri: for<'a> fn(&'a DeltaTableSnapshot) -> &'a str =
+        DeltaTableSnapshot::table_uri;
+    let validate_snapshot_protocol: fn(&DeltaTableSnapshot) -> Result<(), DeltaReaderError> =
+        DeltaTableSnapshot::validate_protocol;
+    let into_table: fn(DeltaTableSnapshot) -> Result<DeltaTable, DeltaReaderError> =
+        DeltaTableSnapshot::into_table;
+    let _ = (
+        snapshot_version,
+        snapshot_protocol,
+        snapshot_table_uri,
+        validate_snapshot_protocol,
+        into_table,
+    );
 
     let version: fn(&DeltaTable) -> u64 = DeltaTable::version;
     let schema: for<'a> fn(&'a DeltaTable) -> &'a SchemaRef = DeltaTable::schema;
@@ -278,9 +304,11 @@ fn datafusion_metrics_contract_is_public() {
         DeltaDataFusionMetrics::source_name;
     let snapshot: fn(&DeltaDataFusionMetrics) -> DeltaDataFusionMetricsSnapshot =
         DeltaDataFusionMetrics::snapshot;
+    let same_instance: fn(&DeltaDataFusionMetrics, &DeltaDataFusionMetrics) -> bool =
+        DeltaDataFusionMetrics::same_instance;
     let collect: fn(&dyn datafusion::physical_plan::ExecutionPlan) -> Vec<DeltaDataFusionMetrics> =
         collect_delta_datafusion_metrics;
-    let _ = (source_name, snapshot, collect, inspect);
+    let _ = (source_name, snapshot, same_instance, collect, inspect);
 }
 
 #[cfg(feature = "datafusion")]


### PR DESCRIPTION
## Summary

- add the staged snapshot boundary needed by Delta Funnel's source lifecycle
- expose exact protocol-feature and metrics-identity accessors at the public ownership boundary
- preserve planning and object-store diagnostic spans across detached partition tasks
- publish the source corresponding to delta-arrow-reader 0.1.2

## Why

The Delta Funnel cutover audit found integration parity gaps that could not be fixed cleanly from the consuming crate. This is the smallest standalone correction needed to preserve the frozen source lifecycle, protocol reporting, terminal metrics identity, and profiling behavior.

## Validation

- full test suite with all features
- complete feature check matrix
- clippy for all targets and features with warnings denied
- rustdoc with warnings denied
- package and publish dry runs
- Delta Funnel cross-repository integration tests
- formatting and diff checks

