### PR TITLE
feat: make DataFusion view types configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow DataFusion consumers to disable string and binary view arrays while keeping them enabled by default.
+
 ## 0.1.3 - 2026-08-11
 
 - Decode DataFusion string and binary columns directly into Arrow view arrays and dictionary-encode string and binary partition columns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.0 - 2026-08-11
+
 - Allow DataFusion consumers to disable string and binary view arrays while keeping them enabled by default.
 
 ## 0.1.3 - 2026-08-11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "delta-arrow-reader"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delta-arrow-reader"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Read-only Delta Lake to Apache Arrow reader"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ The DataFusion provider uses Arrow view arrays for string and binary data-file
 columns and dictionary arrays for string and binary partition columns. Direct
 reader scans retain the Delta table's ordinary Arrow schema.
 
+For transformation-heavy queries that benefit from ordinary Arrow arrays,
+disable view types without changing partition dictionary encoding:
+
+```rust
+# #[cfg(feature = "datafusion")]
+# fn configure() {
+# use delta_arrow_reader::DeltaDataFusionScanOptions;
+let scan_options = DeltaDataFusionScanOptions {
+    use_view_types: false,
+    ..Default::default()
+};
+# let _ = scan_options;
+# }
+```
+
 ## Features
 
 | Feature | Default | Purpose |
@@ -117,6 +132,7 @@ When default features are enabled, NativeAsync is selected by default.
 - The caller supplies the Tokio runtime and drives returned streams.
 - Execution limits, buffering, Parquet metadata prefetch, and optional
   full-file reads are configured through `DeltaReaderExecutionOptions`.
+- DataFusion scan metrics report whether the provider requested view arrays.
 - `DeltaReaderError::phase` and `DeltaReaderError::as_str` return stable,
   redacted categories. Dependency failures remain available through the
   standard error source chain.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ whole result in memory.
 
 ## Installation
 
-The 0.1.3 package declaration is:
+The 0.2.0 package declaration is:
 
 ```toml
 [dependencies]
-delta-arrow-reader = "0.1.3"
+delta-arrow-reader = "0.2.0"
 futures-util = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
@@ -22,7 +22,7 @@ you need SQL integration:
 ```toml
 [dependencies]
 datafusion = { version = "54.1.0", default-features = false, features = ["sql"] }
