### PR TITLE
fix: speed up large DataFusion text scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Decode DataFusion string and binary columns directly into Arrow view arrays and dictionary-encode string and binary partition columns.
+
 ## 0.1.2 - 2026-08-11
 
 - Add staged snapshot loading for protocol checks before Arrow schema conversion.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ println!("batches={}", batches.len());
 # }
 ```
 
+The DataFusion provider uses Arrow view arrays for string and binary data-file
+columns and dictionary arrays for string and binary partition columns. Direct
+reader scans retain the Delta table's ordinary Arrow schema.
+
 ## Features
 
 | Feature | Default | Purpose |

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -574,7 +574,10 @@ impl Query {
 
     const fn expected_columns(self) -> &'static [(&'static str, DataType)] {
         match self {
-            Self::FullRows => &[("id", DataType::Int32), ("customer_name", DataType::Utf8)],
+            Self::FullRows => &[
+                ("id", DataType::Int32),
+                ("customer_name", DataType::Utf8View),
+            ],
             Self::ProjectId | Self::FilterTailIds => &[("id", DataType::Int32)],
         }
     }

--- a/src/datafusion_dynamic_partition_pruning.rs
+++ b/src/datafusion_dynamic_partition_pruning.rs
@@ -208,7 +208,12 @@ fn arrow_partition_type_to_kernel_primitive(
     data_type: &ArrowDataType,
 ) -> Option<KernelPrimitiveType> {
     match data_type {
-        ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => Some(KernelPrimitiveType::String),
+        ArrowDataType::Dictionary(_, value_type) => {
+            arrow_partition_type_to_kernel_primitive(value_type)
+        }
+        ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 | ArrowDataType::Utf8View => {
+            Some(KernelPrimitiveType::String)
+        }
         ArrowDataType::Int8 => Some(KernelPrimitiveType::Byte),
         ArrowDataType::Int16 => Some(KernelPrimitiveType::Short),
         ArrowDataType::Int32 => Some(KernelPrimitiveType::Integer),
@@ -217,9 +222,10 @@ fn arrow_partition_type_to_kernel_primitive(
         ArrowDataType::Float64 => Some(KernelPrimitiveType::Double),
         ArrowDataType::Boolean => Some(KernelPrimitiveType::Boolean),
         ArrowDataType::Date32 => Some(KernelPrimitiveType::Date),
-        ArrowDataType::Binary | ArrowDataType::LargeBinary | ArrowDataType::FixedSizeBinary(_) => {
-            Some(KernelPrimitiveType::Binary)
-        }
+        ArrowDataType::Binary
+        | ArrowDataType::LargeBinary
+        | ArrowDataType::BinaryView
+        | ArrowDataType::FixedSizeBinary(_) => Some(KernelPrimitiveType::Binary),
         ArrowDataType::Timestamp(ArrowTimeUnit::Microsecond, Some(timezone))
             if !timezone.is_empty() =>
         {
@@ -242,10 +248,17 @@ fn kernel_partition_scalar_to_datafusion_scalar(
     match (scalar, data_type) {
         (Scalar::Null(_), data_type) => ScalarValue::try_from(data_type)
             .map_err(|_| PartitionScalarAdapterError::UnsupportedArrowType),
+        (scalar, ArrowDataType::Dictionary(key_type, value_type)) => Ok(ScalarValue::Dictionary(
+            key_type.clone(),
+            Box::new(kernel_partition_scalar_to_datafusion_scalar(
+                scalar, value_type,
+            )?),
+        )),
         (Scalar::String(value), ArrowDataType::Utf8) => Ok(ScalarValue::Utf8(Some(value))),
         (Scalar::String(value), ArrowDataType::LargeUtf8) => {
             Ok(ScalarValue::LargeUtf8(Some(value)))
         }
+        (Scalar::String(value), ArrowDataType::Utf8View) => Ok(ScalarValue::Utf8View(Some(value))),
         (Scalar::Byte(value), ArrowDataType::Int8) => Ok(ScalarValue::Int8(Some(value))),
         (Scalar::Short(value), ArrowDataType::Int16) => Ok(ScalarValue::Int16(Some(value))),
         (Scalar::Integer(value), ArrowDataType::Int32) => Ok(ScalarValue::Int32(Some(value))),
@@ -265,6 +278,9 @@ fn kernel_partition_scalar_to_datafusion_scalar(
         }
         (Scalar::Binary(value), ArrowDataType::LargeBinary) if !value.is_empty() => {
             Ok(ScalarValue::LargeBinary(Some(value)))
+        }
+        (Scalar::Binary(value), ArrowDataType::BinaryView) if !value.is_empty() => {
+            Ok(ScalarValue::BinaryView(Some(value)))
         }
         (Scalar::Binary(value), ArrowDataType::FixedSizeBinary(size))
             if usize::try_from(*size).is_ok_and(|size| value.len() == size)
@@ -487,6 +503,10 @@ mod tests {
     fn partition_scalar_adapter_preserves_provider_arrow_shapes()
     -> Result<(), Box<dyn std::error::Error>> {
         let timezone = Arc::<str>::from("America/Phoenix");
+        let dictionary_type = ArrowDataType::Dictionary(
+            Box::new(ArrowDataType::UInt16),
+            Box::new(ArrowDataType::Utf8),
+        );
 
         assert_eq!(
             kernel_partition_scalar_to_datafusion_scalar(
@@ -497,10 +517,44 @@ mod tests {
         );
         assert_eq!(
             kernel_partition_scalar_to_datafusion_scalar(
+                Scalar::String("value".to_owned()),
+                &ArrowDataType::Utf8View,
+            ),
+            Ok(ScalarValue::Utf8View(Some("value".to_owned())))
+        );
+        assert_eq!(
+            kernel_partition_scalar_to_datafusion_scalar(
+                Scalar::String("value".to_owned()),
+                &dictionary_type,
+            ),
+            Ok(ScalarValue::Dictionary(
+                Box::new(ArrowDataType::UInt16),
+                Box::new(ScalarValue::Utf8(Some("value".to_owned()))),
+            ))
+        );
+        assert_eq!(
+            kernel_partition_scalar_to_datafusion_scalar(
+                Scalar::Null(delta_kernel::schema::DataType::STRING),
+                &dictionary_type,
+            ),
+            Ok(ScalarValue::Dictionary(
+                Box::new(ArrowDataType::UInt16),
+                Box::new(ScalarValue::Utf8(None)),
+            ))
+        );
+        assert_eq!(
+            kernel_partition_scalar_to_datafusion_scalar(
                 Scalar::Binary(b"abc".to_vec()),
                 &ArrowDataType::LargeBinary,
             ),
             Ok(ScalarValue::LargeBinary(Some(b"abc".to_vec())))
+        );
+        assert_eq!(
+            kernel_partition_scalar_to_datafusion_scalar(
+                Scalar::Binary(b"abc".to_vec()),
+                &ArrowDataType::BinaryView,
+            ),
+            Ok(ScalarValue::BinaryView(Some(b"abc".to_vec())))
         );
         assert_eq!(
             kernel_partition_scalar_to_datafusion_scalar(

--- a/src/datafusion_planning.rs
+++ b/src/datafusion_planning.rs
@@ -629,11 +629,15 @@ fn partition_literal_matches(
         return false;
     };
     match (field.data_type(), literal) {
-        (
-            DataType::Utf8 | DataType::LargeUtf8,
-            Expr::Literal(ScalarValue::Utf8(Some(_)) | ScalarValue::LargeUtf8(Some(_)), _),
-        )
-        | (DataType::Int8, Expr::Literal(ScalarValue::Int8(Some(_)), _))
+        (DataType::Utf8 | DataType::LargeUtf8, Expr::Literal(value, _))
+            if matches!(
+                scalar_value(value),
+                Some(DeltaScalar::Utf8(_) | DeltaScalar::LargeUtf8(_))
+            ) =>
+        {
+            true
+        }
+        (DataType::Int8, Expr::Literal(ScalarValue::Int8(Some(_)), _))
         | (DataType::Int16, Expr::Literal(ScalarValue::Int16(Some(_)), _))
         | (DataType::Int32, Expr::Literal(ScalarValue::Int32(Some(_)), _))
         | (DataType::Int64, Expr::Literal(ScalarValue::Int64(Some(_)), _))
@@ -649,13 +653,10 @@ fn partition_literal_matches(
             DataType::Decimal128(precision, scale),
             Expr::Literal(ScalarValue::Decimal128(Some(_), other_precision, other_scale), _),
         ) => *scale >= 0 && precision == other_precision && scale == other_scale,
-        (
-            DataType::Binary | DataType::LargeBinary,
-            Expr::Literal(
-                ScalarValue::Binary(Some(value)) | ScalarValue::LargeBinary(Some(value)),
-                _,
-            ),
-        ) => !value.is_empty(),
+        (DataType::Binary | DataType::LargeBinary, Expr::Literal(value, _)) => matches!(
+            scalar_value(value),
+            Some(DeltaScalar::Binary(value) | DeltaScalar::LargeBinary(value)) if !value.is_empty()
+        ),
         (
             DataType::FixedSizeBinary(size),
             Expr::Literal(ScalarValue::FixedSizeBinary(other_size, Some(value)), _),
@@ -780,10 +781,10 @@ fn data_stats_column_literal(column: &Expr, op: Operator, literal: &Expr, schema
             DataType::Decimal128(precision, scale),
             Expr::Literal(ScalarValue::Decimal128(Some(_), other_precision, other_scale), _),
         ) => *scale >= 0 && precision == other_precision && scale == other_scale,
-        (
-            DataType::Utf8 | DataType::LargeUtf8,
-            Expr::Literal(ScalarValue::Utf8(Some(_)) | ScalarValue::LargeUtf8(Some(_)), _),
-        ) => true,
+        (DataType::Utf8 | DataType::LargeUtf8, Expr::Literal(value, _)) => matches!(
+            scalar_value(value),
+            Some(DeltaScalar::Utf8(_) | DeltaScalar::LargeUtf8(_))
+        ),
         (DataType::Float32, Expr::Literal(ScalarValue::Float32(Some(value)), _)) => {
             value.is_finite() && *value != 0.0
         }
@@ -1027,6 +1028,7 @@ fn expr_literal(expr: &Expr) -> Option<&ScalarValue> {
 
 fn scalar_value(value: &ScalarValue) -> Option<DeltaScalar> {
     match value {
+        ScalarValue::Dictionary(_, value) => scalar_value(value),
         ScalarValue::Boolean(Some(value)) => Some(DeltaScalar::Boolean(*value)),
         ScalarValue::Int8(Some(value)) => Some(DeltaScalar::Int8(*value)),
         ScalarValue::Int16(Some(value)) => Some(DeltaScalar::Int16(*value)),
@@ -1045,8 +1047,10 @@ fn scalar_value(value: &ScalarValue) -> Option<DeltaScalar> {
             scale: *scale,
         }),
         ScalarValue::Utf8(Some(value)) => Some(DeltaScalar::Utf8(value.clone())),
+        ScalarValue::Utf8View(Some(value)) => Some(DeltaScalar::Utf8(value.clone())),
         ScalarValue::LargeUtf8(Some(value)) => Some(DeltaScalar::LargeUtf8(value.clone())),
         ScalarValue::Binary(Some(value)) => Some(DeltaScalar::Binary(value.clone())),
+        ScalarValue::BinaryView(Some(value)) => Some(DeltaScalar::Binary(value.clone())),
         ScalarValue::LargeBinary(Some(value)) => Some(DeltaScalar::LargeBinary(value.clone())),
         ScalarValue::FixedSizeBinary(size, Some(value)) => Some(DeltaScalar::FixedSizeBinary {
             size: *size,
@@ -1759,6 +1763,28 @@ mod tests {
 
     #[test]
     fn unsupported_scalar_families_never_enter_core_predicates() {
+        assert_eq!(
+            scalar_value(&ScalarValue::Utf8View(Some("value".to_owned()))),
+            Some(DeltaScalar::Utf8("value".to_owned()))
+        );
+        assert_eq!(
+            scalar_value(&ScalarValue::BinaryView(Some(vec![1]))),
+            Some(DeltaScalar::Binary(vec![1]))
+        );
+        assert_eq!(
+            scalar_value(&ScalarValue::Dictionary(
+                Box::new(DataType::UInt16),
+                Box::new(ScalarValue::Utf8View(Some("value".to_owned()))),
+            )),
+            Some(DeltaScalar::Utf8("value".to_owned()))
+        );
+        assert!(
+            scalar_value(&ScalarValue::Dictionary(
+                Box::new(DataType::UInt16),
+                Box::new(ScalarValue::UInt16(Some(1))),
+            ))
+            .is_none()
+        );
         let unsupported = [
             ScalarValue::Null,
             ScalarValue::Float16(None),
@@ -1769,8 +1795,6 @@ mod tests {
             ScalarValue::UInt16(Some(1)),
             ScalarValue::UInt32(Some(1)),
             ScalarValue::UInt64(Some(1)),
-            ScalarValue::Utf8View(Some("value".to_owned())),
-            ScalarValue::BinaryView(Some(vec![1])),
             ScalarValue::Date64(Some(1)),
             ScalarValue::Time32Second(Some(1)),
             ScalarValue::Time32Millisecond(Some(1)),

--- a/src/datafusion_provider.rs
+++ b/src/datafusion_provider.rs
@@ -2,12 +2,12 @@
 
 use std::{collections::HashSet, fmt, sync::Arc};
 
-use arrow::datatypes::SchemaRef;
+use arrow::datatypes::{DataType, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
     catalog::Session,
     common::{DataFusionError, Result as DataFusionResult},
-    datasource::{TableProvider, TableType},
+    datasource::{TableProvider, TableType, physical_plan::wrap_partition_type_in_dict},
     execution::context::SessionContext,
     logical_expr::{Expr, TableProviderFilterPushDown},
     physical_plan::ExecutionPlan,
@@ -23,6 +23,7 @@ use crate::{
     planning::{
         DeltaScanPartitionTargetOptions, plan_row_predicate, plan_scan, validate_backend_available,
     },
+    transform::schema_with_view_types,
 };
 
 const TRACING_TARGET: &str = "delta_arrow_reader::datafusion";
@@ -58,6 +59,7 @@ pub struct DeltaDataFusionScanOptions {
 #[derive(Clone)]
 pub struct DeltaTableProvider {
     table: DeltaTable,
+    schema: SchemaRef,
     options: DeltaDataFusionScanOptions,
     source_name: Option<String>,
 }
@@ -84,8 +86,11 @@ impl DeltaTableProvider {
             });
         }
         table.validate_protocol()?;
+        let partition_columns = table.partition_columns().iter().cloned().collect();
+        let schema = datafusion_schema(table.schema(), &partition_columns);
         Ok(Self {
             table,
+            schema,
             options,
             source_name,
         })
@@ -109,7 +114,7 @@ impl DeltaTableProvider {
             .cloned()
             .collect::<HashSet<_>>();
         let filter_refs = filters.iter().collect::<Vec<_>>();
-        let planning = plan_datafusion_scan(
+        let mut planning = plan_datafusion_scan(
             self.table.schema(),
             &partition_columns,
             projection,
@@ -161,7 +166,7 @@ impl DeltaTableProvider {
             &hidden_columns,
             row_predicate,
         )?;
-        let core = plan_scan(
+        let mut core = plan_scan(
             self.table.snapshot(),
             physical_projection.as_deref(),
             &hidden_columns,
@@ -173,6 +178,11 @@ impl DeltaTableProvider {
                 caller_target_partitions: Some(state.config().target_partitions()),
             },
         )?;
+        core.logical_schema = datafusion_schema(&core.logical_schema, &partition_columns);
+        core.physical_schema = datafusion_schema(&core.physical_schema, &partition_columns);
+        core.projected_schema = datafusion_schema(&core.projected_schema, &partition_columns);
+        planning.projection.output_schema =
+            datafusion_schema(&planning.projection.output_schema, &partition_columns);
         let partition_count = core.partitions.len();
         let plan = {
             let _setup = tracing::debug_span!(
@@ -191,6 +201,40 @@ impl DeltaTableProvider {
     }
 }
 
+fn datafusion_schema(schema: &Schema, partition_columns: &HashSet<String>) -> SchemaRef {
+    let view_schema = schema_with_view_types(schema);
+    Arc::new(Schema::new_with_metadata(
+        schema
+            .fields()
+            .iter()
+            .zip(view_schema.fields())
+            .map(|(logical, view)| {
+                if partition_columns.contains(logical.name())
+                    && matches!(
+                        logical.data_type(),
+                        DataType::Utf8
+                            | DataType::LargeUtf8
+                            | DataType::Binary
+                            | DataType::LargeBinary
+                    )
+                {
+                    Arc::new(
+                        logical
+                            .as_ref()
+                            .clone()
+                            .with_data_type(wrap_partition_type_in_dict(
+                                logical.data_type().clone(),
+                            )),
+                    )
+                } else {
+                    Arc::clone(view)
+                }
+            })
+            .collect::<Vec<_>>(),
+        schema.metadata().clone(),
+    ))
+}
+
 impl fmt::Debug for DeltaTableProvider {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -203,7 +247,7 @@ impl fmt::Debug for DeltaTableProvider {
 #[async_trait]
 impl TableProvider for DeltaTableProvider {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(self.table.schema())
+        Arc::clone(&self.schema)
     }
 
     fn table_type(&self) -> TableType {
@@ -467,7 +511,11 @@ fn trace_failure(
 
 #[cfg(test)]
 mod tests {
-    use super::validate_registration_name;
+    use std::collections::{HashMap, HashSet};
+
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    use super::{datafusion_schema, validate_registration_name};
 
     #[test]
     fn registration_names_preserve_the_frozen_unquoted_identifier_boundary() {
@@ -492,5 +540,49 @@ mod tests {
         ] {
             assert!(validate_registration_name(name).is_err(), "{name}");
         }
+    }
+
+    #[test]
+    fn datafusion_schema_uses_views_except_for_dictionary_partitions() {
+        let field_metadata = HashMap::from([("field-key".to_owned(), "field-value".to_owned())]);
+        let schema_metadata = HashMap::from([("schema-key".to_owned(), "schema-value".to_owned())]);
+        let schema = Schema::new_with_metadata(
+            vec![
+                Field::new("text", DataType::Utf8, true).with_metadata(field_metadata.clone()),
+                Field::new("payload", DataType::Binary, true),
+                Field::new("region", DataType::Utf8, true),
+                Field::new("partition_payload", DataType::LargeBinary, true),
+                Field::new("id", DataType::Int32, false),
+            ],
+            schema_metadata.clone(),
+        );
+        let partitions = HashSet::from(["region".to_owned(), "partition_payload".to_owned()]);
+
+        let mapped = datafusion_schema(&schema, &partitions);
+
+        assert_eq!(
+            mapped.as_ref(),
+            &Schema::new_with_metadata(
+                vec![
+                    Field::new("text", DataType::Utf8View, true).with_metadata(field_metadata),
+                    Field::new("payload", DataType::BinaryView, true),
+                    Field::new(
+                        "region",
+                        DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+                        true,
+                    ),
+                    Field::new(
+                        "partition_payload",
+                        DataType::Dictionary(
+                            Box::new(DataType::UInt16),
+                            Box::new(DataType::LargeBinary),
+                        ),
+                        true,
+                    ),
+                    Field::new("id", DataType::Int32, false),
+                ],
+                schema_metadata,
+            )
+        );
     }
 }

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 use arrow::{
     array::{Array, ArrayRef, Int64Array, ListArray, MapArray, StructArray, new_null_array},
     compute::cast,
-    datatypes::{DataType, Field, Fields, SchemaRef},
+    datatypes::{DataType, Field, Fields, Schema, SchemaRef},
     record_batch::RecordBatch,
 };
 use futures_util::{StreamExt, stream};
 use object_store::{ObjectStore, ObjectStoreExt, memory::InMemory, path::Path};
 use parquet::arrow::{
     PARQUET_FIELD_ID_META_KEY, ProjectionMask, RowNumber,
-    arrow_reader::{ArrowPredicateFn, ArrowReaderOptions, RowFilter},
+    arrow_reader::{ArrowPredicateFn, ArrowReaderMetadata, ArrowReaderOptions, RowFilter},
     async_reader::{
         ParquetObjectReader, ParquetRecordBatchStream, ParquetRecordBatchStreamBuilder,
     },
@@ -36,7 +36,7 @@ use crate::{
     native_async_row_group_pruning::native_async_pruned_row_groups,
     planning::{DeltaScanFileTask, DeltaScanPlan},
     scheduling::{FileBatchStream, FileExecutor, FileReadPermit, ScanCancellation},
-    transform::align_batch_to_logical_schema,
+    transform::{align_batch_to_logical_schema, schema_uses_view_types, schema_with_view_types},
 };
 
 struct NativeAsyncFileReader {
@@ -185,12 +185,42 @@ impl NativeAsyncFileReader {
             .context(DataFileReadSnafu {
                 reason: "parquet_row_index_setup_failed",
             })?;
-        let builder = ParquetRecordBatchStreamBuilder::new_with_options(reader, reader_options)
-            .await
+        let builder = if schema_uses_view_types(&provider_schema) {
+            let mut metadata_reader = reader.clone();
+            let metadata =
+                ArrowReaderMetadata::load_async(&mut metadata_reader, reader_options.clone())
+                    .await
+                    .boxed()
+                    .context(DataFileReadSnafu {
+                        reason: "parquet_read_setup_failed",
+                    })?;
+            let file_schema = Schema::new_with_metadata(
+                metadata
+                    .schema()
+                    .fields()
+                    .iter()
+                    .filter(|field| field.name() != ORIGINAL_ROW_INDEX_COLUMN)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                metadata.schema().metadata().clone(),
+            );
+            let metadata = ArrowReaderMetadata::try_new(
+                Arc::clone(metadata.metadata()),
+                reader_options.with_schema(schema_with_view_types(&file_schema)),
+            )
             .boxed()
             .context(DataFileReadSnafu {
                 reason: "parquet_read_setup_failed",
             })?;
+            ParquetRecordBatchStreamBuilder::new_with_metadata(reader, metadata)
+        } else {
+            ParquetRecordBatchStreamBuilder::new_with_options(reader, reader_options)
+                .await
+                .boxed()
+                .context(DataFileReadSnafu {
+                    reason: "parquet_read_setup_failed",
+                })?
+        };
         let schema_match = build_native_async_schema_match(
             builder.parquet_schema(),
             builder.schema(),

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -2,7 +2,11 @@
 
 use std::sync::Arc;
 
-use arrow::{compute::cast, datatypes::SchemaRef, record_batch::RecordBatch};
+use arrow::{
+    compute::cast,
+    datatypes::{DataType, FieldRef, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
 use snafu::ResultExt;
 
 use crate::{
@@ -28,7 +32,7 @@ pub(crate) fn align_batch_to_logical_schema(
             .all(|(actual, expected)| {
                 actual.name() == expected.name()
                     && actual.is_nullable() == expected.is_nullable()
-                    && actual.data_type().equals_datatype(expected.data_type())
+                    && view_compatible(actual.data_type(), expected.data_type())
             });
     if !compatible {
         return Err(delta_kernel::Error::generic(mismatch_message))
@@ -60,6 +64,87 @@ pub(crate) fn align_batch_to_logical_schema(
         })
 }
 
+pub(crate) fn schema_with_view_types(schema: &Schema) -> SchemaRef {
+    Arc::new(Schema::new_with_metadata(
+        schema
+            .fields()
+            .iter()
+            .map(field_with_view_types)
+            .collect::<Vec<_>>(),
+        schema.metadata().clone(),
+    ))
+}
+
+pub(crate) fn schema_uses_view_types(schema: &Schema) -> bool {
+    schema
+        .fields()
+        .iter()
+        .any(|field| data_type_uses_view_types(field.data_type()))
+}
+
+fn field_with_view_types(field: &FieldRef) -> FieldRef {
+    let data_type = match field.data_type() {
+        DataType::Utf8 | DataType::LargeUtf8 => DataType::Utf8View,
+        DataType::Binary | DataType::LargeBinary => DataType::BinaryView,
+        DataType::Struct(fields) => {
+            DataType::Struct(fields.iter().map(field_with_view_types).collect())
+        }
+        DataType::List(inner) => DataType::List(field_with_view_types(inner)),
+        DataType::LargeList(inner) => DataType::LargeList(field_with_view_types(inner)),
+        DataType::ListView(inner) => DataType::ListView(field_with_view_types(inner)),
+        DataType::LargeListView(inner) => DataType::LargeListView(field_with_view_types(inner)),
+        DataType::Map(inner, ordered) => DataType::Map(field_with_view_types(inner), *ordered),
+        _ => return Arc::clone(field),
+    };
+    Arc::new(field.as_ref().clone().with_data_type(data_type))
+}
+
+fn data_type_uses_view_types(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Utf8View | DataType::BinaryView => true,
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|field| data_type_uses_view_types(field.data_type())),
+        DataType::List(inner)
+        | DataType::LargeList(inner)
+        | DataType::ListView(inner)
+        | DataType::LargeListView(inner)
+        | DataType::Map(inner, _) => data_type_uses_view_types(inner.data_type()),
+        _ => false,
+    }
+}
+
+fn view_compatible(actual: &DataType, expected: &DataType) -> bool {
+    if actual.equals_datatype(expected) {
+        return true;
+    }
+    match (actual, expected) {
+        (DataType::Utf8 | DataType::LargeUtf8, DataType::Utf8View)
+        | (DataType::Binary | DataType::LargeBinary, DataType::BinaryView) => true,
+        (actual, DataType::Dictionary(_, expected)) => actual.equals_datatype(expected),
+        (DataType::Struct(actual), DataType::Struct(expected)) => {
+            actual.len() == expected.len()
+                && actual.iter().zip(expected).all(|(actual, expected)| {
+                    actual.is_nullable() == expected.is_nullable()
+                        && view_compatible(actual.data_type(), expected.data_type())
+                })
+        }
+        (DataType::List(actual), DataType::List(expected))
+        | (DataType::LargeList(actual), DataType::LargeList(expected))
+        | (DataType::ListView(actual), DataType::ListView(expected))
+        | (DataType::LargeListView(actual), DataType::LargeListView(expected)) => {
+            actual.is_nullable() == expected.is_nullable()
+                && view_compatible(actual.data_type(), expected.data_type())
+        }
+        (DataType::Map(actual, actual_ordered), DataType::Map(expected, expected_ordered)) => {
+            actual_ordered == expected_ordered
+                && actual.is_nullable() == expected.is_nullable()
+                && view_compatible(actual.data_type(), expected.data_type())
+        }
+        _ => false,
+    }
+}
+
 #[allow(dead_code)]
 impl DeltaScanPlan {
     pub(crate) fn apply_transform(
@@ -87,5 +172,196 @@ impl DeltaScanPlan {
         }
 
         Ok(batch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use arrow::{
+        array::{Array, DictionaryArray, StringArray, StringViewArray},
+        datatypes::{DataType, Field, Schema, UInt16Type},
+        record_batch::RecordBatch,
+    };
+
+    use super::{align_batch_to_logical_schema, schema_uses_view_types, schema_with_view_types};
+
+    #[test]
+    fn view_schema_recurses_and_preserves_schema_contract() {
+        let field_metadata = HashMap::from([("field-key".to_owned(), "field-value".to_owned())]);
+        let schema_metadata = HashMap::from([("schema-key".to_owned(), "schema-value".to_owned())]);
+        let map_entries = Field::new(
+            "entries",
+            DataType::Struct(
+                vec![
+                    Field::new("key", DataType::Utf8, false),
+                    Field::new("value", DataType::Binary, true),
+                ]
+                .into(),
+            ),
+            false,
+        );
+        let schema = Schema::new_with_metadata(
+            vec![
+                Field::new("text", DataType::Utf8, true).with_metadata(field_metadata.clone()),
+                Field::new(
+                    "nested",
+                    DataType::Struct(vec![Field::new("label", DataType::LargeUtf8, true)].into()),
+                    true,
+                ),
+                Field::new(
+                    "items",
+                    DataType::List(Arc::new(Field::new("item", DataType::Binary, true))),
+                    true,
+                ),
+                Field::new(
+                    "properties",
+                    DataType::Map(Arc::new(map_entries), false),
+                    true,
+                ),
+            ],
+            schema_metadata.clone(),
+        );
+
+        let mapped = schema_with_view_types(&schema);
+        let expected_map_entries = Field::new(
+            "entries",
+            DataType::Struct(
+                vec![
+                    Field::new("key", DataType::Utf8View, false),
+                    Field::new("value", DataType::BinaryView, true),
+                ]
+                .into(),
+            ),
+            false,
+        );
+        assert_eq!(
+            mapped.as_ref(),
+            &Schema::new_with_metadata(
+                vec![
+                    Field::new("text", DataType::Utf8View, true).with_metadata(field_metadata),
+                    Field::new(
+                        "nested",
+                        DataType::Struct(
+                            vec![Field::new("label", DataType::Utf8View, true)].into(),
+                        ),
+                        true,
+                    ),
+                    Field::new(
+                        "items",
+                        DataType::List(Arc::new(Field::new("item", DataType::BinaryView, true,))),
+                        true,
+                    ),
+                    Field::new(
+                        "properties",
+                        DataType::Map(Arc::new(expected_map_entries), false),
+                        true,
+                    ),
+                ],
+                schema_metadata,
+            )
+        );
+        assert!(schema_uses_view_types(mapped.as_ref()));
+        assert!(!schema_uses_view_types(&schema));
+        assert_eq!(schema.field(0).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn alignment_accepts_only_explicit_representations_and_fails_closed() {
+        let source_schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, true)]));
+        let source = RecordBatch::try_new(
+            Arc::clone(&source_schema),
+            vec![Arc::new(StringArray::from(vec![Some("safe"), None]))],
+        )
+        .expect("source batch");
+        let view_schema = Arc::new(Schema::new(vec![Field::new(
+            "text",
+            DataType::Utf8View,
+            true,
+        )]));
+        let aligned =
+            align_batch_to_logical_schema(source.clone(), &view_schema, "hostile schema mismatch")
+                .expect("Utf8 should align to Utf8View");
+        let values = aligned
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .expect("StringView output");
+        assert_eq!(values.iter().collect::<Vec<_>>(), [Some("safe"), None]);
+
+        for hostile_schema in [
+            Schema::new(vec![Field::new("renamed", DataType::Utf8View, true)]),
+            Schema::new(vec![Field::new("text", DataType::Utf8View, false)]),
+            Schema::new(vec![Field::new("text", DataType::Int32, true)]),
+        ] {
+            assert!(
+                align_batch_to_logical_schema(
+                    source.clone(),
+                    &Arc::new(hostile_schema),
+                    "hostile schema mismatch",
+                )
+                .is_err()
+            );
+        }
+
+        let partition_source = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "region",
+                DataType::Utf8,
+                false,
+            )])),
+            vec![Arc::new(StringArray::from(vec!["west", "west"]))],
+        )
+        .expect("partition batch");
+        let partition_schema = Arc::new(Schema::new(vec![Field::new(
+            "region",
+            DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+            false,
+        )]));
+        let partition = align_batch_to_logical_schema(
+            partition_source,
+            &partition_schema,
+            "hostile schema mismatch",
+        )
+        .expect("partition should dictionary encode");
+        let partition = partition
+            .column(0)
+            .as_any()
+            .downcast_ref::<DictionaryArray<UInt16Type>>()
+            .expect("UInt16 dictionary");
+        assert_eq!(partition.keys().values(), &[0, 0]);
+        let partition_values = partition
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Utf8 dictionary values");
+        assert_eq!(partition_values.iter().collect::<Vec<_>>(), [Some("west")]);
+
+        let too_many_values = (0..=usize::from(u8::MAX) + 1)
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>();
+        let overflow = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "region",
+                DataType::Utf8,
+                false,
+            )])),
+            vec![Arc::new(StringArray::from(too_many_values))],
+        )
+        .expect("overflow source");
+        let undersized_dictionary = Arc::new(Schema::new(vec![Field::new(
+            "region",
+            DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Utf8)),
+            false,
+        )]));
+        assert!(
+            align_batch_to_logical_schema(
+                overflow,
+                &undersized_dictionary,
+                "hostile schema mismatch",
+            )
+            .is_err()
+        );
     }
 }

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -12,8 +12,11 @@ use std::{
 };
 
 use arrow::{
-    array::{Int32Array, Int64Array, StringArray},
-    datatypes::{DataType, Field, Schema},
+    array::{
+        Array, BinaryViewArray, DictionaryArray, Int32Array, Int64Array, MapArray, StringArray,
+        StringViewArray, StructArray,
+    },
+    datatypes::{DataType, Field, Schema, UInt16Type},
     record_batch::RecordBatch,
 };
 use datafusion::{
@@ -179,13 +182,24 @@ fn regions(batches: &[RecordBatch]) -> Vec<String> {
     batches
         .iter()
         .flat_map(|batch| {
-            batch
+            let regions = batch
                 .column(batch.schema().index_of("region").expect("region column"))
                 .as_any()
+                .downcast_ref::<DictionaryArray<UInt16Type>>()
+                .expect("dictionary region");
+            let values = regions
+                .values()
+                .as_any()
                 .downcast_ref::<StringArray>()
-                .expect("Utf8 region")
+                .expect("Utf8 dictionary values");
+            regions
+                .keys()
                 .iter()
-                .map(|value| value.expect("non-null region").to_owned())
+                .map(|key| {
+                    values
+                        .value(usize::from(key.expect("non-null region")))
+                        .to_owned()
+                })
                 .collect::<Vec<_>>()
         })
         .collect()
@@ -248,7 +262,11 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
     assert_eq!(defaults.target_partitions, None);
 
     let provider = DeltaTableProvider::try_new(table.clone(), defaults)?;
-    assert_eq!(provider.schema(), table.schema().clone());
+    assert_eq!(table.schema().field(1).data_type(), &DataType::Utf8);
+    assert_eq!(
+        provider.schema().field(1).data_type(),
+        &DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8))
+    );
     assert_eq!(provider.table_type(), TableType::Base);
     let debug = format!("{provider:?}");
     assert!(!debug.contains(&fixture.uri()));
@@ -1042,7 +1060,131 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
     assert_eq!(metrics[0].snapshot().reader.estimated_rows, Some(3));
     let batches = collect_plan(&context, plan).await?;
     assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+    let names = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .ok_or("official kernel did not preserve the DataFusion view schema")?;
+    assert_eq!(names.iter().collect::<Vec<_>>(), [Some("bob")]);
     assert_eq!(metrics[0].snapshot().reader.rows_produced, 3);
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg(feature = "native-async")]
+async fn native_scan_decodes_top_level_and_nested_views_with_exact_values() -> TestResult {
+    let fixture = RealParquetDeltaTable::new_with_supported_types("provider-view-values")?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+    register_delta_table(
+        &context,
+        "typed",
+        table,
+        DeltaDataFusionScanOptions::default(),
+    )?;
+
+    let batches = context
+        .sql("SELECT customer_name, payload, attributes FROM typed")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    let names = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .ok_or("customer_name was not Utf8View")?;
+    assert_eq!(
+        names.iter().collect::<Vec<_>>(),
+        [Some("alice"), Some("bob"), None]
+    );
+    let payloads = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<BinaryViewArray>()
+        .ok_or("payload was not BinaryView")?;
+    assert_eq!(
+        payloads.iter().collect::<Vec<_>>(),
+        [Some(b"alpha".as_slice()), Some(b"beta".as_slice()), None]
+    );
+    let attributes = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or("attributes was not Struct")?;
+    let labels = attributes
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .ok_or("attributes.label was not Utf8View")?;
+    assert_eq!(
+        labels.iter().collect::<Vec<_>>(),
+        [Some("low"), Some("high"), None]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg(feature = "native-async")]
+async fn native_scan_preserves_views_through_nested_map_reordering() -> TestResult {
+    let fixture = RealParquetDeltaTable::new_with_reordered_map_value_struct_fields(
+        "provider-reordered-map-views",
+    )?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+    register_delta_table(
+        &context,
+        "mapped",
+        table,
+        DeltaDataFusionScanOptions::default(),
+    )?;
+
+    let batches = context
+        .sql("SELECT attributes FROM mapped")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(batches.len(), 1);
+    let attributes = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .ok_or("attributes was not Map")?;
+    let keys = attributes
+        .keys()
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .ok_or("map keys were not Utf8View")?;
+    assert_eq!(
+        keys.iter().collect::<Vec<_>>(),
+        [Some("home"), Some("work"), Some("mailing")]
+    );
+    let values = attributes
+        .values()
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or("map values were not Struct")?;
+    assert_eq!(values.fields()[0].name(), "zip");
+    assert_eq!(values.fields()[1].name(), "city");
+    let zips = values
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .ok_or("map value zip was not Int32")?;
+    assert_eq!(
+        zips.iter().collect::<Vec<_>>(),
+        [Some(94110), Some(10001), None]
+    );
+    let cities = values
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .ok_or("map value city was not Utf8View")?;
+    assert_eq!(
+        cities.iter().collect::<Vec<_>>(),
+        [Some("san francisco"), Some("new york"), Some("phoenix")]
+    );
     Ok(())
 }
 
@@ -1070,14 +1212,14 @@ async fn joined_delta_scans_keep_distinct_metrics_and_limit_above_join() -> Test
     assert_eq!(star.schema().field(0).name(), "id");
     assert_eq!(star.schema().field(0).data_type(), &DataType::Int32);
     assert_eq!(star.schema().field(1).name(), "customer_name");
-    assert_eq!(star.schema().field(1).data_type(), &DataType::Utf8);
+    assert_eq!(star.schema().field(1).data_type(), &DataType::Utf8View);
     let projected = context
         .sql("SELECT customer_name FROM orders")
         .await?
         .into_optimized_plan()?;
     assert_eq!(projected.schema().fields().len(), 1);
     assert_eq!(projected.schema().field(0).name(), "customer_name");
-    assert_eq!(projected.schema().field(0).data_type(), &DataType::Utf8);
+    assert_eq!(projected.schema().field(0).data_type(), &DataType::Utf8View);
 
     let plan = context
         .sql(


### PR DESCRIPTION
## Summary

- decode DataFusion string and binary data-file columns directly as Arrow view arrays
- dictionary-encode string and binary partition columns while keeping the direct reader schema unchanged
- teach static and dynamic DataFusion predicate planning about view and dictionary scalar representations
- reuse loaded Parquet metadata when supplying the view schema, avoiding an extra metadata request
- update the benchmark contract and document the DataFusion-specific schema behavior

## Why

The DataFusion provider advertised ordinary Utf8 and Binary arrays, which forced copy-heavy Parquet decoding for large text columns. Supplying the execution schema expected by DataFusion lets Parquet emit Utf8View and BinaryView arrays directly.

In the six-run local MinIO comparison used for this investigation, the remaining full-scan wall-time gap to delta-rs fell to 7.7%, CPU was 1.2% higher, average memory was 16.9% lower, and peak memory was 21.4% lower. Text-only scans were about 3% faster.

## Correctness and hostile coverage

- preserves field names, nullability, nested structure, and schema metadata
- rejects renamed, incompatible, and nullability-mismatched schemas
- rejects dictionary key overflow instead of truncating values
- rejects dictionary type smuggling into predicate conversion
- covers null dictionary partition values
- verifies actual Utf8View and BinaryView arrays and exact values
- verifies nested map view arrays when Parquet struct fields arrive in a different order
- verifies the official-kernel residual path and both reader backends

## Validation

- cargo fmt --all -- --check
- cargo check --locked --no-default-features --all-targets
- cargo check --locked --all-features --all-targets
- cargo clippy --locked --all-targets --all-features -- -D warnings
- all eight locked feature combinations in the repository test matrix
- RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
- cargo package --locked
- git diff --check

No dependencies were added, and direct reader scans retain the ordinary Delta Arrow schema.
