### PR TITLE
feat: parallelize CI and warm caches

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,68 @@
+name: Warm CI caches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cache-warm.yml"
+      - ".github/workflows/ci.yml"
+      - ".cargo/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "tests/**"
+      - "benches/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sccache-write
+
+jobs:
+  core:
+    name: Warm core test caches
+    runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_WRITE
+      RUSTC_WRAPPER: sccache
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-ci
+          cache-targets: false
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Warm default test cache
+        run: cargo test --locked --no-run
+      - name: Warm all-features test cache
+        run: cargo test --locked --all-targets --all-features --no-run
+      - name: Check sccache writes
+        id: sccache-writes
+        continue-on-error: true
+        run: >-
+          sccache --show-stats --stats-format json |
+          python -c 'import json, sys; errors = json.load(sys.stdin)["stats"]["cache_write_errors"]; sys.exit(f"sccache reported {errors} cache write errors") if errors else None'
+      - name: Retry cache writes
+        if: steps.sccache-writes.outcome == 'failure'
+        run: |
+          sccache --zero-stats
+          cargo clean
+          cargo test --locked --no-run
+          cargo test --locked --all-targets --all-features --no-run
+      - name: Verify retried sccache writes
+        if: steps.sccache-writes.outcome == 'failure'
+        run: >-
+          sccache --show-stats --stats-format json |
+          python -c 'import json, sys; errors = json.load(sys.stdin)["stats"]["cache_write_errors"]; sys.exit(f"sccache reported {errors} cache write errors") if errors else None'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,27 +8,81 @@ on:
 permissions:
   contents: read
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_RW_MODE: READ_ONLY
+  RUSTC_WRAPPER: sccache
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  feature-tests:
+    name: Feature Tests / ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Minimal
+            base: --no-default-features
+            official: --no-default-features --features official-kernel
+          - name: DataFusion
+            base: --no-default-features --features datafusion
+            official: --no-default-features --features datafusion,official-kernel
+          - name: Native
+            base: ""
+            official: --features official-kernel
+          - name: Native + DataFusion
+            base: --features datafusion
+            official: --all-features
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-ci
+          cache-targets: false
+          save-if: false
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+      - run: cargo test --locked ${{ matrix.base }}
+      - run: cargo test --locked ${{ matrix.official }}
+
+  checks:
+    name: ${{ matrix.task }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [Lints and Docs, Package]
+
+    steps:
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.88.0
           components: clippy, rustfmt
-      - run: cargo fmt --all -- --check
-      - run: cargo check --locked --no-default-features --all-targets
-      - run: cargo check --locked --all-features --all-targets
-      - run: cargo clippy --locked --all-targets --all-features -- -D warnings
-      - run: cargo test --locked --no-default-features
-      - run: cargo test --locked --no-default-features --features official-kernel
-      - run: cargo test --locked --no-default-features --features datafusion
-      - run: cargo test --locked --no-default-features --features datafusion,official-kernel
-      - run: cargo test --locked
-      - run: cargo test --locked --features official-kernel
-      - run: cargo test --locked --features datafusion
-      - run: cargo test --locked --all-features
-      - run: RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
-      - run: cargo package --locked
-      - run: git diff --check
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-ci
+          cache-targets: false
+          save-if: false
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+      - if: matrix.task == 'Lints and Docs'
+        run: cargo fmt --all -- --check
+      - if: matrix.task == 'Lints and Docs'
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+      - if: matrix.task == 'Lints and Docs'
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
+      - if: matrix.task == 'Lints and Docs'
+        run: git diff --check
+      - if: matrix.task == 'Package'
+        run: cargo package --locked


### PR DESCRIPTION
## Summary

- split the eight Rust feature combinations across four parallel test lanes
- run lint/docs and package validation in parallel with the feature tests
- make all CI jobs restore-only consumers of Cargo registry and sccache data
- add a trusted main-branch cache warmer with serialized writes, verification, and one retry
- cancel superseded CI runs while preserving active cache-warming runs

## Why

The previous workflow ran every check sequentially in one job and did not persist compiler artifacts, producing PR runtimes around 13 minutes. This follows the proven delta-funnel cache ownership model while keeping delta-arrow-reader's complete feature coverage.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/cache-warm.yml`
- `cargo fmt --all -- --check`
- `cargo test --locked --no-run`
- `cargo test --locked --all-targets --all-features --no-run`
- `git diff --check`