-delta-arrow-reader = { version = "0.1.3", features = ["datafusion"] }
+delta-arrow-reader = { version = "0.2.0", features = ["datafusion"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -1327,6 +1327,7 @@ async fn run_once(
         DeltaDataFusionScanOptions {
             execution_options,
             target_partitions: Some(target_partitions),
+            use_view_types: true,
         },
     )?;
 

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -48,6 +48,8 @@ use crate::{
 pub struct DeltaDataFusionMetricsSnapshot {
     /// Core reader planning and execution metrics.
     pub reader: DeltaReadMetricsSnapshot,
+    /// Whether the provider requested Arrow view arrays for string and binary data columns.
+    pub use_view_types: bool,
     /// Effective DataFusion task batch size observed at execution.
     pub output_batch_size: Option<u64>,
     /// Files pruned before admission by a dynamic partition filter.
@@ -77,6 +79,7 @@ pub struct DeltaDataFusionMetrics {
 struct DeltaDataFusionMetricsInner {
     source_name: Option<String>,
     reader: DeltaReadMetrics,
+    use_view_types: bool,
     output_batch_size: AtomicU64,
     dynamic_partition_files_pruned: AtomicU64,
     dynamic_partition_files_kept: AtomicU64,
@@ -90,11 +93,12 @@ struct DeltaDataFusionMetricsInner {
 
 impl DeltaDataFusionMetrics {
     #[allow(dead_code)]
-    fn new(source_name: Option<String>, reader: DeltaReadMetrics) -> Self {
+    fn new(source_name: Option<String>, reader: DeltaReadMetrics, use_view_types: bool) -> Self {
         Self {
             inner: Arc::new(DeltaDataFusionMetricsInner {
                 source_name,
                 reader,
+                use_view_types,
                 output_batch_size: AtomicU64::new(0),
                 dynamic_partition_files_pruned: AtomicU64::new(0),
                 dynamic_partition_files_kept: AtomicU64::new(0),
@@ -118,6 +122,7 @@ impl DeltaDataFusionMetrics {
         let inner = self.inner.as_ref();
         DeltaDataFusionMetricsSnapshot {
             reader: inner.reader.snapshot(),
+            use_view_types: inner.use_view_types,
             output_batch_size: nonzero_load(&inner.output_batch_size),
             dynamic_partition_files_pruned: load(&inner.dynamic_partition_files_pruned),
             dynamic_partition_files_kept: load(&inner.dynamic_partition_files_kept),
@@ -247,12 +252,14 @@ pub(crate) fn create_datafusion_execution_plan(
     planning: DataFusionScanPlanning,
     row_predicate: Option<DeltaKernelPredicate>,
     source_name: Option<String>,
+    use_view_types: bool,
 ) -> Arc<dyn ExecutionPlan> {
     Arc::new(DeltaDataFusionExec::new(
         plan,
         planning,
         row_predicate,
         source_name,
+        use_view_types,
     ))
 }
 
@@ -274,6 +281,7 @@ impl DeltaDataFusionExec {
         planning: DataFusionScanPlanning,
         row_predicate: Option<DeltaKernelPredicate>,
         source_name: Option<String>,
+        use_view_types: bool,
     ) -> Self {
         let schema = planning.projection.output_schema;
         let output_projection = planning.projection.output_projection.map(Arc::from);
@@ -284,7 +292,8 @@ impl DeltaDataFusionExec {
             Boundedness::Bounded,
         )
         .with_scheduling_type(SchedulingType::Cooperative);
-        let metrics = DeltaDataFusionMetrics::new(source_name, plan.metrics.clone());
+        let metrics =
+            DeltaDataFusionMetrics::new(source_name, plan.metrics.clone(), use_view_types);
         let limiter = ScanReadLimiter::new(
             plan.execution_options,
             plan.partition_target_diagnostic.target_partitions,
@@ -808,6 +817,7 @@ mod tests {
             planning,
             row_predicate,
             source_name,
+            true,
         ))
     }
 

--- a/src/datafusion_provider.rs
+++ b/src/datafusion_provider.rs
@@ -29,12 +29,24 @@ use crate::{
 const TRACING_TARGET: &str = "delta_arrow_reader::datafusion";
 
 /// DataFusion-specific scan settings for one provider.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct DeltaDataFusionScanOptions {
     /// Reader execution settings used by each provider scan.
     pub execution_options: DeltaReaderExecutionOptions,
     /// Optional explicit scan partition target.
     pub target_partitions: Option<usize>,
+    /// Decode string and binary data-file columns into Arrow view arrays.
+    pub use_view_types: bool,
+}
+
+impl Default for DeltaDataFusionScanOptions {
+    fn default() -> Self {
+        Self {
+            execution_options: DeltaReaderExecutionOptions::default(),
+            target_partitions: None,
+            use_view_types: true,
+        }
+    }
 }
 
 /// Immutable DataFusion provider for one loaded Delta table snapshot.
@@ -87,7 +99,7 @@ impl DeltaTableProvider {
         }
         table.validate_protocol()?;
         let partition_columns = table.partition_columns().iter().cloned().collect();
-        let schema = datafusion_schema(table.schema(), &partition_columns);
+        let schema = datafusion_schema(table.schema(), &partition_columns, options.use_view_types);
         Ok(Self {
             table,
             schema,
@@ -178,11 +190,26 @@ impl DeltaTableProvider {
                 caller_target_partitions: Some(state.config().target_partitions()),
             },
         )?;
-        core.logical_schema = datafusion_schema(&core.logical_schema, &partition_columns);
-        core.physical_schema = datafusion_schema(&core.physical_schema, &partition_columns);
-        core.projected_schema = datafusion_schema(&core.projected_schema, &partition_columns);
-        planning.projection.output_schema =
-            datafusion_schema(&planning.projection.output_schema, &partition_columns);
+        core.logical_schema = datafusion_schema(
+            &core.logical_schema,
+            &partition_columns,
+            self.options.use_view_types,
+        );
+        core.physical_schema = datafusion_schema(
+            &core.physical_schema,
+            &partition_columns,
+            self.options.use_view_types,
+        );
+        core.projected_schema = datafusion_schema(
+            &core.projected_schema,
+            &partition_columns,
+            self.options.use_view_types,
+        );
+        planning.projection.output_schema = datafusion_schema(
+            &planning.projection.output_schema,
+            &partition_columns,
+            self.options.use_view_types,
+        );
         let partition_count = core.partitions.len();
         let plan = {
             let _setup = tracing::debug_span!(
@@ -195,13 +222,18 @@ impl DeltaTableProvider {
                 planning,
                 row_predicate,
                 self.source_name.clone(),
+                self.options.use_view_types,
             )
         };
         Ok((plan, partition_count))
     }
 }
 
-fn datafusion_schema(schema: &Schema, partition_columns: &HashSet<String>) -> SchemaRef {
+fn datafusion_schema(
+    schema: &Schema,
+    partition_columns: &HashSet<String>,
+    use_view_types: bool,
+) -> SchemaRef {
     let view_schema = schema_with_view_types(schema);
     Arc::new(Schema::new_with_metadata(
         schema
@@ -226,8 +258,10 @@ fn datafusion_schema(schema: &Schema, partition_columns: &HashSet<String>) -> Sc
                                 logical.data_type().clone(),
                             )),
                     )
-                } else {
+                } else if use_view_types {
                     Arc::clone(view)
+                } else {
+                    Arc::clone(logical)
                 }
             })
             .collect::<Vec<_>>(),
@@ -558,7 +592,7 @@ mod tests {
         );
         let partitions = HashSet::from(["region".to_owned(), "partition_payload".to_owned()]);
 
-        let mapped = datafusion_schema(&schema, &partitions);
+        let mapped = datafusion_schema(&schema, &partitions, true);
 
         assert_eq!(
             mapped.as_ref(),
@@ -581,8 +615,22 @@ mod tests {
                     ),
                     Field::new("id", DataType::Int32, false),
                 ],
-                schema_metadata,
+                schema_metadata.clone(),
             )
         );
+
+        let standard = datafusion_schema(&schema, &partitions, false);
+        assert_eq!(standard.field(0).data_type(), &DataType::Utf8);
+        assert_eq!(standard.field(1).data_type(), &DataType::Binary);
+        assert_eq!(
+            standard.field(2).data_type(),
+            &DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8))
+        );
+        assert_eq!(
+            standard.field(3).data_type(),
+            &DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::LargeBinary),)
+        );
+        assert_eq!(standard.field(4).data_type(), &DataType::Int32);
+        assert_eq!(standard.metadata(), &schema_metadata);
     }
 }

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -13,8 +13,8 @@ use std::{
 
 use arrow::{
     array::{
-        Array, BinaryViewArray, DictionaryArray, Int32Array, Int64Array, MapArray, StringArray,
-        StringViewArray, StructArray,
+        Array, BinaryArray, BinaryViewArray, DictionaryArray, Int32Array, Int64Array, MapArray,
+        StringArray, StringViewArray, StructArray,
     },
     datatypes::{DataType, Field, Schema, UInt16Type},
     record_batch::RecordBatch,
@@ -260,6 +260,7 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
         DeltaReaderExecutionOptions::default()
     );
     assert_eq!(defaults.target_partitions, None);
+    assert!(defaults.use_view_types);
 
     let provider = DeltaTableProvider::try_new(table.clone(), defaults)?;
     assert_eq!(table.schema().field(1).data_type(), &DataType::Utf8);
@@ -390,6 +391,7 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
             DeltaDataFusionScanOptions {
                 execution_options,
                 target_partitions: None,
+                ..Default::default()
             },
         )
         .expect_err("disabled backend must fail");
@@ -557,6 +559,7 @@ async fn native_exact_and_official_residual_execution_return_the_same_rows() -> 
             DeltaDataFusionScanOptions {
                 execution_options,
                 target_partitions: Some(2),
+                use_view_types: true,
             },
         )?;
         let data_filter = col("id").gt(lit(1_i32));
@@ -872,6 +875,7 @@ async fn execution_stream_drop_preserves_bounded_partial_metrics() -> TestResult
         DeltaDataFusionScanOptions {
             execution_options,
             target_partitions: Some(1),
+            use_view_types: true,
         },
     )?;
     let context = SessionContext::new();
@@ -922,6 +926,7 @@ async fn native_metadata_hint_preserves_rows_and_request_fallback() -> TestResul
             DeltaDataFusionScanOptions {
                 execution_options,
                 target_partitions: Some(1),
+                use_view_types: true,
             },
         )?;
         let plan = context
@@ -1033,10 +1038,11 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
     register_delta_table(
         &context,
         "orders",
-        table,
+        table.clone(),
         DeltaDataFusionScanOptions {
             execution_options,
             target_partitions: Some(1),
+            use_view_types: true,
         },
     )?;
 
@@ -1057,6 +1063,7 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
 
     let metrics = collect_delta_datafusion_metrics(plan.as_ref());
     assert_eq!(metrics.len(), 1);
+    assert!(metrics[0].snapshot().use_view_types);
     assert_eq!(metrics[0].snapshot().reader.estimated_rows, Some(3));
     let batches = collect_plan(&context, plan).await?;
     assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
@@ -1067,27 +1074,55 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
         .ok_or("official kernel did not preserve the DataFusion view schema")?;
     assert_eq!(names.iter().collect::<Vec<_>>(), [Some("bob")]);
     assert_eq!(metrics[0].snapshot().reader.rows_produced, 3);
+
+    register_delta_table(
+        &context,
+        "orders_standard",
+        table,
+        DeltaDataFusionScanOptions {
+            execution_options,
+            target_partitions: Some(1),
+            use_view_types: false,
+        },
+    )?;
+    let plan = context
+        .sql("SELECT customer_name FROM orders_standard WHERE id > 1 LIMIT 1")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+    let batches = collect_plan(&context, plan).await?;
+    assert!(!metrics[0].snapshot().use_view_types);
+    let names = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or("official kernel did not preserve the standard Utf8 schema")?;
+    assert_eq!(names.iter().collect::<Vec<_>>(), [Some("bob")]);
     Ok(())
 }
 
 #[tokio::test]
 #[cfg(feature = "native-async")]
-async fn native_scan_decodes_top_level_and_nested_views_with_exact_values() -> TestResult {
+async fn native_scan_decodes_both_string_representations_with_exact_values() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_supported_types("provider-view-values")?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
     let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     register_delta_table(
         &context,
         "typed",
-        table,
+        table.clone(),
         DeltaDataFusionScanOptions::default(),
     )?;
 
-    let batches = context
+    let plan = context
         .sql("SELECT customer_name, payload, attributes FROM typed")
         .await?
-        .collect()
+        .create_physical_plan()
         .await?;
+    let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+    let batches = collect_plan(&context, plan).await?;
+    assert!(metrics[0].snapshot().use_view_types);
     assert_eq!(batches.len(), 1);
     let batch = &batches[0];
     let names = batch
@@ -1118,6 +1153,69 @@ async fn native_scan_decodes_top_level_and_nested_views_with_exact_values() -> T
         .as_any()
         .downcast_ref::<StringViewArray>()
         .ok_or("attributes.label was not Utf8View")?;
+    assert_eq!(
+        labels.iter().collect::<Vec<_>>(),
+        [Some("low"), Some("high"), None]
+    );
+
+    let standard = DeltaTableProvider::try_new(
+        table,
+        DeltaDataFusionScanOptions {
+            use_view_types: false,
+            ..Default::default()
+        },
+    )?;
+    assert_eq!(
+        standard
+            .schema()
+            .field_with_name("customer_name")?
+            .data_type(),
+        &DataType::Utf8
+    );
+    assert_eq!(
+        standard.schema().field_with_name("payload")?.data_type(),
+        &DataType::Binary
+    );
+    context.register_table("typed_standard", Arc::new(standard))?;
+
+    let plan = context
+        .sql("SELECT customer_name, payload, attributes FROM typed_standard")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+    let batches = collect_plan(&context, plan).await?;
+    assert!(!metrics[0].snapshot().use_view_types);
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    let names = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or("customer_name was not Utf8")?;
+    assert_eq!(
+        names.iter().collect::<Vec<_>>(),
+        [Some("alice"), Some("bob"), None]
+    );
+    let payloads = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .ok_or("payload was not Binary")?;
+    assert_eq!(
+        payloads.iter().collect::<Vec<_>>(),
+        [Some(b"alpha".as_slice()), Some(b"beta".as_slice()), None]
+    );
+    let attributes = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or("attributes was not Struct")?;
+    let labels = attributes
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or("attributes.label was not Utf8")?;
     assert_eq!(
         labels.iter().collect::<Vec<_>>(),
         [Some("low"), Some("high"), None]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -324,6 +324,7 @@ fn datafusion_provider_contract_is_public() {
     fn assert_result_traits<T: std::fmt::Debug + Clone + PartialEq + Eq>() {}
 
     assert_debug_clone::<DeltaDataFusionScanOptions>();
+    assert!(DeltaDataFusionScanOptions::default().use_view_types);
     assert_clone::<DeltaTableProvider>();
     assert_result_traits::<RegisteredDeltaTable>();
     let construct: fn(


### PR DESCRIPTION
## Summary

- add a per-provider use_view_types policy, enabled by default
- preserve dictionary encoding for partition columns independently of the policy
- expose the selected policy in DataFusion metrics
- verify NativeAsync and OfficialKernel output types and values in both modes
- prepare the semver-major 0.2.0 release

## Why

Arrow view arrays speed up scan-heavy workloads, while ordinary Utf8 and Binary arrays performed better in the Delta Funnel transformation-heavy HIP workflow. Consumers can now choose without a post-scan cast.

## Validation

- cargo clippy, all targets and all features, with warnings denied
- full Cargo feature test matrix
- no-default-feature doctests
- rustdoc with warnings denied
- Cargo package verification