### PR TITLE
feat: add release-plz automation

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -18,6 +18,7 @@ permissions:
 
 concurrency:
   group: sccache-write
+  queue: max
 
 jobs:
   core:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,151 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sccache-write
+  queue: max
+
+env:
+  RELEASE_PLZ_RUST_VERSION: "1.91"
+
+jobs:
+  release-pr:
+    name: Release-plz PR
+    if: >-
+      github.event_name == 'push' &&
+      github.repository_owner == 'mag1cfrog' &&
+      vars.RELEASE_PLZ_PR_ENABLED == 'true' &&
+      !contains(github.event.head_commit.message, 'chore: release v') &&
+      !contains(github.event.head_commit.message, 'release-plz-')
+    runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Install release-plz Rust toolchain
+        run: |
+          rustup toolchain install "$RELEASE_PLZ_RUST_VERSION" --profile minimal
+          rustup default "$RELEASE_PLZ_RUST_VERSION"
+
+      - name: Configure Cargo target
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/release-plz-target" >> "$GITHUB_ENV"
+
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-plz
+          cache-targets: false
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Verify sccache writes
+        run: >-
+          sccache --show-stats --stats-format json |
+          python -c 'import json, sys; errors = json.load(sys.stdin)["stats"]["cache_write_errors"]; sys.exit(f"sccache reported {errors} cache write errors") if errors else None'
+
+  release:
+    name: Release-plz release
+    if: >-
+      github.repository_owner == 'mag1cfrog' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'push' &&
+          (
+            contains(github.event.head_commit.message, 'chore: release v') ||
+            contains(github.event.head_commit.message, 'release-plz-')
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    environment: crates-io-release
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+
+    steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Install release-plz Rust toolchain
+        run: |
+          rustup toolchain install "$RELEASE_PLZ_RUST_VERSION" --profile minimal
+          rustup default "$RELEASE_PLZ_RUST_VERSION"
+
+      - name: Configure Cargo target
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/release-plz-target" >> "$GITHUB_ENV"
+
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-plz
+          cache-targets: false
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Verify sccache writes
+        run: >-
+          sccache --show-stats --stats-format json |
+          python -c 'import json, sys; errors = json.load(sys.stdin)["stats"]["cache_write_errors"]; sys.exit(f"sccache reported {errors} cache write errors") if errors else None'


### PR DESCRIPTION
## Summary

- add release-plz release PR and publishing jobs based on the Delta Funnel workflow
- authenticate GitHub writes through the shared GitHub App
- publish to crates.io with OIDC trusted publishing and the protected `crates-io-release` environment
- serialize the sccache writer queue used by release-plz and cache warming

## Why

The repository currently requires manual release preparation and publishing. This adds the same automated release flow used by Delta Funnel without storing a long-lived crates.io token.

## Impact

Pushes to `main` can create or update a release PR. Merging a release PR triggers the protected release job, which publishes through crates.io trusted publishing and creates the GitHub release.

Repository setup completed alongside this PR:

- `APP_ID` and `APP_PRIVATE_KEY` Actions secrets
- GitHub App access to `mag1cfrog/delta-arrow-reader`
- `RELEASE_PLZ_PR_ENABLED=true` repository variable
- `crates-io-release` environment with required reviewer
- crates.io trusted publisher for this repository and workflow

## Validation

- workflow is byte-for-byte identical to the Delta Funnel release-plz workflow
- YAML parsing passed
- `cargo metadata --no-deps --format-version 1` passed
- `git diff --check` passed
- confirmed no `CARGO_REGISTRY_TOKEN` or separate crates.io auth action is used
