### PR TITLE
chore: prepare 0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.3 - 2026-08-11
+
 - Decode DataFusion string and binary columns directly into Arrow view arrays and dictionary-encode string and binary partition columns.
 
 ## 0.1.2 - 2026-08-11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "delta-arrow-reader"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delta-arrow-reader"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Read-only Delta Lake to Apache Arrow reader"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ whole result in memory.
 
 ## Installation
 
-The 0.1.2 package declaration is:
+The 0.1.3 package declaration is:
 
 ```toml
 [dependencies]
-delta-arrow-reader = "0.1.2"
+delta-arrow-reader = "0.1.3"
 futures-util = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
@@ -22,7 +22,7 @@ you need SQL integration:
 ```toml
 [dependencies]
 datafusion = { version = "54.1.0", default-features = false, features = ["sql"] }
-delta-arrow-reader = { version = "0.1.2", features = ["datafusion"] }
+delta-arrow-reader = { version = "0.1.3", features = ["datafusion"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
## Summary

- bump delta-arrow-reader from 0.1.2 to 0.1.3
- publish the DataFusion Arrow view-array performance improvement in the changelog
- update both README dependency examples

## Validation

- complete locked feature test matrix
- Clippy with warnings denied
- rustdoc with warnings denied
- cargo package --locked
- cargo publish --dry-run --locked
