### PR TITLE
feat: skip CI for non-code changes

### DIFF
--- a/.github/path-filters.json
+++ b/.github/path-filters.json
@@ -1,0 +1,12 @@
+{
+  "code": [
+    ".cargo/**",
+    ".github/path-filters.json",
+    ".github/workflows/ci.yml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "src/**",
+    "tests/**",
+    "benches/**"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   SCCACHE_GHA_ENABLED: "true"
@@ -18,8 +19,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Detect code changes
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: .github/path-filters.json
+
   feature-tests:
     name: Feature Tests / ${{ matrix.name }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -56,6 +75,8 @@ jobs:
 
   checks:
     name: ${{ matrix.task }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -86,3 +107,32 @@ jobs:
         run: git diff --check
       - if: matrix.task == 'Package'
         run: cargo package --locked
+
+  ci:
+    name: CI
+    needs: [changes, feature-tests, checks]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check results
+        run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Detect Changes did not pass: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "No code changes detected"
+            exit 0
+          fi
+
+          if [ "${{ needs.feature-tests.result }}" != "success" ]; then
+            echo "Feature Tests did not pass: ${{ needs.feature-tests.result }}"
+            exit 1
+          fi
+
+          if [ "${{ needs.checks.result }}" != "success" ]; then
+            echo "Checks did not pass: ${{ needs.checks.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- detect code-affecting changes with the same `dorny/paths-filter` pattern used by Delta Funnel
- skip Rust tests, lints, docs generation, and packaging for documentation-only PRs
- retain an aggregate `CI` job so required checks still complete successfully

## Why

Documentation-only changes currently launch all six Rust CI jobs even though they cannot affect the build. Internal job gating avoids that work without the required-check problem caused by workflow-level `paths-ignore`.

## Validation

- `actionlint` passes for both workflows
- filter JSON parses successfully
- routing assertions confirm Rust and CI files run checks while README, changelog, docs, license, notice, and security files skip them
