### PR TITLE
feat: repartition Parquet scans within files

### DIFF
--- a/src/datafusion_dynamic_partition_pruning.rs
+++ b/src/datafusion_dynamic_partition_pruning.rs
@@ -486,7 +486,7 @@ mod tests {
     fn file_task(partition_values: &[(&str, &str)]) -> DeltaScanFileTask {
         DeltaScanFileTask {
             path: "part-000.parquet".to_owned(),
-            estimated_bytes: None,
+            file_size: None,
             parquet_byte_range: None,
             estimated_rows: None,
             modification_time_ms: None,

--- a/src/datafusion_dynamic_partition_pruning.rs
+++ b/src/datafusion_dynamic_partition_pruning.rs
@@ -487,6 +487,7 @@ mod tests {
         DeltaScanFileTask {
             path: "part-000.parquet".to_owned(),
             estimated_bytes: None,
+            parquet_byte_range: None,
             estimated_rows: None,
             modification_time_ms: None,
             partition_values: partition_values

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -334,7 +334,7 @@ impl DeltaDataFusionExec {
         })
     }
 
-    fn with_partitions(
+    fn with_repartitioned_partitions(
         &self,
         partitions: Vec<DeltaScanFileTaskPartition>,
     ) -> Arc<dyn ExecutionPlan> {
@@ -383,7 +383,7 @@ fn repartition_file_tasks(
         return Ok(None);
     }
 
-    let Some(file_groups) = datafusion_file_groups(partitions)? else {
+    let Some(file_groups) = file_groups_from_partitions(partitions)? else {
         return Ok(None);
     };
     let Some(file_groups) = FileGroupPartitioner::new()
@@ -394,17 +394,17 @@ fn repartition_file_tasks(
         return Ok(None);
     };
 
-    scan_task_partitions(file_groups).map(Some)
+    partitions_from_file_groups(file_groups).map(Some)
 }
 
-fn datafusion_file_groups(
+fn file_groups_from_partitions(
     partitions: &[DeltaScanFileTaskPartition],
 ) -> DataFusionResult<Option<Vec<FileGroup>>> {
     let mut groups = Vec::with_capacity(partitions.len());
     for partition in partitions {
         let mut files = Vec::with_capacity(partition.file_tasks.len());
         for task in &partition.file_tasks {
-            let Some(file) = datafusion_file(task)? else {
+            let Some(file) = partitioned_file_from_task(task)? else {
                 return Ok(None);
             };
             files.push(file);
@@ -414,7 +414,9 @@ fn datafusion_file_groups(
     Ok(Some(groups))
 }
 
-fn datafusion_file(task: &DeltaScanFileTask) -> DataFusionResult<Option<PartitionedFile>> {
+fn partitioned_file_from_task(
+    task: &DeltaScanFileTask,
+) -> DataFusionResult<Option<PartitionedFile>> {
     let Some(file_size) = task.file_size.filter(|size| *size > 0) else {
         return Ok(None);
     };
@@ -434,7 +436,7 @@ fn datafusion_file(task: &DeltaScanFileTask) -> DataFusionResult<Option<Partitio
     Ok(Some(file.with_extension(task.clone())))
 }
 
-fn scan_task_partitions(
+fn partitions_from_file_groups(
     groups: Vec<FileGroup>,
 ) -> DataFusionResult<Vec<DeltaScanFileTaskPartition>> {
     let mut partitions = Vec::with_capacity(groups.len());
@@ -442,14 +444,14 @@ fn scan_task_partitions(
         let tasks = group
             .into_inner()
             .into_iter()
-            .map(scan_file_task)
+            .map(task_from_partitioned_file)
             .collect::<DataFusionResult<Vec<_>>>()?;
         partitions.push(build_partition(tasks).map_err(datafusion_error)?);
     }
     Ok(partitions)
 }
 
-fn scan_file_task(file: PartitionedFile) -> DataFusionResult<DeltaScanFileTask> {
+fn task_from_partitioned_file(file: PartitionedFile) -> DataFusionResult<DeltaScanFileTask> {
     let mut task = file
         .extension::<DeltaScanFileTask>()
         .cloned()
@@ -545,7 +547,7 @@ impl ExecutionPlan for DeltaDataFusionExec {
         else {
             return Ok(None);
         };
-        Ok(Some(self.with_partitions(partitions)))
+        Ok(Some(self.with_repartitioned_partitions(partitions)))
     }
 
     fn execute(
@@ -1198,14 +1200,14 @@ mod tests {
     }
 
     #[test]
-    fn scan_file_task_rejects_malformed_partitioner_output() {
+    fn task_from_partitioned_file_rejects_malformed_partitioner_output() {
         let mut missing_extension = PartitionedFile::new("missing-extension.parquet", 100);
         missing_extension.range = Some(FileRange { start: 0, end: 100 });
-        assert!(scan_file_task(missing_extension).is_err());
+        assert!(task_from_partitioned_file(missing_extension).is_err());
 
         let missing_range = PartitionedFile::new("missing-range.parquet", 100)
             .with_extension(sized_file_task("missing-range.parquet", Some(100)));
-        assert!(scan_file_task(missing_range).is_err());
+        assert!(task_from_partitioned_file(missing_range).is_err());
 
         for range in [
             FileRange {
@@ -1218,13 +1220,13 @@ mod tests {
             let mut invalid = PartitionedFile::new("invalid-range.parquet", 100)
                 .with_extension(sized_file_task("invalid-range.parquet", Some(100)));
             invalid.range = Some(range);
-            assert!(scan_file_task(invalid).is_err());
+            assert!(task_from_partitioned_file(invalid).is_err());
         }
 
         let mut missing_size = PartitionedFile::new("missing-size.parquet", 100)
             .with_extension(sized_file_task("missing-size.parquet", None));
         missing_size.range = Some(FileRange { start: 0, end: 100 });
-        assert!(scan_file_task(missing_size).is_err());
+        assert!(task_from_partitioned_file(missing_size).is_err());
     }
 
     #[tokio::test]

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -12,6 +12,10 @@ use std::{
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use datafusion::{
     common::{DataFusionError, Result as DataFusionResult, config::ConfigOptions},
+    datasource::{
+        listing::{FileRange, PartitionedFile},
+        physical_plan::{FileGroup, FileGroupPartitioner},
+    },
     execution::TaskContext,
     physical_expr::EquivalenceProperties,
     physical_plan::{
@@ -39,7 +43,7 @@ use crate::{
     direct::{native_async_executor, official_kernel_executor},
     kernel::DeltaKernelPredicate,
     metrics::saturating_fetch_add,
-    planning::{DeltaScanFileTask, DeltaScanPlan},
+    planning::{DeltaScanFileTask, DeltaScanFileTaskPartition, DeltaScanPlan, build_partition},
     scheduling::{DeltaScanExecution, FileAdmission, FileAdmissionFn, ScanReadLimiter},
 };
 
@@ -263,6 +267,7 @@ pub(crate) fn create_datafusion_execution_plan(
     ))
 }
 
+#[derive(Clone)]
 struct DeltaDataFusionExec {
     plan: Arc<DeltaScanPlan>,
     schema: SchemaRef,
@@ -285,13 +290,7 @@ impl DeltaDataFusionExec {
     ) -> Self {
         let schema = planning.projection.output_schema;
         let output_projection = planning.projection.output_projection.map(Arc::from);
-        let properties = PlanProperties::new(
-            EquivalenceProperties::new(Arc::clone(&schema)),
-            Partitioning::UnknownPartitioning(plan.partitions.len()),
-            EmissionType::Incremental,
-            Boundedness::Bounded,
-        )
-        .with_scheduling_type(SchedulingType::Cooperative);
+        let properties = scan_properties(&schema, plan.partitions.len());
         let metrics =
             DeltaDataFusionMetrics::new(source_name, plan.metrics.clone(), use_view_types);
         let limiter = ScanReadLimiter::new(
@@ -305,7 +304,7 @@ impl DeltaDataFusionExec {
             schema,
             output_projection,
             row_predicate,
-            properties: Arc::new(properties),
+            properties,
             metrics,
             limiter,
             dynamic_filters: Arc::from([]),
@@ -317,16 +316,133 @@ impl DeltaDataFusionExec {
         dynamic_filters: Vec<DeltaRetainedDynamicFilter>,
     ) -> Arc<dyn ExecutionPlan> {
         Arc::new(Self {
-            plan: Arc::clone(&self.plan),
-            schema: Arc::clone(&self.schema),
-            output_projection: self.output_projection.clone(),
-            row_predicate: self.row_predicate.clone(),
-            properties: Arc::clone(&self.properties),
-            metrics: self.metrics.clone(),
-            limiter: Arc::clone(&self.limiter),
             dynamic_filters: Arc::from(dynamic_filters),
+            ..self.clone()
         })
     }
+
+    fn with_partitions(
+        &self,
+        partitions: Vec<DeltaScanFileTaskPartition>,
+    ) -> Arc<dyn ExecutionPlan> {
+        let partition_count = partitions.len();
+        let mut plan = (*self.plan).clone();
+        plan.partitions = partitions;
+        let target_partitions = plan.partition_target_diagnostic.target_partitions;
+        let limiter =
+            ScanReadLimiter::new(plan.execution_options, target_partitions, partition_count);
+        Arc::new(Self {
+            plan: Arc::new(plan),
+            properties: scan_properties(&self.schema, partition_count),
+            limiter,
+            ..self.clone()
+        })
+    }
+}
+
+fn scan_properties(schema: &SchemaRef, partition_count: usize) -> Arc<PlanProperties> {
+    Arc::new(
+        PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(schema)),
+            Partitioning::UnknownPartitioning(partition_count),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        )
+        .with_scheduling_type(SchedulingType::Cooperative),
+    )
+}
+
+fn repartition_file_tasks(
+    partitions: &[DeltaScanFileTaskPartition],
+    target_partitions: usize,
+    minimum_total_bytes: usize,
+) -> DataFusionResult<Option<Vec<DeltaScanFileTaskPartition>>> {
+    if target_partitions == 0 {
+        return Err(adapter_error("scan_partition_target_must_be_positive"));
+    }
+
+    let Some(file_groups) = datafusion_file_groups(partitions)? else {
+        return Ok(None);
+    };
+    let Some(file_groups) = FileGroupPartitioner::new()
+        .with_target_partitions(target_partitions)
+        .with_repartition_file_min_size(minimum_total_bytes)
+        .repartition_file_groups(&file_groups)
+    else {
+        return Ok(None);
+    };
+
+    scan_task_partitions(file_groups).map(Some)
+}
+
+fn datafusion_file_groups(
+    partitions: &[DeltaScanFileTaskPartition],
+) -> DataFusionResult<Option<Vec<FileGroup>>> {
+    let mut groups = Vec::with_capacity(partitions.len());
+    for partition in partitions {
+        let mut files = Vec::with_capacity(partition.file_tasks.len());
+        for task in &partition.file_tasks {
+            let Some(file) = datafusion_file(task)? else {
+                return Ok(None);
+            };
+            files.push(file);
+        }
+        groups.push(FileGroup::new(files));
+    }
+    Ok(Some(groups))
+}
+
+fn datafusion_file(task: &DeltaScanFileTask) -> DataFusionResult<Option<PartitionedFile>> {
+    let Some(file_size) = task.file_size.filter(|size| *size > 0) else {
+        return Ok(None);
+    };
+    let mut file = PartitionedFile::new(&task.path, file_size);
+    if let Some(range) = &task.parquet_byte_range {
+        if range.start >= range.end || range.end > file_size {
+            return Err(adapter_error("scan_file_range_invalid"));
+        }
+        file.range = Some(FileRange {
+            start: i64::try_from(range.start)
+                .map_err(|_| adapter_error("scan_file_range_invalid"))?,
+            end: i64::try_from(range.end).map_err(|_| adapter_error("scan_file_range_invalid"))?,
+        });
+    }
+    // DataFusion copies extensions to every output range. Carry the Delta task
+    // so its schema, partition, transform, and deletion-vector metadata survive.
+    Ok(Some(file.with_extension(task.clone())))
+}
+
+fn scan_task_partitions(
+    groups: Vec<FileGroup>,
+) -> DataFusionResult<Vec<DeltaScanFileTaskPartition>> {
+    let mut partitions = Vec::with_capacity(groups.len());
+    for group in groups {
+        let tasks = group
+            .into_inner()
+            .into_iter()
+            .map(scan_file_task)
+            .collect::<DataFusionResult<Vec<_>>>()?;
+        partitions.push(build_partition(tasks).map_err(datafusion_error)?);
+    }
+    Ok(partitions)
+}
+
+fn scan_file_task(file: PartitionedFile) -> DataFusionResult<DeltaScanFileTask> {
+    let mut task = file
+        .extension::<DeltaScanFileTask>()
+        .cloned()
+        .ok_or_else(|| adapter_error("scan_file_task_extension_missing"))?;
+    let range = file
+        .range
+        .ok_or_else(|| adapter_error("scan_file_range_missing"))?;
+    let start = u64::try_from(range.start).map_err(|_| adapter_error("scan_file_range_invalid"))?;
+    let end = u64::try_from(range.end).map_err(|_| adapter_error("scan_file_range_invalid"))?;
+    if start >= end || task.file_size.is_none_or(|file_size| end > file_size) {
+        return Err(adapter_error("scan_file_range_invalid"));
+    }
+    task.parquet_byte_range = Some(start..end);
+    task.estimated_rows = None;
+    Ok(task)
 }
 
 impl fmt::Debug for DeltaDataFusionExec {
@@ -382,6 +498,27 @@ impl ExecutionPlan for DeltaDataFusionExec {
                 "DeltaDataFusionExec does not accept child execution plans".to_owned(),
             ))
         }
+    }
+
+    fn repartitioned(
+        &self,
+        _datafusion_target_partitions: usize,
+        config: &ConfigOptions,
+    ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
+        if self.plan.execution_options.reader_backend() != DeltaReaderBackend::NativeAsync {
+            return Ok(None);
+        }
+        // Scan planning already applied the provider override and resource caps.
+        let target_partitions = self.plan.partition_target_diagnostic.target_partitions;
+        let Some(partitions) = repartition_file_tasks(
+            &self.plan.partitions,
+            target_partitions,
+            config.optimizer.repartition_file_min_size,
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(self.with_partitions(partitions)))
     }
 
     fn execute(
@@ -825,6 +962,24 @@ mod tests {
         SessionContext::new_with_config(SessionConfig::new().with_batch_size(batch_size))
     }
 
+    fn sized_file_task(path: &str, size: Option<u64>) -> DeltaScanFileTask {
+        use crate::{
+            deletion_vector::DeletionVectorMetadata, kernel::KernelPhysicalToLogicalTransform,
+        };
+
+        DeltaScanFileTask {
+            path: path.to_owned(),
+            file_size: size,
+            parquet_byte_range: None,
+            estimated_rows: size,
+            stats: None,
+            modification_time_ms: None,
+            partition_values: Default::default(),
+            deletion_vector: DeletionVectorMetadata::default(),
+            transform: KernelPhysicalToLogicalTransform::default(),
+        }
+    }
+
     fn ids(batches: &[RecordBatch]) -> Vec<i32> {
         batches
             .iter()
@@ -840,6 +995,171 @@ mod tests {
                     .collect::<Vec<_>>()
             })
             .collect()
+    }
+
+    #[test]
+    fn file_repartitioning_balances_ranges_without_losing_file_identity() -> TestResult {
+        let input = vec![build_partition(vec![
+            sized_file_task("large.parquet", Some(100)),
+            sized_file_task("small.parquet", Some(20)),
+        ])?];
+        let partitions = repartition_file_tasks(&input, 4, 1)?.ok_or("not repartitioned")?;
+
+        assert_eq!(
+            partitions
+                .iter()
+                .map(|partition| partition.estimated_bytes)
+                .collect::<Vec<_>>(),
+            vec![Some(30); 4]
+        );
+        let mut ranges = std::collections::BTreeMap::<_, Vec<_>>::new();
+        for task in partitions
+            .iter()
+            .flat_map(|partition| &partition.file_tasks)
+        {
+            ranges
+                .entry(task.path.as_str())
+                .or_default()
+                .push(task.parquet_byte_range.clone().ok_or("missing range")?);
+            assert_eq!(
+                task.file_size,
+                Some(if task.path == "large.parquet" {
+                    100
+                } else {
+                    20
+                })
+            );
+            assert_eq!(task.estimated_rows, None);
+        }
+        assert_eq!(
+            ranges.remove("large.parquet"),
+            Some(vec![0..30, 30..60, 60..90, 90..100])
+        );
+        assert_eq!(
+            ranges.remove("small.parquet"),
+            Some(std::iter::once(0..20).collect())
+        );
+        assert!(ranges.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn file_repartitioning_refuses_unsupported_inputs_and_rejects_invalid_ranges() -> TestResult {
+        let input = vec![build_partition(vec![sized_file_task(
+            "known.parquet",
+            Some(120),
+        )])?];
+
+        assert!(repartition_file_tasks(&input, 4, 121)?.is_none());
+        assert!(
+            repartition_file_tasks(
+                &[build_partition(vec![sized_file_task(
+                    "unknown.parquet",
+                    None,
+                )])?],
+                4,
+                1
+            )?
+            .is_none()
+        );
+        assert!(
+            repartition_file_tasks(
+                &[build_partition(vec![sized_file_task(
+                    "empty.parquet",
+                    Some(0),
+                )])?],
+                4,
+                1
+            )?
+            .is_none()
+        );
+        assert!(repartition_file_tasks(&input, 0, 1).is_err());
+
+        let mut invalid = sized_file_task("invalid.parquet", Some(100));
+        invalid.parquet_byte_range = Some(90..110);
+        assert!(repartition_file_tasks(&[build_partition(vec![invalid])?], 4, 1).is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn native_repartitioning_reads_each_row_once_and_preserves_byte_accounting() -> TestResult
+    {
+        let fixture = TestTable::partitioned("file-repartitioning")?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let plan = build_plan(
+            &table,
+            None,
+            &[],
+            4,
+            DeltaReaderExecutionOptions::new(),
+            None,
+        )?;
+        let expected_bytes = collect_delta_datafusion_metrics(plan.as_ref())[0]
+            .snapshot()
+            .reader
+            .estimated_bytes;
+        let mut config = ConfigOptions::new();
+        config.optimizer.repartition_file_min_size = 1;
+        let repartitioned = plan
+            .repartitioned(4, &config)?
+            .ok_or("native scan was not repartitioned")?;
+
+        assert_eq!(
+            repartitioned
+                .properties()
+                .output_partitioning()
+                .partition_count(),
+            4
+        );
+        let mut actual_ids = ids(&datafusion::physical_plan::collect(
+            Arc::clone(&repartitioned),
+            session(1024).task_ctx(),
+        )
+        .await?);
+        actual_ids.sort_unstable();
+        assert_eq!(actual_ids, [1, 2, 3, 4]);
+        let metrics = collect_delta_datafusion_metrics(repartitioned.as_ref())[0].snapshot();
+        assert_eq!(
+            metrics.reader.parquet_data_file_opened_bytes,
+            expected_bytes
+        );
+
+        let explicit_one = build_plan(
+            &table,
+            None,
+            &[],
+            1,
+            DeltaReaderExecutionOptions::new(),
+            None,
+        )?;
+        let explicit_one = explicit_one
+            .repartitioned(4, &config)?
+            .ok_or("explicit one-partition scan was not normalized")?;
+        assert_eq!(
+            explicit_one
+                .properties()
+                .output_partitioning()
+                .partition_count(),
+            1
+        );
+
+        #[cfg(feature = "official-kernel")]
+        {
+            let official = build_plan(
+                &table,
+                None,
+                &[],
+                4,
+                DeltaReaderExecutionOptions::new()
+                    .with_reader_backend(DeltaReaderBackend::OfficialKernel)?,
+                None,
+            )?;
+            assert!(official.repartitioned(4, &config)?.is_none());
+        }
+
+        Ok(())
     }
 
     fn dynamic_filter(name: &str, index: usize) -> Arc<DynamicFilterPhysicalExpr> {
@@ -1296,7 +1616,7 @@ mod tests {
         let second = retained(dynamic_filter("region", 1))?;
         let missing = DeltaScanFileTask {
             path: "missing-partition.parquet".to_owned(),
-            estimated_bytes: None,
+            file_size: None,
             parquet_byte_range: None,
             estimated_rows: None,
             stats: None,

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -1059,6 +1059,32 @@ mod tests {
     }
 
     #[test]
+    fn file_repartitioning_never_escapes_an_existing_range() -> TestResult {
+        let mut task = sized_file_task("partial.parquet", Some(100));
+        task.parquet_byte_range = Some(20..80);
+        task.estimated_rows = None;
+        let partitions = repartition_file_tasks(&[build_partition(vec![task])?], 3, 1)?
+            .ok_or("partial range was not repartitioned")?;
+
+        assert_eq!(
+            partitions
+                .iter()
+                .flat_map(|partition| &partition.file_tasks)
+                .map(|task| task.parquet_byte_range.clone())
+                .collect::<Vec<_>>(),
+            [Some(20..40), Some(40..60), Some(60..80)]
+        );
+        assert!(
+            partitions
+                .iter()
+                .flat_map(|partition| &partition.file_tasks)
+                .all(|task| task.file_size == Some(100) && task.estimated_rows.is_none())
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn file_repartitioning_refuses_unsupported_inputs_and_rejects_invalid_ranges() -> TestResult {
         let input = vec![build_partition(vec![sized_file_task(
             "known.parquet",
@@ -1090,11 +1116,56 @@ mod tests {
         );
         assert!(repartition_file_tasks(&input, 0, 1).is_err());
 
-        let mut invalid = sized_file_task("invalid.parquet", Some(100));
-        invalid.parquet_byte_range = Some(90..110);
-        assert!(repartition_file_tasks(&[build_partition(vec![invalid])?], 4, 1).is_err());
+        for range in [90..110, std::ops::Range { start: 90, end: 80 }, 90..90] {
+            let mut invalid = sized_file_task("invalid.parquet", Some(100));
+            invalid.parquet_byte_range = Some(range);
+            assert!(repartition_file_tasks(&[build_partition(vec![invalid])?], 4, 1).is_err());
+        }
+
+        let oversized = u64::try_from(i64::MAX)? + 1;
+        assert!(
+            repartition_file_tasks(
+                &[build_partition(vec![sized_file_task(
+                    "oversized.parquet",
+                    Some(oversized),
+                )])?],
+                2,
+                1,
+            )
+            .is_err()
+        );
 
         Ok(())
+    }
+
+    #[test]
+    fn scan_file_task_rejects_malformed_partitioner_output() {
+        let mut missing_extension = PartitionedFile::new("missing-extension.parquet", 100);
+        missing_extension.range = Some(FileRange { start: 0, end: 100 });
+        assert!(scan_file_task(missing_extension).is_err());
+
+        let missing_range = PartitionedFile::new("missing-range.parquet", 100)
+            .with_extension(sized_file_task("missing-range.parquet", Some(100)));
+        assert!(scan_file_task(missing_range).is_err());
+
+        for range in [
+            FileRange {
+                start: -1,
+                end: 100,
+            },
+            FileRange { start: 50, end: 50 },
+            FileRange { start: 0, end: 101 },
+        ] {
+            let mut invalid = PartitionedFile::new("invalid-range.parquet", 100)
+                .with_extension(sized_file_task("invalid-range.parquet", Some(100)));
+            invalid.range = Some(range);
+            assert!(scan_file_task(invalid).is_err());
+        }
+
+        let mut missing_size = PartitionedFile::new("missing-size.parquet", 100)
+            .with_extension(sized_file_task("missing-size.parquet", None));
+        missing_size.range = Some(FileRange { start: 0, end: 100 });
+        assert!(scan_file_task(missing_size).is_err());
     }
 
     #[tokio::test]

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -440,11 +440,16 @@ fn scan_file_task(file: PartitionedFile) -> DataFusionResult<DeltaScanFileTask> 
         .ok_or_else(|| adapter_error("scan_file_range_missing"))?;
     let start = u64::try_from(range.start).map_err(|_| adapter_error("scan_file_range_invalid"))?;
     let end = u64::try_from(range.end).map_err(|_| adapter_error("scan_file_range_invalid"))?;
-    if start >= end || task.file_size.is_none_or(|file_size| end > file_size) {
+    let file_size = task
+        .file_size
+        .ok_or_else(|| adapter_error("scan_file_size_missing"))?;
+    if start >= end || end > file_size {
         return Err(adapter_error("scan_file_range_invalid"));
     }
-    task.parquet_byte_range = Some(start..end);
-    task.estimated_rows = None;
+    task.parquet_byte_range = (start != 0 || end != file_size).then_some(start..end);
+    if task.parquet_byte_range.is_some() {
+        task.estimated_rows = None;
+    }
     Ok(task)
 }
 
@@ -1020,10 +1025,11 @@ mod tests {
             .iter()
             .flat_map(|partition| &partition.file_tasks)
         {
-            ranges
-                .entry(task.path.as_str())
-                .or_default()
-                .push(task.parquet_byte_range.clone().ok_or("missing range")?);
+            ranges.entry(task.path.as_str()).or_default().push(
+                task.parquet_byte_range
+                    .clone()
+                    .unwrap_or(0..task.file_size.ok_or("missing file size")?),
+            );
             assert_eq!(
                 task.file_size,
                 Some(if task.path == "large.parquet" {
@@ -1032,7 +1038,12 @@ mod tests {
                     20
                 })
             );
-            assert_eq!(task.estimated_rows, None);
+            if task.path == "small.parquet" {
+                assert!(task.parquet_byte_range.is_none());
+                assert_eq!(task.estimated_rows, Some(20));
+            } else {
+                assert_eq!(task.estimated_rows, None);
+            }
         }
         assert_eq!(
             ranges.remove("large.parquet"),

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -56,9 +56,11 @@ pub struct DeltaDataFusionMetricsSnapshot {
     pub use_view_types: bool,
     /// Effective DataFusion task batch size observed at execution.
     pub output_batch_size: Option<u64>,
-    /// Files pruned before admission by a dynamic partition filter.
+    /// File tasks pruned before admission by a dynamic partition filter.
+    /// A task is either a whole physical file or one independently read file range.
     pub dynamic_partition_files_pruned: u64,
-    /// Files kept after consulting retained dynamic partition filters.
+    /// File tasks kept after consulting retained dynamic partition filters.
+    /// A task is either a whole physical file or one independently read file range.
     pub dynamic_partition_files_kept: u64,
     /// Physical filters offered to the post-optimization hook.
     pub dynamic_filters_received: u64,
@@ -68,9 +70,9 @@ pub struct DeltaDataFusionMetricsSnapshot {
     pub dynamic_filters_unsupported: u64,
     /// Current dynamic expressions consulted during file admission.
     pub dynamic_filter_snapshots: u64,
-    /// Kept files with missing, invalid, or unparsable partition metadata.
+    /// Kept file tasks with missing, invalid, or unparsable partition metadata.
     pub dynamic_files_not_pruned_missing_metadata: u64,
-    /// Kept files with unavailable, unsupported, or failed expressions.
+    /// Kept file tasks with unavailable, unsupported, or failed expressions.
     pub dynamic_files_not_pruned_unsupported_expression: u64,
 }
 
@@ -154,11 +156,11 @@ impl DeltaDataFusionMetrics {
             .store(u64::try_from(value).unwrap_or(u64::MAX), Ordering::Relaxed);
     }
 
-    fn record_dynamic_partition_file_pruned(&self) {
+    fn record_dynamic_partition_task_pruned(&self) {
         saturating_fetch_add(&self.inner.dynamic_partition_files_pruned, 1);
     }
 
-    fn record_dynamic_partition_file_kept(&self) {
+    fn record_dynamic_partition_task_kept(&self) {
         saturating_fetch_add(&self.inner.dynamic_partition_files_kept, 1);
     }
 
@@ -328,6 +330,7 @@ impl DeltaDataFusionExec {
         let partition_count = partitions.len();
         let mut plan = (*self.plan).clone();
         plan.partitions = partitions;
+        plan.metrics.record_scan_partitions_planned(partition_count);
         let target_partitions = plan.partition_target_diagnostic.target_partitions;
         let limiter =
             ScanReadLimiter::new(plan.execution_options, target_partitions, partition_count);
@@ -632,7 +635,7 @@ fn dynamic_admission(
             metrics.record_dynamic_filter_snapshot();
             match evaluate_dynamic_partition_filter(filter, task) {
                 DeltaDynamicPartitionPruningDecision::Prune(_) => {
-                    metrics.record_dynamic_partition_file_pruned();
+                    metrics.record_dynamic_partition_task_pruned();
                     return Ok(FileAdmission::Skip);
                 }
                 DeltaDynamicPartitionPruningDecision::Keep(reason) => {
@@ -647,7 +650,7 @@ fn dynamic_admission(
         if unsupported_expression {
             metrics.record_unsupported_expression();
         }
-        metrics.record_dynamic_partition_file_kept();
+        metrics.record_dynamic_partition_task_kept();
         Ok(FileAdmission::Admit)
     })
 }
@@ -1121,6 +1124,7 @@ mod tests {
         actual_ids.sort_unstable();
         assert_eq!(actual_ids, [1, 2, 3, 4]);
         let metrics = collect_delta_datafusion_metrics(repartitioned.as_ref())[0].snapshot();
+        assert_eq!(metrics.reader.scan_partitions_planned, 4);
         assert_eq!(
             metrics.reader.parquet_data_file_opened_bytes,
             expected_bytes
@@ -1698,8 +1702,8 @@ mod tests {
             let metrics = metrics.clone();
             handles.push(thread::spawn(move || {
                 for _ in 0..ITERATIONS {
-                    metrics.record_dynamic_partition_file_pruned();
-                    metrics.record_dynamic_partition_file_kept();
+                    metrics.record_dynamic_partition_task_pruned();
+                    metrics.record_dynamic_partition_task_kept();
                     metrics.record_dynamic_filters_received(3);
                     metrics.record_dynamic_filters_accepted(1);
                     metrics.record_dynamic_filters_unsupported(2);

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -368,6 +368,9 @@ fn scan_properties(schema: &SchemaRef, partition_count: usize) -> Arc<PlanProper
     )
 }
 
+/// Attempts to split file tasks into additional DataFusion execution partitions.
+///
+/// `Ok(None)` preserves the existing plan when splitting is unnecessary or unsafe.
 fn repartition_file_tasks(
     partitions: &[DeltaScanFileTaskPartition],
     target_partitions: usize,
@@ -383,6 +386,7 @@ fn repartition_file_tasks(
         return Ok(None);
     }
 
+    // DataFusion cannot safely split tasks whose physical file size is unknown.
     let Some(file_groups) = file_groups_from_partitions(partitions)? else {
         return Ok(None);
     };
@@ -391,6 +395,7 @@ fn repartition_file_tasks(
         .with_repartition_file_min_size(minimum_total_bytes)
         .repartition_file_groups(&file_groups)
     else {
+        // Preserve the original plan when DataFusion finds no useful split.
         return Ok(None);
     };
 
@@ -469,6 +474,8 @@ fn task_from_partitioned_file(file: PartitionedFile) -> DataFusionResult<DeltaSc
     }
     task.parquet_byte_range = (start != 0 || end != file_size).then_some(start..end);
     if task.parquet_byte_range.is_some() {
+        // A range covers an unknown subset of the file's rows, so the original
+        // whole-file estimate is no longer valid for partition accounting.
         task.estimated_rows = None;
     }
     Ok(task)

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -30,6 +30,13 @@ use datafusion::{
 };
 use futures_util::{StreamExt, stream};
 
+#[cfg(not(feature = "native-async"))]
+use crate::direct::native_async_executor;
+#[cfg(feature = "native-async")]
+use crate::native_async_reader::{
+    NativeAsyncParquetMetadataCache, native_async_file_executor,
+    native_async_file_executor_with_metadata_cache,
+};
 use crate::{
     DeltaReadMetrics, DeltaReadMetricsSnapshot, DeltaReaderBackend, DeltaReaderError,
     datafusion_dynamic_filters::{
@@ -40,7 +47,7 @@ use crate::{
         evaluate_dynamic_partition_filter,
     },
     datafusion_planning::DataFusionScanPlanning,
-    direct::{native_async_executor, official_kernel_executor},
+    direct::official_kernel_executor,
     kernel::DeltaKernelPredicate,
     metrics::saturating_fetch_add,
     planning::{DeltaScanFileTask, DeltaScanFileTaskPartition, DeltaScanPlan, build_partition},
@@ -279,6 +286,8 @@ struct DeltaDataFusionExec {
     metrics: DeltaDataFusionMetrics,
     limiter: Arc<ScanReadLimiter>,
     dynamic_filters: Arc<[DeltaRetainedDynamicFilter]>,
+    #[cfg(feature = "native-async")]
+    parquet_metadata_cache: Option<Arc<NativeAsyncParquetMetadataCache>>,
 }
 
 impl DeltaDataFusionExec {
@@ -310,6 +319,8 @@ impl DeltaDataFusionExec {
             metrics,
             limiter,
             dynamic_filters: Arc::from([]),
+            #[cfg(feature = "native-async")]
+            parquet_metadata_cache: None,
         }
     }
 
@@ -338,6 +349,8 @@ impl DeltaDataFusionExec {
             plan: Arc::new(plan),
             properties: scan_properties(&self.schema, partition_count),
             limiter,
+            #[cfg(feature = "native-async")]
+            parquet_metadata_cache: Some(Arc::new(NativeAsyncParquetMetadataCache::default())),
             ..self.clone()
         })
     }
@@ -362,6 +375,12 @@ fn repartition_file_tasks(
 ) -> DataFusionResult<Option<Vec<DeltaScanFileTaskPartition>>> {
     if target_partitions == 0 {
         return Err(adapter_error("scan_partition_target_must_be_positive"));
+    }
+    // Whole-file planning already balances up to the requested partition count.
+    // Intra-file splitting fills missing parallelism; rebalancing a full plan
+    // requires a separate, evidence-backed skew policy.
+    if partitions.len() >= target_partitions {
+        return Ok(None);
     }
 
     let Some(file_groups) = datafusion_file_groups(partitions)? else {
@@ -542,12 +561,33 @@ impl ExecutionPlan for DeltaDataFusionExec {
         self.metrics.record_output_batch_size(output_batch_size);
         let admission = dynamic_admission(self.metrics.clone(), Arc::clone(&self.dynamic_filters));
         let executor = match self.plan.execution_options.reader_backend() {
-            DeltaReaderBackend::NativeAsync => native_async_executor(
-                &self.plan,
-                Some(output_batch_size),
-                self.row_predicate.clone(),
-            )
-            .map_err(datafusion_error)?,
+            DeltaReaderBackend::NativeAsync => {
+                #[cfg(feature = "native-async")]
+                {
+                    match &self.parquet_metadata_cache {
+                        Some(cache) => native_async_file_executor_with_metadata_cache(
+                            &self.plan,
+                            Some(output_batch_size),
+                            self.row_predicate.clone(),
+                            Arc::clone(cache),
+                        ),
+                        None => native_async_file_executor(
+                            &self.plan,
+                            Some(output_batch_size),
+                            self.row_predicate.clone(),
+                        ),
+                    }
+                }
+                #[cfg(not(feature = "native-async"))]
+                {
+                    native_async_executor(
+                        &self.plan,
+                        Some(output_batch_size),
+                        self.row_predicate.clone(),
+                    )
+                    .map_err(datafusion_error)?
+                }
+            }
             DeltaReaderBackend::OfficialKernel => {
                 official_kernel_executor(&self.plan).map_err(datafusion_error)?
             }
@@ -1085,6 +1125,25 @@ mod tests {
     }
 
     #[test]
+    fn file_repartitioning_does_not_rebalance_a_full_whole_file_plan() -> TestResult {
+        let input = vec![
+            build_partition(vec![sized_file_task("huge.parquet", Some(1_000))])?,
+            build_partition(vec![sized_file_task("small-0.parquet", Some(10))])?,
+            build_partition(vec![sized_file_task("small-1.parquet", Some(10))])?,
+            build_partition(vec![sized_file_task("small-2.parquet", Some(10))])?,
+        ];
+
+        assert!(repartition_file_tasks(&input, 4, 1)?.is_none());
+        assert!(
+            input
+                .iter()
+                .flat_map(|partition| &partition.file_tasks)
+                .all(|task| task.parquet_byte_range.is_none())
+        );
+        Ok(())
+    }
+
+    #[test]
     fn file_repartitioning_refuses_unsupported_inputs_and_rejects_invalid_ranges() -> TestResult {
         let input = vec![build_partition(vec![sized_file_task(
             "known.parquet",
@@ -1220,16 +1279,7 @@ mod tests {
             DeltaReaderExecutionOptions::new(),
             None,
         )?;
-        let explicit_one = explicit_one
-            .repartitioned(4, &config)?
-            .ok_or("explicit one-partition scan was not normalized")?;
-        assert_eq!(
-            explicit_one
-                .properties()
-                .output_partitioning()
-                .partition_count(),
-            1
-        );
+        assert!(explicit_one.repartitioned(4, &config)?.is_none());
 
         #[cfg(feature = "official-kernel")]
         {

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -1297,6 +1297,7 @@ mod tests {
         let missing = DeltaScanFileTask {
             path: "missing-partition.parquet".to_owned(),
             estimated_bytes: None,
+            parquet_byte_range: None,
             estimated_rows: None,
             stats: None,
             modification_time_ms: None,

--- a/src/deletion_vector.rs
+++ b/src/deletion_vector.rs
@@ -25,18 +25,6 @@ pub(crate) struct DeletionVectorMetadata {
 
 struct DeletionVectorRows {
     indexes: Box<[u64]>,
-    #[cfg(test)]
-    drop_probe: Option<DeletionVectorRowsDropProbe>,
-}
-
-#[cfg(test)]
-struct DeletionVectorRowsDropProbe(Arc<std::sync::atomic::AtomicBool>);
-
-#[cfg(test)]
-impl Drop for DeletionVectorRowsDropProbe {
-    fn drop(&mut self) {
-        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
-    }
 }
 
 impl DeletionVectorRows {
@@ -45,15 +33,7 @@ impl DeletionVectorRows {
         indexes.dedup();
         Self {
             indexes: indexes.into_boxed_slice(),
-            #[cfg(test)]
-            drop_probe: None,
         }
-    }
-
-    #[cfg(test)]
-    fn with_drop_probe(mut self, dropped: Arc<std::sync::atomic::AtomicBool>) -> Self {
-        self.drop_probe = Some(DeletionVectorRowsDropProbe(dropped));
-        self
     }
 }
 
@@ -472,10 +452,7 @@ mod tests {
         error::Error as _,
         fs,
         path::{Path, PathBuf},
-        sync::{
-            Arc, Weak,
-            atomic::{AtomicBool, Ordering},
-        },
+        sync::{Arc, Weak},
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -595,17 +572,13 @@ mod tests {
 
     #[test]
     fn regression_weak_cache_drops_the_payload_owner() {
-        let dropped = Arc::new(AtomicBool::new(false));
-        let rows =
-            Arc::new(DeletionVectorRows::new(vec![3, 1, 3]).with_drop_probe(Arc::clone(&dropped)));
+        let rows = Arc::new(DeletionVectorRows::new(vec![3, 1, 3]));
         let cached_rows = Arc::downgrade(&rows);
 
         assert_eq!(rows.indexes.as_ref(), [1, 3]);
-        assert!(!dropped.load(Ordering::SeqCst));
         drop(rows);
 
         assert!(cached_rows.upgrade().is_none());
-        assert!(dropped.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/src/deletion_vector.rs
+++ b/src/deletion_vector.rs
@@ -1,5 +1,7 @@
 //! Private deletion-vector coordinate handling and Arrow masking.
 
+use std::sync::Arc;
+
 use arrow::{
     array::{Array, BooleanArray, Int64Array},
     compute::filter_record_batch,
@@ -15,17 +17,29 @@ use crate::{
 };
 
 #[allow(dead_code)]
-#[derive(Clone, Default)]
-pub(crate) struct DeletionVectorMetadata(Option<KernelDeletionVectorHandle>);
+#[derive(Clone)]
+pub(crate) struct DeletionVectorMetadata {
+    handle: Option<KernelDeletionVectorHandle>,
+    shared_row_indexes: Arc<tokio::sync::OnceCell<Arc<[u64]>>>,
+}
+
+impl Default for DeletionVectorMetadata {
+    fn default() -> Self {
+        Self::from_kernel(None)
+    }
+}
 
 #[allow(dead_code)]
 impl DeletionVectorMetadata {
     pub(crate) fn is_present(&self) -> bool {
-        self.0.is_some()
+        self.handle.is_some()
     }
 
     pub(crate) fn from_kernel(handle: Option<KernelDeletionVectorHandle>) -> Self {
-        Self(handle)
+        Self {
+            handle,
+            shared_row_indexes: Arc::new(tokio::sync::OnceCell::new()),
+        }
     }
 }
 
@@ -36,7 +50,7 @@ pub(crate) async fn load_deletion_vector_selection(
     metrics: &DeltaReadMetrics,
 ) -> Result<Option<DeletionVectorSelection>, DeltaReaderError> {
     load_deletion_vector_selection_from_engine_context(
-        std::sync::Arc::clone(snapshot.engine_context()),
+        Arc::clone(snapshot.engine_context()),
         metadata,
         metrics,
     )
@@ -45,26 +59,38 @@ pub(crate) async fn load_deletion_vector_selection(
 
 #[allow(dead_code)]
 pub(crate) async fn load_deletion_vector_selection_from_engine_context(
-    engine_context: std::sync::Arc<DeltaKernelEngineContext>,
+    engine_context: Arc<DeltaKernelEngineContext>,
     metadata: DeletionVectorMetadata,
     metrics: &DeltaReadMetrics,
 ) -> Result<Option<DeletionVectorSelection>, DeltaReaderError> {
+    let Some(handle) = metadata.handle.clone() else {
+        return Ok(None);
+    };
     let metrics_for_task = metrics.clone();
-    match tokio::task::spawn_blocking(move || {
-        load_deletion_vector_selection_blocking(
-            engine_context.as_ref(),
-            metadata,
-            &metrics_for_task,
-        )
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(source) => {
-            metrics.record_deletion_vector_failure();
-            Err(dependency_error("deletion_vector_load_task_failed", source))
-        }
-    }
+    let row_indexes = metadata
+        .shared_row_indexes
+        .get_or_try_init(|| async move {
+            match tokio::task::spawn_blocking(move || {
+                load_deletion_vector_row_indexes(
+                    engine_context.as_ref(),
+                    &handle,
+                    &metrics_for_task,
+                )
+            })
+            .await
+            {
+                Ok(result) => result,
+                Err(source) => {
+                    metrics.record_deletion_vector_failure();
+                    Err(dependency_error("deletion_vector_load_task_failed", source))
+                }
+            }
+        })
+        .await?;
+    Ok(Some(DeletionVectorSelection::from_shared(
+        Arc::clone(row_indexes),
+        metrics.clone(),
+    )))
 }
 
 #[allow(dead_code)]
@@ -73,10 +99,22 @@ pub(crate) fn load_deletion_vector_selection_blocking(
     metadata: DeletionVectorMetadata,
     metrics: &DeltaReadMetrics,
 ) -> Result<Option<DeletionVectorSelection>, DeltaReaderError> {
-    let Some(handle) = metadata.0 else {
+    let Some(handle) = metadata.handle else {
         return Ok(None);
     };
-    let row_indexes = match engine_context.load_deletion_vector_row_indexes(&handle) {
+    let row_indexes = load_deletion_vector_row_indexes(engine_context, &handle, metrics)?;
+    Ok(Some(DeletionVectorSelection::from_shared(
+        row_indexes,
+        metrics.clone(),
+    )))
+}
+
+fn load_deletion_vector_row_indexes(
+    engine_context: &DeltaKernelEngineContext,
+    handle: &KernelDeletionVectorHandle,
+    metrics: &DeltaReadMetrics,
+) -> Result<Arc<[u64]>, DeltaReaderError> {
+    let mut row_indexes = match engine_context.load_deletion_vector_row_indexes(handle) {
         Ok(row_indexes) => row_indexes,
         Err(source) => {
             metrics.record_deletion_vector_failure();
@@ -88,12 +126,14 @@ pub(crate) fn load_deletion_vector_selection_blocking(
     };
 
     metrics.record_deletion_vector_payload_loaded();
-    DeletionVectorSelection::try_new(row_indexes, metrics.clone()).map(Some)
+    row_indexes.sort_unstable();
+    row_indexes.dedup();
+    Ok(row_indexes.into())
 }
 
 #[allow(dead_code)]
 pub(crate) struct DeletionVectorSelection {
-    deleted_row_indexes: Box<[u64]>,
+    deleted_row_indexes: Arc<[u64]>,
     consumed_row_count: u64,
     original_row_index_deleted_cursor: Option<usize>,
     last_original_row_index: Option<u64>,
@@ -120,8 +160,12 @@ impl DeletionVectorSelection {
         deleted_row_indexes.sort_unstable();
         deleted_row_indexes.dedup();
 
-        Ok(Self {
-            deleted_row_indexes: deleted_row_indexes.into_boxed_slice(),
+        Ok(Self::from_shared(deleted_row_indexes.into(), metrics))
+    }
+
+    fn from_shared(deleted_row_indexes: Arc<[u64]>, metrics: DeltaReadMetrics) -> Self {
+        Self {
+            deleted_row_indexes,
             consumed_row_count: 0,
             original_row_index_deleted_cursor: Some(0),
             last_original_row_index: None,
@@ -129,7 +173,7 @@ impl DeletionVectorSelection {
             metrics,
             applied: false,
             closed: false,
-        })
+        }
     }
 
     pub(crate) fn mask_ordered_batch(
@@ -504,7 +548,7 @@ mod tests {
     }
 
     #[test]
-    fn lazy_loader_skips_absence_and_loads_inline_selection()
+    fn lazy_loader_skips_absence_and_shares_inline_payloads()
     -> Result<(), Box<dyn std::error::Error>> {
         let table = DeltaLogTable::new("inline")?;
         let snapshot = table.snapshot()?;
@@ -527,17 +571,22 @@ mod tests {
         let inline_metrics = metrics();
         let inline_metadata = inline_metadata()?;
         assert!(inline_metadata.is_present());
-        let selection = runtime
-            .block_on(load_deletion_vector_selection(
-                &snapshot,
-                inline_metadata,
-                &inline_metrics,
-            ))?
-            .expect("inline descriptor must produce a selection");
-        assert_eq!(
-            selection.deleted_row_indexes.as_ref(),
-            INLINE_DV_DELETED_ROW_INDEXES
-        );
+        let second_metadata = inline_metadata.clone();
+        let (selection, second_selection) = runtime.block_on(async {
+            tokio::join!(
+                load_deletion_vector_selection(&snapshot, inline_metadata, &inline_metrics,),
+                load_deletion_vector_selection(&snapshot, second_metadata, &inline_metrics,)
+            )
+        });
+        let selection = selection?.expect("inline descriptor must produce a selection");
+        let second_selection =
+            second_selection?.expect("inline descriptor must produce a second selection");
+        for selection in [&selection, &second_selection] {
+            assert_eq!(
+                selection.deleted_row_indexes.as_ref(),
+                INLINE_DV_DELETED_ROW_INDEXES
+            );
+        }
         let metrics = inline_metrics.snapshot();
         assert_eq!(metrics.deletion_vector_payloads_loaded, 1);
         assert_eq!(metrics.deletion_vector_failures, 0);

--- a/src/deletion_vector.rs
+++ b/src/deletion_vector.rs
@@ -1,6 +1,6 @@
 //! Private deletion-vector coordinate handling and Arrow masking.
 
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use arrow::{
     array::{Array, BooleanArray, Int64Array},
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct DeletionVectorMetadata {
     handle: Option<KernelDeletionVectorHandle>,
-    shared_row_indexes: Arc<tokio::sync::OnceCell<Arc<[u64]>>>,
+    cached_row_indexes: Arc<tokio::sync::Mutex<Option<Weak<[u64]>>>>,
 }
 
 impl Default for DeletionVectorMetadata {
@@ -38,7 +38,7 @@ impl DeletionVectorMetadata {
     pub(crate) fn from_kernel(handle: Option<KernelDeletionVectorHandle>) -> Self {
         Self {
             handle,
-            shared_row_indexes: Arc::new(tokio::sync::OnceCell::new()),
+            cached_row_indexes: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 }
@@ -66,11 +66,12 @@ pub(crate) async fn load_deletion_vector_selection_from_engine_context(
     let Some(handle) = metadata.handle.clone() else {
         return Ok(None);
     };
-    let metrics_for_task = metrics.clone();
-    let row_indexes = metadata
-        .shared_row_indexes
-        .get_or_try_init(|| async move {
-            match tokio::task::spawn_blocking(move || {
+    let mut cached_row_indexes = metadata.cached_row_indexes.lock().await;
+    let row_indexes = match cached_row_indexes.as_ref().and_then(Weak::upgrade) {
+        Some(row_indexes) => row_indexes,
+        None => {
+            let metrics_for_task = metrics.clone();
+            let row_indexes = match tokio::task::spawn_blocking(move || {
                 load_deletion_vector_row_indexes(
                     engine_context.as_ref(),
                     &handle,
@@ -84,11 +85,13 @@ pub(crate) async fn load_deletion_vector_selection_from_engine_context(
                     metrics.record_deletion_vector_failure();
                     Err(dependency_error("deletion_vector_load_task_failed", source))
                 }
-            }
-        })
-        .await?;
+            }?;
+            *cached_row_indexes = Some(Arc::downgrade(&row_indexes));
+            row_indexes
+        }
+    };
     Ok(Some(DeletionVectorSelection::from_shared(
-        Arc::clone(row_indexes),
+        row_indexes,
         metrics.clone(),
     )))
 }
@@ -432,7 +435,7 @@ mod tests {
         error::Error as _,
         fs,
         path::{Path, PathBuf},
-        sync::Arc,
+        sync::{Arc, Weak},
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -547,37 +550,30 @@ mod tests {
         .map(metadata)
     }
 
-    #[test]
-    fn lazy_loader_skips_absence_and_shares_inline_payloads()
+    #[tokio::test]
+    async fn lazy_loader_skips_absence_and_shares_inline_payloads()
     -> Result<(), Box<dyn std::error::Error>> {
         let table = DeltaLogTable::new("inline")?;
         let snapshot = table.snapshot()?;
         let engine_context = Arc::clone(snapshot.engine_context());
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()?;
 
         let absent_metrics = metrics();
         let absent_metadata =
             DeletionVectorMetadata::from_kernel(preserve_deletion_vector(DvInfo::default()));
-        let absent = runtime.block_on(load_deletion_vector_selection(
-            &snapshot,
-            absent_metadata,
-            &absent_metrics,
-        ))?;
+        let absent =
+            load_deletion_vector_selection(&snapshot, absent_metadata, &absent_metrics).await?;
         assert!(absent.is_none());
         assert_eq!(absent_metrics.snapshot().deletion_vector_payloads_loaded, 0);
 
         let inline_metrics = metrics();
         let inline_metadata = inline_metadata()?;
         assert!(inline_metadata.is_present());
+        let cached_row_indexes = Arc::clone(&inline_metadata.cached_row_indexes);
         let second_metadata = inline_metadata.clone();
-        let (selection, second_selection) = runtime.block_on(async {
-            tokio::join!(
-                load_deletion_vector_selection(&snapshot, inline_metadata, &inline_metrics,),
-                load_deletion_vector_selection(&snapshot, second_metadata, &inline_metrics,)
-            )
-        });
+        let (selection, second_selection) = tokio::join!(
+            load_deletion_vector_selection(&snapshot, inline_metadata.clone(), &inline_metrics),
+            load_deletion_vector_selection(&snapshot, second_metadata, &inline_metrics)
+        );
         let selection = selection?.expect("inline descriptor must produce a selection");
         let second_selection =
             second_selection?.expect("inline descriptor must produce a second selection");
@@ -587,8 +583,38 @@ mod tests {
                 INLINE_DV_DELETED_ROW_INDEXES
             );
         }
+        assert!(Arc::ptr_eq(
+            &selection.deleted_row_indexes,
+            &second_selection.deleted_row_indexes
+        ));
+        assert!(
+            cached_row_indexes
+                .lock()
+                .await
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .is_some()
+        );
+        drop(selection);
+        drop(second_selection);
+        assert!(
+            cached_row_indexes
+                .lock()
+                .await
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .is_none()
+        );
+
+        let reloaded = load_deletion_vector_selection(&snapshot, inline_metadata, &inline_metrics)
+            .await?
+            .expect("released inline payload must reload");
+        assert_eq!(
+            reloaded.deleted_row_indexes.as_ref(),
+            INLINE_DV_DELETED_ROW_INDEXES
+        );
         let metrics = inline_metrics.snapshot();
-        assert_eq!(metrics.deletion_vector_payloads_loaded, 1);
+        assert_eq!(metrics.deletion_vector_payloads_loaded, 2);
         assert_eq!(metrics.deletion_vector_failures, 0);
         assert_eq!(metrics.deletion_vector_rejections, 0);
         assert!(Arc::ptr_eq(&engine_context, snapshot.engine_context()));

--- a/src/deletion_vector.rs
+++ b/src/deletion_vector.rs
@@ -25,6 +25,18 @@ pub(crate) struct DeletionVectorMetadata {
 
 struct DeletionVectorRows {
     indexes: Box<[u64]>,
+    #[cfg(test)]
+    drop_probe: Option<DeletionVectorRowsDropProbe>,
+}
+
+#[cfg(test)]
+struct DeletionVectorRowsDropProbe(Arc<std::sync::atomic::AtomicBool>);
+
+#[cfg(test)]
+impl Drop for DeletionVectorRowsDropProbe {
+    fn drop(&mut self) {
+        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 impl DeletionVectorRows {
@@ -33,7 +45,15 @@ impl DeletionVectorRows {
         indexes.dedup();
         Self {
             indexes: indexes.into_boxed_slice(),
+            #[cfg(test)]
+            drop_probe: None,
         }
+    }
+
+    #[cfg(test)]
+    fn with_drop_probe(mut self, dropped: Arc<std::sync::atomic::AtomicBool>) -> Self {
+        self.drop_probe = Some(DeletionVectorRowsDropProbe(dropped));
+        self
     }
 }
 
@@ -452,7 +472,10 @@ mod tests {
         error::Error as _,
         fs,
         path::{Path, PathBuf},
-        sync::{Arc, Weak},
+        sync::{
+            Arc, Weak,
+            atomic::{AtomicBool, Ordering},
+        },
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -469,7 +492,10 @@ mod tests {
     };
     use delta_kernel::scan::state::DvInfo;
 
-    use super::{DeletionVectorMetadata, DeletionVectorSelection, load_deletion_vector_selection};
+    use super::{
+        DeletionVectorMetadata, DeletionVectorRows, DeletionVectorSelection,
+        load_deletion_vector_selection,
+    };
     use crate::{
         DeltaReadMetrics, DeltaReaderBackend, DeltaReaderError, DeltaReaderPhase,
         DeltaSnapshotSelection, DeltaStorageOptions,
@@ -565,6 +591,21 @@ mod tests {
             2,
         )
         .map(metadata)
+    }
+
+    #[test]
+    fn regression_weak_cache_drops_the_payload_owner() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let rows =
+            Arc::new(DeletionVectorRows::new(vec![3, 1, 3]).with_drop_probe(Arc::clone(&dropped)));
+        let cached_rows = Arc::downgrade(&rows);
+
+        assert_eq!(rows.indexes.as_ref(), [1, 3]);
+        assert!(!dropped.load(Ordering::SeqCst));
+        drop(rows);
+
+        assert!(cached_rows.upgrade().is_none());
+        assert!(dropped.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/src/deletion_vector.rs
+++ b/src/deletion_vector.rs
@@ -20,7 +20,21 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct DeletionVectorMetadata {
     handle: Option<KernelDeletionVectorHandle>,
-    cached_row_indexes: Arc<tokio::sync::Mutex<Option<Weak<[u64]>>>>,
+    cached_rows: Arc<tokio::sync::Mutex<Option<Weak<DeletionVectorRows>>>>,
+}
+
+struct DeletionVectorRows {
+    indexes: Box<[u64]>,
+}
+
+impl DeletionVectorRows {
+    fn new(mut indexes: Vec<u64>) -> Self {
+        indexes.sort_unstable();
+        indexes.dedup();
+        Self {
+            indexes: indexes.into_boxed_slice(),
+        }
+    }
 }
 
 impl Default for DeletionVectorMetadata {
@@ -38,7 +52,7 @@ impl DeletionVectorMetadata {
     pub(crate) fn from_kernel(handle: Option<KernelDeletionVectorHandle>) -> Self {
         Self {
             handle,
-            cached_row_indexes: Arc::new(tokio::sync::Mutex::new(None)),
+            cached_rows: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 }
@@ -66,12 +80,12 @@ pub(crate) async fn load_deletion_vector_selection_from_engine_context(
     let Some(handle) = metadata.handle.clone() else {
         return Ok(None);
     };
-    let mut cached_row_indexes = metadata.cached_row_indexes.lock().await;
-    let row_indexes = match cached_row_indexes.as_ref().and_then(Weak::upgrade) {
-        Some(row_indexes) => row_indexes,
+    let mut cached_rows = metadata.cached_rows.lock().await;
+    let rows = match cached_rows.as_ref().and_then(Weak::upgrade) {
+        Some(rows) => rows,
         None => {
             let metrics_for_task = metrics.clone();
-            let row_indexes = match tokio::task::spawn_blocking(move || {
+            let rows = match tokio::task::spawn_blocking(move || {
                 load_deletion_vector_row_indexes(
                     engine_context.as_ref(),
                     &handle,
@@ -86,12 +100,12 @@ pub(crate) async fn load_deletion_vector_selection_from_engine_context(
                     Err(dependency_error("deletion_vector_load_task_failed", source))
                 }
             }?;
-            *cached_row_indexes = Some(Arc::downgrade(&row_indexes));
-            row_indexes
+            *cached_rows = Some(Arc::downgrade(&rows));
+            rows
         }
     };
     Ok(Some(DeletionVectorSelection::from_shared(
-        row_indexes,
+        rows,
         metrics.clone(),
     )))
 }
@@ -116,8 +130,8 @@ fn load_deletion_vector_row_indexes(
     engine_context: &DeltaKernelEngineContext,
     handle: &KernelDeletionVectorHandle,
     metrics: &DeltaReadMetrics,
-) -> Result<Arc<[u64]>, DeltaReaderError> {
-    let mut row_indexes = match engine_context.load_deletion_vector_row_indexes(handle) {
+) -> Result<Arc<DeletionVectorRows>, DeltaReaderError> {
+    let row_indexes = match engine_context.load_deletion_vector_row_indexes(handle) {
         Ok(row_indexes) => row_indexes,
         Err(source) => {
             metrics.record_deletion_vector_failure();
@@ -129,14 +143,12 @@ fn load_deletion_vector_row_indexes(
     };
 
     metrics.record_deletion_vector_payload_loaded();
-    row_indexes.sort_unstable();
-    row_indexes.dedup();
-    Ok(row_indexes.into())
+    Ok(Arc::new(DeletionVectorRows::new(row_indexes)))
 }
 
 #[allow(dead_code)]
 pub(crate) struct DeletionVectorSelection {
-    deleted_row_indexes: Arc<[u64]>,
+    deleted_rows: Arc<DeletionVectorRows>,
     consumed_row_count: u64,
     original_row_index_deleted_cursor: Option<usize>,
     last_original_row_index: Option<u64>,
@@ -157,18 +169,18 @@ enum DeletionVectorAccessMode {
 #[allow(dead_code)]
 impl DeletionVectorSelection {
     pub(crate) fn try_new(
-        mut deleted_row_indexes: Vec<u64>,
+        deleted_row_indexes: Vec<u64>,
         metrics: DeltaReadMetrics,
     ) -> Result<Self, DeltaReaderError> {
-        deleted_row_indexes.sort_unstable();
-        deleted_row_indexes.dedup();
-
-        Ok(Self::from_shared(deleted_row_indexes.into(), metrics))
+        Ok(Self::from_shared(
+            Arc::new(DeletionVectorRows::new(deleted_row_indexes)),
+            metrics,
+        ))
     }
 
-    fn from_shared(deleted_row_indexes: Arc<[u64]>, metrics: DeltaReadMetrics) -> Self {
+    fn from_shared(deleted_rows: Arc<DeletionVectorRows>, metrics: DeltaReadMetrics) -> Self {
         Self {
-            deleted_row_indexes,
+            deleted_rows,
             consumed_row_count: 0,
             original_row_index_deleted_cursor: Some(0),
             last_original_row_index: None,
@@ -237,12 +249,14 @@ impl DeletionVectorSelection {
         };
         let mut keep_mask = vec![true; batch_len];
         let deleted_start = self
-            .deleted_row_indexes
+            .deleted_rows
+            .indexes
             .partition_point(|row_index| *row_index < self.consumed_row_count);
         let deleted_end = self
-            .deleted_row_indexes
+            .deleted_rows
+            .indexes
             .partition_point(|row_index| *row_index < requested_end);
-        for deleted_row_index in &self.deleted_row_indexes[deleted_start..deleted_end] {
+        for deleted_row_index in &self.deleted_rows.indexes[deleted_start..deleted_end] {
             let batch_index = match usize::try_from(*deleted_row_index - self.consumed_row_count) {
                 Ok(batch_index) => batch_index,
                 Err(_) => {
@@ -295,17 +309,19 @@ impl DeletionVectorSelection {
 
             let keep = if cursor_is_valid {
                 while self
-                    .deleted_row_indexes
+                    .deleted_rows
+                    .indexes
                     .get(cursor)
                     .is_some_and(|deleted_row_index| *deleted_row_index < row_index)
                 {
                     cursor += 1;
                 }
-                self.deleted_row_indexes
+                self.deleted_rows
+                    .indexes
                     .get(cursor)
                     .is_none_or(|deleted_row_index| *deleted_row_index != row_index)
             } else {
-                self.deleted_row_indexes.binary_search(&row_index).is_err()
+                self.deleted_rows.indexes.binary_search(&row_index).is_err()
             };
             keep_mask.push(keep);
             last_row_index = Some(row_index);
@@ -366,9 +382,10 @@ impl DeletionVectorSelection {
         }
 
         let consumed_deleted = self
-            .deleted_row_indexes
+            .deleted_rows
+            .indexes
             .partition_point(|row_index| *row_index < self.consumed_row_count);
-        if consumed_deleted < self.deleted_row_indexes.len() {
+        if consumed_deleted < self.deleted_rows.indexes.len() {
             return self.reject(
                 "invalid_deletion_vector_coordinates",
                 "deletion-vector entries remain after physical file completion",
@@ -568,7 +585,7 @@ mod tests {
         let inline_metrics = metrics();
         let inline_metadata = inline_metadata()?;
         assert!(inline_metadata.is_present());
-        let cached_row_indexes = Arc::clone(&inline_metadata.cached_row_indexes);
+        let cached_rows = Arc::clone(&inline_metadata.cached_rows);
         let second_metadata = inline_metadata.clone();
         let (selection, second_selection) = tokio::join!(
             load_deletion_vector_selection(&snapshot, inline_metadata.clone(), &inline_metrics),
@@ -579,16 +596,16 @@ mod tests {
             second_selection?.expect("inline descriptor must produce a second selection");
         for selection in [&selection, &second_selection] {
             assert_eq!(
-                selection.deleted_row_indexes.as_ref(),
+                selection.deleted_rows.indexes.as_ref(),
                 INLINE_DV_DELETED_ROW_INDEXES
             );
         }
         assert!(Arc::ptr_eq(
-            &selection.deleted_row_indexes,
-            &second_selection.deleted_row_indexes
+            &selection.deleted_rows,
+            &second_selection.deleted_rows
         ));
         assert!(
-            cached_row_indexes
+            cached_rows
                 .lock()
                 .await
                 .as_ref()
@@ -598,7 +615,7 @@ mod tests {
         drop(selection);
         drop(second_selection);
         assert!(
-            cached_row_indexes
+            cached_rows
                 .lock()
                 .await
                 .as_ref()
@@ -610,7 +627,7 @@ mod tests {
             .await?
             .expect("released inline payload must reload");
         assert_eq!(
-            reloaded.deleted_row_indexes.as_ref(),
+            reloaded.deleted_rows.indexes.as_ref(),
             INLINE_DV_DELETED_ROW_INDEXES
         );
         let metrics = inline_metrics.snapshot();
@@ -639,7 +656,7 @@ mod tests {
                 &relative_metrics,
             ))?
             .expect("relative descriptor must produce a selection");
-        assert_eq!(selection.deleted_row_indexes.as_ref(), [0, 9]);
+        assert_eq!(selection.deleted_rows.indexes.as_ref(), [0, 9]);
         assert_eq!(
             relative_metrics.snapshot().deletion_vector_payloads_loaded,
             1
@@ -654,7 +671,7 @@ mod tests {
                 &empty_metrics,
             ))?
             .expect("empty present descriptor must produce a selection");
-        assert!(empty.deleted_row_indexes.is_empty());
+        assert!(empty.deleted_rows.indexes.is_empty());
         empty.finish()?;
         let metrics = empty_metrics.snapshot();
         assert_eq!(metrics.deletion_vector_payloads_loaded, 1);
@@ -791,7 +808,7 @@ mod tests {
         let metrics = metrics();
         let mut selection = DeletionVectorSelection::try_new(vec![3, 1, 3], metrics.clone())?;
 
-        assert_eq!(selection.deleted_row_indexes.as_ref(), [1, 3]);
+        assert_eq!(selection.deleted_rows.indexes.as_ref(), [1, 3]);
         assert_eq!(
             selection.select_original_row_indexes(&row_indexes(&[0, 1, 2, 3, 4]))?,
             [true, false, true, false, true]

--- a/src/deletion_vector.rs
+++ b/src/deletion_vector.rs
@@ -16,10 +16,13 @@ use crate::{
     snapshot::LoadedDeltaTableSnapshot,
 };
 
+/// A data file's deletion-vector handle and reusable decoded row coordinates.
 #[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct DeletionVectorMetadata {
+    /// Kernel handle used to load the deletion-vector payload.
     handle: Option<KernelDeletionVectorHandle>,
+    /// Weakly cached coordinates shared by overlapping readers of the same file.
     cached_rows: Arc<tokio::sync::Mutex<Option<Weak<DeletionVectorRows>>>>,
 }
 
@@ -80,6 +83,8 @@ pub(crate) async fn load_deletion_vector_selection_from_engine_context(
     let Some(handle) = metadata.handle.clone() else {
         return Ok(None);
     };
+    // Serialize the first load across range tasks. Keeping only a weak entry
+    // avoids retaining a potentially large payload after the last reader exits.
     let mut cached_rows = metadata.cached_rows.lock().await;
     let rows = match cached_rows.as_ref().and_then(Weak::upgrade) {
         Some(rows) => rows,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -14,7 +14,7 @@ pub struct DeltaReadMetricsSnapshot {
     pub reader_backend: DeltaReaderBackend,
     /// Whether planning exhausted the Delta scan metadata iterator.
     pub scan_metadata_exhausted: Option<bool>,
-    /// Execution partitions planned for the scan.
+    /// Final execution partitions planned for the scan, including source repartitioning.
     pub scan_partitions_planned: u64,
     /// Data files selected during planning.
     pub files_planned: u64,
@@ -28,9 +28,9 @@ pub struct DeltaReadMetricsSnapshot {
     pub scan_partitions_started: u64,
     /// Scan partitions that completed normally.
     pub scan_partitions_completed: u64,
-    /// Data-file reads that started.
+    /// Data-file tasks that started, including independently read file ranges.
     pub files_started: u64,
-    /// Data-file reads that completed normally.
+    /// Data-file tasks that completed normally, including independently read file ranges.
     pub files_completed: u64,
     /// Backend-logical record batches handed to the scheduler.
     pub batches_produced: u64,
@@ -66,7 +66,7 @@ struct DeltaReadMetricsInner {
     snapshot_version: u64,
     reader_backend: DeltaReaderBackend,
     scan_metadata_exhausted: Option<bool>,
-    scan_partitions_planned: u64,
+    scan_partitions_planned: AtomicU64,
     files_planned: u64,
     files_filtered_during_planning: Option<u64>,
     estimated_rows: Option<u64>,
@@ -108,7 +108,9 @@ impl DeltaReadMetrics {
                 snapshot_version: config.snapshot_version,
                 reader_backend: config.reader_backend,
                 scan_metadata_exhausted: config.scan_metadata_exhausted,
-                scan_partitions_planned: usize_to_u64_saturating(config.scan_partitions_planned),
+                scan_partitions_planned: AtomicU64::new(usize_to_u64_saturating(
+                    config.scan_partitions_planned,
+                )),
                 files_planned: usize_to_u64_saturating(config.files_planned),
                 files_filtered_during_planning: config.files_filtered_during_planning,
                 estimated_rows: config.estimated_rows,
@@ -139,7 +141,7 @@ impl DeltaReadMetrics {
             snapshot_version: inner.snapshot_version,
             reader_backend: inner.reader_backend,
             scan_metadata_exhausted: inner.scan_metadata_exhausted,
-            scan_partitions_planned: inner.scan_partitions_planned,
+            scan_partitions_planned: load(&inner.scan_partitions_planned),
             files_planned: inner.files_planned,
             files_filtered_during_planning: inner.files_filtered_during_planning,
             estimated_rows: inner.estimated_rows,
@@ -171,6 +173,13 @@ impl DeltaReadMetrics {
             DeltaReaderBackend::NativeAsync => Some(load(counter)),
             DeltaReaderBackend::OfficialKernel => None,
         }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn record_scan_partitions_planned(&self, value: usize) {
+        self.inner
+            .scan_partitions_planned
+            .store(usize_to_u64_saturating(value), Ordering::Relaxed);
     }
 
     #[allow(dead_code)]
@@ -323,6 +332,7 @@ mod tests {
     #[test]
     fn snapshot_maps_live_counters() {
         let metrics = metrics(DeltaReaderBackend::NativeAsync);
+        metrics.record_scan_partitions_planned(16);
         let counters = [
             &metrics.inner.scan_partitions_started,
             &metrics.inner.scan_partitions_completed,
@@ -345,6 +355,7 @@ mod tests {
         }
 
         let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.scan_partitions_planned, 16);
         assert_eq!(snapshot.scan_partitions_started, 1);
         assert_eq!(snapshot.scan_partitions_completed, 2);
         assert_eq!(snapshot.files_started, 3);

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -177,8 +177,8 @@ impl NativeAsyncFileReader {
         include_original_row_index: bool,
     ) -> Result<NativeAsyncParquetStream, DeltaReaderError> {
         let object = self.parquet_object_for_task(task).await?;
-        let reader =
-            ParquetObjectReader::new(object.store, object.path).with_file_size(object.file_size);
+        let file_size = object.file_size;
+        let reader = ParquetObjectReader::new(object.store, object.path).with_file_size(file_size);
         let reader = match self.execution_options.parquet_metadata_size_hint() {
             Some(hint) => reader.with_footer_size_hint(hint),
             None => reader,
@@ -234,9 +234,14 @@ impl NativeAsyncFileReader {
             ProjectionMask::roots(builder.parquet_schema(), schema_match.projected_roots());
         let row_groups = native_async_pruned_row_groups(
             builder.metadata(),
+            file_size,
             task.parquet_byte_range.as_ref(),
             physical_predicate,
-        );
+        )
+        .boxed()
+        .context(DataFileReadSnafu {
+            reason: "parquet_row_group_range_invalid",
+        })?;
         let builder = match row_groups {
             Some(row_groups) => builder.with_row_groups(row_groups),
             None => builder,

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -2257,6 +2257,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn regression_invalid_parquet_range_is_redacted_at_the_reader_boundary()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = TestDir::new("native-invalid-parquet-range")?;
+        let bytes = parquet_bytes()?;
+        fs::write(root.path().join("secret.parquet"), &bytes)?;
+        let file_size = u64::try_from(bytes.len())?;
+        let mut task = task("secret.parquet", Some(file_size))?;
+        task.parquet_byte_range = Some(0..file_size + 1);
+        let reader = reader(&root, DeltaReaderExecutionOptions::new(), metrics())?;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let error = match reader
+            .open_parquet_stream(&task, schema, None, None, None, false)
+            .await
+        {
+            Ok(_) => return Err("invalid Parquet range unexpectedly succeeded".into()),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error.to_string(),
+            "delta reader error: phase=data_file_read error=data_file_read reason=parquet_row_group_range_invalid"
+        );
+        assert!(!error.to_string().contains("secret.parquet"));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn threshold_buffers_only_eligible_unsplit_files_with_one_metered_full_get()
     -> Result<(), Box<dyn std::error::Error>> {
         let bytes = b"0123456789abcdef";

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -181,7 +181,7 @@ impl NativeAsyncFileReader {
         }
     }
 
-    async fn split_parquet_metadata(
+    async fn load_split_parquet_metadata(
         &self,
         metadata_cache: Option<&NativeAsyncParquetMetadataCache>,
         path: &Path,
@@ -260,7 +260,7 @@ impl NativeAsyncFileReader {
             })?;
         let builder = if task.parquet_byte_range.is_some() {
             let metadata = self
-                .split_parquet_metadata(
+                .load_split_parquet_metadata(
                     metadata_cache,
                     &path,
                     file_size,

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -357,7 +357,7 @@ impl NativeAsyncFileReader {
             .context(DataFileReadSnafu {
                 reason: "data_file_path_resolution_failed",
             })?;
-        let file_size = task.estimated_bytes.ok_or_else(|| {
+        let file_size = task.file_size.ok_or_else(|| {
             data_file_error(
                 "data_file_size_missing",
                 delta_kernel::Error::generic("file size is required for NativeAsync reads"),
@@ -427,7 +427,7 @@ pub(crate) fn native_async_file_executor(
     let physical_predicate = plan.physical_predicate.clone();
 
     Arc::new(move |task, permit, cancellation| {
-        if let Some(bytes) = task.estimated_bytes {
+        if let Some(bytes) = task.estimated_scan_bytes() {
             reader.metrics.record_parquet_data_file_opened_bytes(bytes);
         }
         let reader = Arc::clone(&reader);
@@ -1619,7 +1619,7 @@ mod tests {
                 transform: None,
                 partition_values: HashMap::new(),
             }))?;
-        task.estimated_bytes = file_size;
+        task.file_size = file_size;
         Ok(task)
     }
 
@@ -3379,7 +3379,7 @@ mod tests {
             .ok_or("expected unique metadata plan")?
             .partitions[0]
             .file_tasks[0]
-            .estimated_bytes = None;
+            .file_size = None;
         let metadata_metrics = metadata_plan.metrics.clone();
         let error = execute_official_plan(metadata_plan)
             .await

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -161,6 +161,9 @@ impl NativeAsyncFileReader {
         task: &DeltaScanFileTask,
     ) -> Result<NativeAsyncParquetObject, DeltaReaderError> {
         let object = self.resolve_parquet_object(task)?;
+        if task.parquet_byte_range.is_some() {
+            return Ok(object);
+        }
         self.buffer_small_parquet_object(object).await
     }
 
@@ -2249,15 +2252,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn threshold_buffers_only_eligible_files_with_one_metered_full_get()
+    async fn threshold_buffers_only_eligible_unsplit_files_with_one_metered_full_get()
     -> Result<(), Box<dyn std::error::Error>> {
         let bytes = b"0123456789abcdef";
 
-        for (name, threshold, expect_buffered) in [
-            ("disabled", None, false),
-            ("below", Some(bytes.len() - 1), false),
-            ("exact", Some(bytes.len()), true),
-            ("above", Some(bytes.len() + 1), true),
+        for (name, threshold, byte_range, expect_buffered) in [
+            ("disabled", None, None, false),
+            ("below", Some(bytes.len() - 1), None, false),
+            ("exact", Some(bytes.len()), None, true),
+            ("above", Some(bytes.len() + 1), None, true),
+            ("split", Some(bytes.len()), Some(0..8), false),
         ] {
             let root = TestDir::new(name)?;
             fs::write(root.path().join("part.parquet"), bytes)?;
@@ -2265,9 +2269,9 @@ mod tests {
             let options = DeltaReaderExecutionOptions::new()
                 .with_parquet_full_file_read_threshold(threshold)?;
             let reader = reader(&root, options, metrics.clone())?;
-            let object = reader
-                .parquet_object_for_task(&task("part.parquet", Some(u64::try_from(bytes.len())?))?)
-                .await?;
+            let mut task = task("part.parquet", Some(u64::try_from(bytes.len())?))?;
+            task.parquet_byte_range = byte_range;
+            let object = reader.parquet_object_for_task(&task).await?;
             let snapshot = metrics.snapshot();
             assert_eq!(
                 snapshot.parquet_data_file_full_get_operations,

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -1,6 +1,9 @@
 //! NativeAsync Parquet data-file reader.
 
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use arrow::{
     array::{Array, ArrayRef, Int64Array, ListArray, MapArray, StructArray, new_null_array},
@@ -14,11 +17,14 @@ use parquet::arrow::{
     PARQUET_FIELD_ID_META_KEY, ProjectionMask, RowNumber,
     arrow_reader::{ArrowPredicateFn, ArrowReaderMetadata, ArrowReaderOptions, RowFilter},
     async_reader::{
-        ParquetObjectReader, ParquetRecordBatchStream, ParquetRecordBatchStreamBuilder,
+        AsyncFileReader, ParquetObjectReader, ParquetRecordBatchStream,
+        ParquetRecordBatchStreamBuilder,
     },
 };
+use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::{SchemaDescriptor, TypePtr};
 use snafu::ResultExt;
+use tokio::sync::OnceCell;
 
 const ORIGINAL_ROW_INDEX_COLUMN: &str = "__delta_arrow_reader_original_row_index";
 
@@ -44,6 +50,25 @@ struct NativeAsyncFileReader {
     store: Arc<dyn ObjectStore>,
     execution_options: DeltaReaderExecutionOptions,
     metrics: DeltaReadMetrics,
+}
+
+#[derive(Default)]
+pub(crate) struct NativeAsyncParquetMetadataCache {
+    entries: Mutex<HashMap<(Path, u64), Arc<ParquetMetadataCell>>>,
+}
+
+type ParquetMetadataCell = OnceCell<Arc<ParquetMetaData>>;
+
+impl NativeAsyncParquetMetadataCache {
+    fn entry(&self, path: &Path, file_size: u64) -> Arc<ParquetMetadataCell> {
+        Arc::clone(
+            self.entries
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .entry((path.clone(), file_size))
+                .or_insert_with(|| Arc::new(OnceCell::new())),
+        )
+    }
 }
 
 struct NativeAsyncParquetObject {
@@ -156,6 +181,27 @@ impl NativeAsyncFileReader {
         }
     }
 
+    async fn split_parquet_metadata(
+        &self,
+        metadata_cache: Option<&NativeAsyncParquetMetadataCache>,
+        path: &Path,
+        file_size: u64,
+        reader: &mut ParquetObjectReader,
+        options: &ArrowReaderOptions,
+    ) -> Result<Arc<ParquetMetaData>, DeltaReaderError> {
+        let metadata = match metadata_cache {
+            Some(cache) => cache
+                .entry(path, file_size)
+                .get_or_try_init(|| reader.get_metadata(Some(options)))
+                .await
+                .map(Arc::clone),
+            None => reader.get_metadata(Some(options)).await,
+        };
+        metadata.boxed().context(DataFileReadSnafu {
+            reason: "parquet_read_setup_failed",
+        })
+    }
+
     async fn parquet_object_for_task(
         &self,
         task: &DeltaScanFileTask,
@@ -176,10 +222,34 @@ impl NativeAsyncFileReader {
         row_predicate: Option<(&DeltaKernelPredicate, &KernelScanSchemas)>,
         include_original_row_index: bool,
     ) -> Result<NativeAsyncParquetStream, DeltaReaderError> {
+        self.open_parquet_stream_with_metadata_cache(
+            task,
+            provider_schema,
+            output_batch_size,
+            physical_predicate,
+            row_predicate,
+            include_original_row_index,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn open_parquet_stream_with_metadata_cache(
+        &self,
+        task: &DeltaScanFileTask,
+        provider_schema: SchemaRef,
+        output_batch_size: Option<usize>,
+        physical_predicate: Option<&DeltaKernelPredicate>,
+        row_predicate: Option<(&DeltaKernelPredicate, &KernelScanSchemas)>,
+        include_original_row_index: bool,
+        metadata_cache: Option<&NativeAsyncParquetMetadataCache>,
+    ) -> Result<NativeAsyncParquetStream, DeltaReaderError> {
         let object = self.parquet_object_for_task(task).await?;
         let file_size = object.file_size;
-        let reader = ParquetObjectReader::new(object.store, object.path).with_file_size(file_size);
-        let reader = match self.execution_options.parquet_metadata_size_hint() {
+        let path = object.path;
+        let reader = ParquetObjectReader::new(object.store, path.clone()).with_file_size(file_size);
+        let mut reader = match self.execution_options.parquet_metadata_size_hint() {
             Some(hint) => reader.with_footer_size_hint(hint),
             None => reader,
         };
@@ -188,7 +258,28 @@ impl NativeAsyncFileReader {
             .context(DataFileReadSnafu {
                 reason: "parquet_row_index_setup_failed",
             })?;
-        let builder = if schema_uses_view_types(&provider_schema) {
+        let builder = if task.parquet_byte_range.is_some() {
+            let metadata = self
+                .split_parquet_metadata(
+                    metadata_cache,
+                    &path,
+                    file_size,
+                    &mut reader,
+                    &reader_options,
+                )
+                .await?;
+            let metadata = ArrowReaderMetadata::try_new(metadata, reader_options.clone())
+                .boxed()
+                .context(DataFileReadSnafu {
+                    reason: "parquet_read_setup_failed",
+                })?;
+            let metadata = if schema_uses_view_types(&provider_schema) {
+                metadata_with_view_types(metadata, reader_options)?
+            } else {
+                metadata
+            };
+            ParquetRecordBatchStreamBuilder::new_with_metadata(reader, metadata)
+        } else if schema_uses_view_types(&provider_schema) {
             let mut metadata_reader = reader.clone();
             let metadata =
                 ArrowReaderMetadata::load_async(&mut metadata_reader, reader_options.clone())
@@ -197,25 +288,10 @@ impl NativeAsyncFileReader {
                     .context(DataFileReadSnafu {
                         reason: "parquet_read_setup_failed",
                     })?;
-            let file_schema = Schema::new_with_metadata(
-                metadata
-                    .schema()
-                    .fields()
-                    .iter()
-                    .filter(|field| field.name() != ORIGINAL_ROW_INDEX_COLUMN)
-                    .cloned()
-                    .collect::<Vec<_>>(),
-                metadata.schema().metadata().clone(),
-            );
-            let metadata = ArrowReaderMetadata::try_new(
-                Arc::clone(metadata.metadata()),
-                reader_options.with_schema(schema_with_view_types(&file_schema)),
+            ParquetRecordBatchStreamBuilder::new_with_metadata(
+                reader,
+                metadata_with_view_types(metadata, reader_options)?,
             )
-            .boxed()
-            .context(DataFileReadSnafu {
-                reason: "parquet_read_setup_failed",
-            })?;
-            ParquetRecordBatchStreamBuilder::new_with_metadata(reader, metadata)
         } else {
             ParquetRecordBatchStreamBuilder::new_with_options(reader, reader_options)
                 .await
@@ -282,11 +358,20 @@ impl NativeAsyncFileReader {
         self: &Arc<Self>,
         request: NativeAsyncFileReadRequest,
     ) -> Result<NativeAsyncFileReadStream, DeltaReaderError> {
+        self.open_logical_file_stream_with_metadata_cache(request, None)
+            .await
+    }
+
+    async fn open_logical_file_stream_with_metadata_cache(
+        self: &Arc<Self>,
+        request: NativeAsyncFileReadRequest,
+        metadata_cache: Option<&NativeAsyncParquetMetadataCache>,
+    ) -> Result<NativeAsyncFileReadStream, DeltaReaderError> {
         let include_original_row_index = request.task.deletion_vector.is_present();
         let parquet = tokio::select! {
             biased;
             () = request.cancellation.cancelled() => return Err(cancelled_error()),
-            result = self.open_parquet_stream(
+            result = self.open_parquet_stream_with_metadata_cache(
                 &request.task,
                 request.physical_schema,
                 request.output_batch_size,
@@ -296,6 +381,7 @@ impl NativeAsyncFileReader {
                     .as_ref()
                     .map(|predicate| (predicate, &request.kernel_schemas)),
                 include_original_row_index,
+                metadata_cache,
             ) => result?,
         };
         if request.cancellation.is_cancelled() {
@@ -419,6 +505,30 @@ impl NativeAsyncFileReader {
     }
 }
 
+fn metadata_with_view_types(
+    metadata: ArrowReaderMetadata,
+    reader_options: ArrowReaderOptions,
+) -> Result<ArrowReaderMetadata, DeltaReaderError> {
+    let file_schema = Schema::new_with_metadata(
+        metadata
+            .schema()
+            .fields()
+            .iter()
+            .filter(|field| field.name() != ORIGINAL_ROW_INDEX_COLUMN)
+            .cloned()
+            .collect::<Vec<_>>(),
+        metadata.schema().metadata().clone(),
+    );
+    ArrowReaderMetadata::try_new(
+        Arc::clone(metadata.metadata()),
+        reader_options.with_schema(schema_with_view_types(&file_schema)),
+    )
+    .boxed()
+    .context(DataFileReadSnafu {
+        reason: "parquet_read_setup_failed",
+    })
+}
+
 pub(crate) fn native_async_file_executor(
     plan: &Arc<DeltaScanPlan>,
     output_batch_size: Option<usize>,
@@ -429,6 +539,41 @@ pub(crate) fn native_async_file_executor(
         plan.execution_options,
         plan.metrics.clone(),
     ));
+    native_async_file_executor_from_reader::<false>(
+        plan,
+        output_batch_size,
+        row_predicate,
+        reader,
+        None,
+    )
+}
+
+pub(crate) fn native_async_file_executor_with_metadata_cache(
+    plan: &Arc<DeltaScanPlan>,
+    output_batch_size: Option<usize>,
+    row_predicate: Option<DeltaKernelPredicate>,
+    metadata_cache: Arc<NativeAsyncParquetMetadataCache>,
+) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
+    native_async_file_executor_from_reader::<true>(
+        plan,
+        output_batch_size,
+        row_predicate,
+        Arc::new(NativeAsyncFileReader::new(
+            Arc::clone(&plan.engine_context),
+            plan.execution_options,
+            plan.metrics.clone(),
+        )),
+        Some(metadata_cache),
+    )
+}
+
+fn native_async_file_executor_from_reader<const SHARED_METADATA: bool>(
+    plan: &Arc<DeltaScanPlan>,
+    output_batch_size: Option<usize>,
+    row_predicate: Option<DeltaKernelPredicate>,
+    reader: Arc<NativeAsyncFileReader>,
+    metadata_cache: Option<Arc<NativeAsyncParquetMetadataCache>>,
+) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
     let physical_schema = Arc::clone(&plan.physical_schema);
     let logical_schema = Arc::clone(&plan.logical_schema);
     let kernel_schemas = plan.kernel_schemas.clone();
@@ -444,20 +589,29 @@ pub(crate) fn native_async_file_executor(
         let kernel_schemas = kernel_schemas.clone();
         let physical_predicate = physical_predicate.clone();
         let row_predicate = row_predicate.clone();
+        let metadata_cache = metadata_cache.clone();
         Box::pin(async move {
-            let file = reader
-                .open_logical_file_stream(NativeAsyncFileReadRequest {
-                    task,
-                    physical_schema,
-                    logical_schema,
-                    kernel_schemas,
-                    physical_predicate,
-                    row_predicate,
-                    output_batch_size,
-                    permit,
-                    cancellation,
-                })
-                .await?;
+            let request = NativeAsyncFileReadRequest {
+                task,
+                physical_schema,
+                logical_schema,
+                kernel_schemas,
+                physical_predicate,
+                row_predicate,
+                output_batch_size,
+                permit,
+                cancellation,
+            };
+            let file = if SHARED_METADATA {
+                reader
+                    .open_logical_file_stream_with_metadata_cache(
+                        request,
+                        metadata_cache.as_deref(),
+                    )
+                    .await?
+            } else {
+                reader.open_logical_file_stream(request).await?
+            };
             let batches = stream::try_unfold(file, |mut file| async move {
                 file.next_batch()
                     .await
@@ -1308,8 +1462,8 @@ mod tests {
     use parquet::file::properties::{EnabledStatistics, WriterProperties};
 
     use super::{
-        NativeAsyncFileReadRequest, NativeAsyncFileReader, data_file_error,
-        native_async_file_executor,
+        NativeAsyncFileReadRequest, NativeAsyncFileReader, NativeAsyncParquetMetadataCache,
+        data_file_error, native_async_file_executor,
     };
     #[cfg(feature = "official-kernel")]
     use crate::official_kernel_reader::official_kernel_file_executor;
@@ -2034,6 +2188,47 @@ mod tests {
         Ok((Arc::new(reader), gated, task))
     }
 
+    async fn gated_split_metadata_reader(
+        name: &str,
+        gate_request: GateRequest,
+    ) -> Result<
+        (
+            Arc<NativeAsyncFileReader>,
+            Arc<GatedObjectStore>,
+            DeltaScanFileTask,
+            Arc<Schema>,
+            Arc<NativeAsyncParquetMetadataCache>,
+        ),
+        Box<dyn std::error::Error>,
+    > {
+        let root = TestDir::new(name)?;
+        let parquet_bytes = parquet_bytes()?;
+        let file_size = u64::try_from(parquet_bytes.len())?;
+        let metrics = metrics();
+        let mut reader = reader(&root, DeltaReaderExecutionOptions::new(), metrics.clone())?;
+        let mut task = task("part.parquet", Some(file_size))?;
+        task.parquet_byte_range = Some(0..file_size);
+        let object = reader.resolve_parquet_object(&task)?;
+        let inner = Arc::new(InMemory::new());
+        inner.put(&object.path, parquet_bytes.into()).await?;
+        let gated = GatedObjectStore::new(inner, gate_request);
+        reader.store = Arc::new(MeteredParquetObjectStore::new(
+            Arc::clone(&gated) as Arc<dyn ObjectStore>,
+            metrics,
+        ));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        Ok((
+            Arc::new(reader),
+            gated,
+            task,
+            schema,
+            Arc::new(NativeAsyncParquetMetadataCache::default()),
+        ))
+    }
+
     fn file_read_request(
         plan: &Arc<crate::planning::DeltaScanPlan>,
         task: DeltaScanFileTask,
@@ -2283,6 +2478,183 @@ mod tests {
             "delta reader error: phase=data_file_read error=data_file_read reason=parquet_row_group_range_invalid"
         );
         assert!(!error.to_string().contains("secret.parquet"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn split_tasks_share_one_concurrent_parquet_metadata_load()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (reader, gated, mut first_task, schema, metadata_cache) = gated_split_metadata_reader(
+            "native-split-metadata-single-flight",
+            GateRequest::Range(1),
+        )
+        .await?;
+        let file_size = first_task
+            .file_size
+            .ok_or("test task must have a file size")?;
+        first_task.parquet_byte_range = Some(0..file_size / 2);
+        let mut second_task = first_task.clone();
+        second_task.parquet_byte_range = Some(file_size / 2..file_size);
+
+        let first_reader = Arc::clone(&reader);
+        let first_schema = Arc::clone(&schema);
+        let first_cache = Arc::clone(&metadata_cache);
+        let first = tokio::spawn(async move {
+            first_reader
+                .open_parquet_stream_with_metadata_cache(
+                    &first_task,
+                    first_schema,
+                    None,
+                    None,
+                    None,
+                    false,
+                    Some(first_cache.as_ref()),
+                )
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), gated.wait_started()).await?;
+
+        let second_reader = Arc::clone(&reader);
+        let second = tokio::spawn(async move {
+            second_reader
+                .open_parquet_stream_with_metadata_cache(
+                    &second_task,
+                    schema,
+                    None,
+                    None,
+                    None,
+                    false,
+                    Some(metadata_cache.as_ref()),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert_eq!(gated.range_calls.load(Ordering::Acquire), 1);
+        assert!(!second.is_finished());
+
+        gated.release.add_permits(1);
+        tokio::time::timeout(std::time::Duration::from_secs(5), first).await???;
+        tokio::time::timeout(std::time::Duration::from_secs(5), second).await???;
+        assert_eq!(
+            reader
+                .metrics
+                .snapshot()
+                .parquet_data_file_range_get_operations,
+            Some(1)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_split_metadata_load_can_be_retried() -> Result<(), Box<dyn std::error::Error>> {
+        let (reader, gated, task, schema, metadata_cache) = gated_split_metadata_reader(
+            "native-split-metadata-retry",
+            GateRequest::Range(usize::MAX),
+        )
+        .await?;
+        gated.fail_next_range();
+
+        let error = match reader
+            .open_parquet_stream_with_metadata_cache(
+                &task,
+                Arc::clone(&schema),
+                None,
+                None,
+                None,
+                false,
+                Some(metadata_cache.as_ref()),
+            )
+            .await
+        {
+            Ok(_) => return Err("injected metadata failure must fail the first split task".into()),
+            Err(error) => error,
+        };
+        assert_eq!(error.as_str(), "data_file_read");
+        reader
+            .open_parquet_stream_with_metadata_cache(
+                &task,
+                schema,
+                None,
+                None,
+                None,
+                false,
+                Some(metadata_cache.as_ref()),
+            )
+            .await?;
+
+        assert_eq!(gated.range_calls.load(Ordering::Acquire), 2);
+        assert_eq!(
+            reader
+                .metrics
+                .snapshot()
+                .parquet_data_file_range_get_operations,
+            Some(2)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancelled_split_metadata_load_wakes_a_retrying_task()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (reader, gated, task, schema, metadata_cache) = gated_split_metadata_reader(
+            "native-split-metadata-cancellation",
+            GateRequest::Range(1),
+        )
+        .await?;
+
+        let first_reader = Arc::clone(&reader);
+        let first_task = task.clone();
+        let first_schema = Arc::clone(&schema);
+        let first_cache = Arc::clone(&metadata_cache);
+        let first = tokio::spawn(async move {
+            first_reader
+                .open_parquet_stream_with_metadata_cache(
+                    &first_task,
+                    first_schema,
+                    None,
+                    None,
+                    None,
+                    false,
+                    Some(first_cache.as_ref()),
+                )
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), gated.wait_started()).await?;
+        first.abort();
+        let join_error = match first.await {
+            Ok(_) => return Err("aborted metadata task unexpectedly completed".into()),
+            Err(error) => error,
+        };
+        assert!(join_error.is_cancelled());
+        assert!(gated.was_cancelled());
+
+        gated.gate_next_range();
+        let second_reader = Arc::clone(&reader);
+        let second = tokio::spawn(async move {
+            second_reader
+                .open_parquet_stream_with_metadata_cache(
+                    &task,
+                    schema,
+                    None,
+                    None,
+                    None,
+                    false,
+                    Some(metadata_cache.as_ref()),
+                )
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), gated.wait_started()).await?;
+        gated.release.add_permits(1);
+        tokio::time::timeout(std::time::Duration::from_secs(5), second).await???;
+
+        assert_eq!(gated.range_calls.load(Ordering::Acquire), 2);
+        assert_eq!(
+            reader
+                .metrics
+                .snapshot()
+                .parquet_data_file_range_get_operations,
+            Some(2)
+        );
         Ok(())
     }
 

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -229,7 +229,11 @@ impl NativeAsyncFileReader {
         .map_err(|error| data_file_error("parquet_schema_match_failed", error))?;
         let projection =
             ProjectionMask::roots(builder.parquet_schema(), schema_match.projected_roots());
-        let row_groups = native_async_pruned_row_groups(builder.metadata(), physical_predicate);
+        let row_groups = native_async_pruned_row_groups(
+            builder.metadata(),
+            task.parquet_byte_range.as_ref(),
+            physical_predicate,
+        );
         let builder = match row_groups {
             Some(row_groups) => builder.with_row_groups(row_groups),
             None => builder,

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -52,8 +52,10 @@ struct NativeAsyncFileReader {
     metrics: DeltaReadMetrics,
 }
 
+/// Parquet footer metadata shared by ranged tasks within one physical scan.
 #[derive(Default)]
 pub(crate) struct NativeAsyncParquetMetadataCache {
+    /// In-flight or completed footer loads keyed by file path and planned size.
     entries: Mutex<HashMap<(Path, u64), Arc<ParquetMetadataCell>>>,
 }
 
@@ -259,6 +261,8 @@ impl NativeAsyncFileReader {
                 reason: "parquet_row_index_setup_failed",
             })?;
         let builder = if task.parquet_byte_range.is_some() {
+            // Ranged tasks need explicit footer metadata to select row groups.
+            // Sharing it avoids one footer read for every range of the same file.
             let metadata = self
                 .load_split_parquet_metadata(
                     metadata_cache,
@@ -280,6 +284,8 @@ impl NativeAsyncFileReader {
             };
             ParquetRecordBatchStreamBuilder::new_with_metadata(reader, metadata)
         } else if schema_uses_view_types(&provider_schema) {
+            // View arrays require rewriting the Arrow schema stored in the
+            // metadata before constructing the stream builder.
             let mut metadata_reader = reader.clone();
             let metadata =
                 ArrowReaderMetadata::load_async(&mut metadata_reader, reader_options.clone())
@@ -293,6 +299,7 @@ impl NativeAsyncFileReader {
                 metadata_with_view_types(metadata, reader_options)?,
             )
         } else {
+            // Ordinary whole-file scans can let the builder load its metadata.
             ParquetRecordBatchStreamBuilder::new_with_options(reader, reader_options)
                 .await
                 .boxed()

--- a/src/native_async_row_group_pruning.rs
+++ b/src/native_async_row_group_pruning.rs
@@ -14,9 +14,12 @@ use chrono::{DateTime, Days};
 use delta_kernel::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
 };
-use parquet::file::metadata::{ParquetMetaData, RowGroupMetaData};
 use parquet::file::statistics::Statistics;
 use parquet::schema::types::ColumnDescPtr;
+use parquet::{
+    errors::{ParquetError, Result as ParquetResult},
+    file::metadata::{ParquetMetaData, RowGroupMetaData},
+};
 
 use delta_kernel::{
     expressions::{ColumnName, DecimalData, Scalar},
@@ -33,34 +36,52 @@ use crate::kernel::DeltaKernelPredicate;
 #[allow(dead_code)]
 pub(crate) fn native_async_pruned_row_groups(
     metadata: &ParquetMetaData,
+    file_size: u64,
     byte_range: Option<&Range<u64>>,
     predicate: Option<&DeltaKernelPredicate>,
-) -> Option<Vec<usize>> {
+) -> ParquetResult<Option<Vec<usize>>> {
     if byte_range.is_none() && predicate.is_none() {
-        return None;
+        return Ok(None);
     }
 
-    Some(
-        metadata
-            .row_groups()
-            .iter()
-            .enumerate()
-            .filter_map(|(ordinal, row_group)| {
-                let in_range = byte_range.is_none_or(|range| {
-                    let column = row_group.column(0);
-                    let offset = column
-                        .dictionary_page_offset()
-                        .unwrap_or_else(|| column.data_page_offset());
-                    u64::try_from(offset).is_ok_and(|offset| range.contains(&offset))
-                });
-                let may_match = predicate.is_none_or(|predicate| {
-                    NativeAsyncRowGroupStats::new(row_group)
-                        .may_contain_matching_rows(predicate.as_ref())
-                });
-                (in_range && may_match).then_some(ordinal)
-            })
-            .collect(),
-    )
+    if byte_range.is_some_and(|range| range.start >= range.end || range.end > file_size) {
+        return Err(ParquetError::General(
+            "parquet scan byte range is outside the file".to_owned(),
+        ));
+    }
+
+    let mut selected = Vec::new();
+    for (ordinal, row_group) in metadata.row_groups().iter().enumerate() {
+        let in_range = match byte_range {
+            None => true,
+            Some(range) => {
+                let column = row_group.columns().first().ok_or_else(|| {
+                    ParquetError::General(
+                        "parquet row group has no first-column metadata".to_owned(),
+                    )
+                })?;
+                let offset = column
+                    .dictionary_page_offset()
+                    .unwrap_or_else(|| column.data_page_offset());
+                let offset = u64::try_from(offset).map_err(|_| {
+                    ParquetError::General("parquet row-group offset is negative".to_owned())
+                })?;
+                if offset >= file_size {
+                    return Err(ParquetError::General(
+                        "parquet row-group offset is outside the file".to_owned(),
+                    ));
+                }
+                range.contains(&offset)
+            }
+        };
+        let may_match = predicate.is_none_or(|predicate| {
+            NativeAsyncRowGroupStats::new(row_group).may_contain_matching_rows(predicate.as_ref())
+        });
+        if in_range && may_match {
+            selected.push(ordinal);
+        }
+    }
+    Ok(Some(selected))
 }
 
 struct NativeAsyncRowGroupStats<'a> {
@@ -355,6 +376,18 @@ mod tests {
         Ok(ParquetMetaData::new(file, row_groups))
     }
 
+    fn metadata_without_columns() -> Result<ParquetMetaData, parquet::errors::ParquetError> {
+        let schema = SchemaType::group_type_builder("schema").build()?;
+        let schema = Arc::new(SchemaDescriptor::new(Arc::new(schema)));
+        let row_group = RowGroupMetaData::builder(Arc::clone(&schema))
+            .set_num_rows(1)
+            .set_ordinal(0)
+            .set_column_metadata(vec![])
+            .build()?;
+        let file = FileMetaData::new(1, 1, None, None, schema, None);
+        Ok(ParquetMetaData::new(file, vec![row_group]))
+    }
+
     #[test]
     fn byte_range_selects_each_row_group_exactly_once() -> Result<(), Box<dyn std::error::Error>> {
         let metadata = metadata_with_row_group_offsets(&[
@@ -365,19 +398,19 @@ mod tests {
         ])?;
 
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, Some(&(0..25)), None),
+            native_async_pruned_row_groups(&metadata, 80, Some(&(0..25)), None)?,
             Some(vec![0])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, Some(&(25..50)), None),
+            native_async_pruned_row_groups(&metadata, 80, Some(&(25..50)), None)?,
             Some(vec![1])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, Some(&(50..65)), None),
+            native_async_pruned_row_groups(&metadata, 80, Some(&(50..65)), None)?,
             Some(vec![2])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, Some(&(65..80)), None),
+            native_async_pruned_row_groups(&metadata, 80, Some(&(65..80)), None)?,
             Some(vec![3])
         );
 
@@ -390,13 +423,47 @@ mod tests {
         let metadata = metadata_with_row_group_offsets(&[(30, Some(20)), (40, None)])?;
 
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, Some(&(20..40)), None),
+            native_async_pruned_row_groups(&metadata, 41, Some(&(20..40)), None)?,
             Some(vec![0])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, Some(&(40..41)), None),
+            native_async_pruned_row_groups(&metadata, 41, Some(&(40..41)), None)?,
             Some(vec![1])
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn byte_range_rejects_malformed_row_group_coordinates() -> Result<(), Box<dyn std::error::Error>>
+    {
+        assert!(
+            native_async_pruned_row_groups(
+                &metadata_without_columns()?,
+                100,
+                Some(&(0..100)),
+                None,
+            )
+            .is_err()
+        );
+        for metadata in [
+            metadata_with_row_group_offsets(&[(-1, None)])?,
+            metadata_with_row_group_offsets(&[(10, Some(-1))])?,
+            metadata_with_row_group_offsets(&[(100, None)])?,
+            metadata_with_row_group_offsets(&[(101, None)])?,
+        ] {
+            assert!(native_async_pruned_row_groups(&metadata, 100, Some(&(0..100)), None).is_err());
+        }
+
+        let metadata = metadata_with_row_group_offsets(&[(0, None), (99, None)])?;
+        assert_eq!(
+            native_async_pruned_row_groups(&metadata, 100, Some(&(0..100)), None)?,
+            Some(vec![0, 1])
+        );
+        for (start, end) in [(0, 0), (0, 101), (100, 99)] {
+            let range = start..end;
+            assert!(native_async_pruned_row_groups(&metadata, 100, Some(&range), None).is_err());
+        }
 
         Ok(())
     }

--- a/src/native_async_row_group_pruning.rs
+++ b/src/native_async_row_group_pruning.rs
@@ -8,6 +8,7 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::ops::Range;
 
 use chrono::{DateTime, Days};
 use delta_kernel::kernel_predicates::{
@@ -24,17 +25,20 @@ use delta_kernel::{
 
 use crate::kernel::DeltaKernelPredicate;
 
-/// Computes the row groups that cannot be eliminated by footer statistics.
+/// Computes the row groups selected by a byte range and footer statistics.
 ///
-/// `None` means there is no physical predicate to use for row-group pruning.
+/// `None` means there is no byte range or physical predicate to use for pruning.
 /// `Some(Vec::new())` means every row group was proven impossible and the
 /// parquet reader should return no rows.
 #[allow(dead_code)]
 pub(crate) fn native_async_pruned_row_groups(
     metadata: &ParquetMetaData,
+    byte_range: Option<&Range<u64>>,
     predicate: Option<&DeltaKernelPredicate>,
 ) -> Option<Vec<usize>> {
-    let predicate = predicate?;
+    if byte_range.is_none() && predicate.is_none() {
+        return None;
+    }
 
     Some(
         metadata
@@ -42,9 +46,18 @@ pub(crate) fn native_async_pruned_row_groups(
             .iter()
             .enumerate()
             .filter_map(|(ordinal, row_group)| {
-                NativeAsyncRowGroupStats::new(row_group)
-                    .may_contain_matching_rows(predicate.as_ref())
-                    .then_some(ordinal)
+                let in_range = byte_range.is_none_or(|range| {
+                    let column = row_group.column(0);
+                    let offset = column
+                        .dictionary_page_offset()
+                        .unwrap_or_else(|| column.data_page_offset());
+                    u64::try_from(offset).is_ok_and(|offset| range.contains(&offset))
+                });
+                let may_match = predicate.is_none_or(|predicate| {
+                    NativeAsyncRowGroupStats::new(row_group)
+                        .may_contain_matching_rows(predicate.as_ref())
+                });
+                (in_range && may_match).then_some(ordinal)
             })
             .collect(),
     )
@@ -304,7 +317,89 @@ fn decimal_scalar_from_bytes(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use parquet::{
+        basic::Type as PhysicalType,
+        file::metadata::{ColumnChunkMetaData, FileMetaData, RowGroupMetaData},
+        schema::types::{SchemaDescriptor, Type as SchemaType},
+    };
+
     use super::*;
+
+    fn metadata_with_row_group_offsets(
+        offsets: &[(i64, Option<i64>)],
+    ) -> Result<ParquetMetaData, parquet::errors::ParquetError> {
+        let schema = SchemaType::group_type_builder("schema")
+            .with_fields(vec![Arc::new(
+                SchemaType::primitive_type_builder("value", PhysicalType::INT32).build()?,
+            )])
+            .build()?;
+        let schema = Arc::new(SchemaDescriptor::new(Arc::new(schema)));
+        let row_groups = offsets
+            .iter()
+            .enumerate()
+            .map(|(ordinal, (data_offset, dictionary_offset))| {
+                let column = ColumnChunkMetaData::builder(schema.columns()[0].clone())
+                    .set_data_page_offset(*data_offset)
+                    .set_dictionary_page_offset(*dictionary_offset)
+                    .build()?;
+                RowGroupMetaData::builder(Arc::clone(&schema))
+                    .set_num_rows(1)
+                    .set_ordinal(ordinal as i16)
+                    .set_column_metadata(vec![column])
+                    .build()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let file = FileMetaData::new(1, row_groups.len() as i64, None, None, schema, None);
+        Ok(ParquetMetaData::new(file, row_groups))
+    }
+
+    #[test]
+    fn byte_range_selects_each_row_group_exactly_once() -> Result<(), Box<dyn std::error::Error>> {
+        let metadata = metadata_with_row_group_offsets(&[
+            (10, None),
+            (30, Some(25)),
+            (50, None),
+            (70, Some(65)),
+        ])?;
+
+        assert_eq!(
+            native_async_pruned_row_groups(&metadata, Some(&(0..25)), None),
+            Some(vec![0])
+        );
+        assert_eq!(
+            native_async_pruned_row_groups(&metadata, Some(&(25..50)), None),
+            Some(vec![1])
+        );
+        assert_eq!(
+            native_async_pruned_row_groups(&metadata, Some(&(50..65)), None),
+            Some(vec![2])
+        );
+        assert_eq!(
+            native_async_pruned_row_groups(&metadata, Some(&(65..80)), None),
+            Some(vec![3])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn byte_range_uses_dictionary_offset_and_half_open_bounds()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let metadata = metadata_with_row_group_offsets(&[(30, Some(20)), (40, None)])?;
+
+        assert_eq!(
+            native_async_pruned_row_groups(&metadata, Some(&(20..40)), None),
+            Some(vec![0])
+        );
+        assert_eq!(
+            native_async_pruned_row_groups(&metadata, Some(&(40..41)), None),
+            Some(vec![1])
+        );
+
+        Ok(())
+    }
 
     #[test]
     fn decimal_scalar_from_fixed_len_bytes_sign_extends_negative_values()

--- a/src/native_async_row_group_pruning.rs
+++ b/src/native_async_row_group_pruning.rs
@@ -435,8 +435,8 @@ mod tests {
     }
 
     #[test]
-    fn byte_range_rejects_malformed_row_group_coordinates() -> Result<(), Box<dyn std::error::Error>>
-    {
+    fn regression_byte_range_rejects_malformed_row_group_coordinates()
+    -> Result<(), Box<dyn std::error::Error>> {
         assert!(
             native_async_pruned_row_groups(
                 &metadata_without_columns()?,

--- a/src/official_kernel_reader.rs
+++ b/src/official_kernel_reader.rs
@@ -69,7 +69,7 @@ fn read_file(
     }
     let DeltaScanFileTask {
         path,
-        estimated_bytes,
+        file_size,
         modification_time_ms,
         deletion_vector,
         transform,
@@ -91,7 +91,7 @@ fn read_file(
     if cancellation.is_cancelled() {
         return Ok(());
     }
-    let size = estimated_bytes.ok_or_else(|| {
+    let size = file_size.ok_or_else(|| {
         data_file_error(
             "data_file_size_missing",
             delta_kernel::Error::generic("file size is required for OfficialKernel reads"),

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -343,11 +343,15 @@ fn logical_projection(
     }))
 }
 
+/// File-read tasks executed together as one scan partition.
 #[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct DeltaScanFileTaskPartition {
+    /// Whole-file or ranged Parquet reads assigned to this partition.
     pub(crate) file_tasks: Vec<DeltaScanFileTask>,
+    /// Total bytes to read when every task has a known size.
     pub(crate) estimated_bytes: Option<u64>,
+    /// Total output rows when every task has a valid whole-file estimate.
     pub(crate) estimated_rows: Option<u64>,
 }
 
@@ -440,6 +444,7 @@ fn group_by_file_count(
     Ok(partitions)
 }
 
+/// Builds a scan partition and its aggregate size and row estimates.
 pub(crate) fn build_partition(
     file_tasks: Vec<DeltaScanFileTask>,
 ) -> Result<DeltaScanFileTaskPartition, DeltaReaderError> {
@@ -508,28 +513,41 @@ fn validate_projection(
     Ok(())
 }
 
+/// One physical Parquet read, covering either a whole data file or a byte range.
 #[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct DeltaScanFileTask {
+    /// Object-store path of the physical data file.
     pub(crate) path: String,
+    /// Size of the complete physical file, when known.
     pub(crate) file_size: Option<u64>,
+    /// Byte range assigned by intra-file repartitioning, or `None` for the whole file.
     pub(crate) parquet_byte_range: Option<Range<u64>>,
+    /// Expected output rows, available only for whole-file tasks with statistics.
     pub(crate) estimated_rows: Option<u64>,
+    /// Delta file statistics used by planning and pruning.
     pub(crate) stats: Option<DeltaScanFileStats>,
+    /// Data-file modification time from the Delta add action.
     pub(crate) modification_time_ms: Option<i64>,
+    /// Logical partition-column values from the Delta add action.
     pub(crate) partition_values: BTreeMap<String, String>,
+    /// Deletion vector associated with the complete physical file.
     pub(crate) deletion_vector: DeletionVectorMetadata,
+    /// Physical-to-logical expression applied after reading the Parquet data.
     pub(crate) transform: KernelPhysicalToLogicalTransform,
 }
 
+/// Row-count statistics retained from a Delta add action.
 #[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct DeltaScanFileStats {
+    /// Number of physical rows in the complete data file.
     pub(crate) num_records: u64,
 }
 
 #[allow(dead_code)]
 impl DeltaScanFileTask {
+    /// Returns bytes assigned to this task, using its range when split.
     pub(crate) fn estimated_scan_bytes(&self) -> Option<u64> {
         match &self.parquet_byte_range {
             Some(range) => range.end.checked_sub(range.start),

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -3,6 +3,7 @@
 use std::{
     cmp::Reverse,
     collections::{BTreeMap, BinaryHeap, HashSet},
+    ops::Range,
     sync::Arc,
 };
 
@@ -506,6 +507,7 @@ fn validate_projection(
 pub(crate) struct DeltaScanFileTask {
     pub(crate) path: String,
     pub(crate) estimated_bytes: Option<u64>,
+    pub(crate) parquet_byte_range: Option<Range<u64>>,
     pub(crate) estimated_rows: Option<u64>,
     pub(crate) stats: Option<DeltaScanFileStats>,
     pub(crate) modification_time_ms: Option<i64>,
@@ -536,6 +538,7 @@ impl DeltaScanFileTask {
         Ok(Self {
             path: file.path,
             estimated_bytes: Some(estimated_bytes),
+            parquet_byte_range: None,
             estimated_rows: stats.as_ref().map(|stats| stats.num_records),
             stats,
             modification_time_ms: file.modification_time_ms,

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -38,6 +38,7 @@ pub(crate) struct DeltaScanPartitionTargetOptions {
 }
 
 #[allow(dead_code)]
+#[derive(Clone)]
 pub(crate) struct DeltaScanPlan {
     pub(crate) snapshot_version: u64,
     pub(crate) engine_context: Arc<DeltaKernelEngineContext>,
@@ -218,7 +219,7 @@ fn build_unpartitioned_scan_plan(
         .map(DeltaScanFileTask::try_from_kernel)
         .collect::<Result<Vec<_>, _>>()?;
     let estimated_bytes = checked_sum(
-        file_tasks.iter().map(|task| task.estimated_bytes),
+        file_tasks.iter().map(|task| task.file_size),
         "scan_estimated_bytes_overflow",
     )?;
     let estimated_rows = checked_sum(
@@ -343,6 +344,7 @@ fn logical_projection(
 }
 
 #[allow(dead_code)]
+#[derive(Clone)]
 pub(crate) struct DeltaScanFileTaskPartition {
     pub(crate) file_tasks: Vec<DeltaScanFileTask>,
     pub(crate) estimated_bytes: Option<u64>,
@@ -362,7 +364,9 @@ pub(crate) fn group_scan_file_tasks(
     }
 
     let estimated_bytes = checked_sum(
-        file_tasks.iter().map(|task| task.estimated_bytes),
+        file_tasks
+            .iter()
+            .map(DeltaScanFileTask::estimated_scan_bytes),
         "scan_estimated_bytes_overflow",
     )?;
     if file_tasks.is_empty() {
@@ -380,7 +384,7 @@ fn group_by_estimated_bytes(
     target_partitions: usize,
 ) -> Result<Vec<DeltaScanFileTaskPartition>, DeltaReaderError> {
     let output_limit = target_partitions.min(file_tasks.len());
-    file_tasks.sort_by_key(|task| Reverse(task.estimated_bytes));
+    file_tasks.sort_by_key(|task| Reverse(task.estimated_scan_bytes()));
     let mut file_tasks = file_tasks.into_iter();
     let mut partition_tasks = Vec::with_capacity(output_limit);
     let mut partition_loads = BinaryHeap::with_capacity(output_limit);
@@ -389,7 +393,7 @@ fn group_by_estimated_bytes(
         let Some(file_task) = file_tasks.next() else {
             return partition_planning_error("known_size_grouping_exhausted_tasks");
         };
-        let Some(file_bytes) = file_task.estimated_bytes else {
+        let Some(file_bytes) = file_task.estimated_scan_bytes() else {
             return partition_planning_error("known_size_grouping_missing_estimated_bytes");
         };
         partition_tasks.push(vec![file_task]);
@@ -397,7 +401,7 @@ fn group_by_estimated_bytes(
     }
 
     for file_task in file_tasks {
-        let Some(file_bytes) = file_task.estimated_bytes else {
+        let Some(file_bytes) = file_task.estimated_scan_bytes() else {
             return partition_planning_error("known_size_grouping_missing_estimated_bytes");
         };
         let Some(Reverse((partition_bytes, partition_index))) = partition_loads.pop() else {
@@ -436,11 +440,13 @@ fn group_by_file_count(
     Ok(partitions)
 }
 
-fn build_partition(
+pub(crate) fn build_partition(
     file_tasks: Vec<DeltaScanFileTask>,
 ) -> Result<DeltaScanFileTaskPartition, DeltaReaderError> {
     let estimated_bytes = checked_sum(
-        file_tasks.iter().map(|task| task.estimated_bytes),
+        file_tasks
+            .iter()
+            .map(DeltaScanFileTask::estimated_scan_bytes),
         "partition_estimated_bytes_overflow",
     )?;
     let estimated_rows = checked_sum(
@@ -506,7 +512,7 @@ fn validate_projection(
 #[derive(Clone)]
 pub(crate) struct DeltaScanFileTask {
     pub(crate) path: String,
-    pub(crate) estimated_bytes: Option<u64>,
+    pub(crate) file_size: Option<u64>,
     pub(crate) parquet_byte_range: Option<Range<u64>>,
     pub(crate) estimated_rows: Option<u64>,
     pub(crate) stats: Option<DeltaScanFileStats>,
@@ -524,8 +530,15 @@ pub(crate) struct DeltaScanFileStats {
 
 #[allow(dead_code)]
 impl DeltaScanFileTask {
+    pub(crate) fn estimated_scan_bytes(&self) -> Option<u64> {
+        match &self.parquet_byte_range {
+            Some(range) => range.end.checked_sub(range.start),
+            None => self.file_size,
+        }
+    }
+
     pub(crate) fn try_from_kernel(file: KernelScanFileMetadata) -> Result<Self, DeltaReaderError> {
-        let estimated_bytes = u64::try_from(file.size)
+        let file_size = u64::try_from(file.size)
             .boxed()
             .context(ScanPlanningSnafu {
                 reason: "negative_file_size",
@@ -537,7 +550,7 @@ impl DeltaScanFileTask {
 
         Ok(Self {
             path: file.path,
-            estimated_bytes: Some(estimated_bytes),
+            file_size: Some(file_size),
             parquet_byte_range: None,
             estimated_rows: stats.as_ref().map(|stats| stats.num_records),
             stats,
@@ -771,7 +784,7 @@ mod tests {
         estimated_rows: Option<u64>,
     ) -> Result<DeltaScanFileTask, crate::DeltaReaderError> {
         let mut task = task(kernel_file(path))?;
-        task.estimated_bytes = estimated_bytes;
+        task.file_size = estimated_bytes;
         task.estimated_rows = estimated_rows;
         task.stats = estimated_rows.map(|num_records| DeltaScanFileStats { num_records });
         Ok(task)
@@ -854,7 +867,7 @@ mod tests {
         let task = task(file)?;
 
         assert_eq!(task.path, "part-00000.parquet");
-        assert_eq!(task.estimated_bytes, Some(123));
+        assert_eq!(task.file_size, Some(123));
         assert_eq!(task.estimated_rows, Some(7));
         assert_eq!(task.stats.as_ref().map(|stats| stats.num_records), Some(7));
         assert_eq!(task.modification_time_ms, Some(1_587_968_586_000));
@@ -880,7 +893,7 @@ mod tests {
 
         let task = task(file)?;
 
-        assert_eq!(task.estimated_bytes, Some(0));
+        assert_eq!(task.file_size, Some(0));
         assert_eq!(task.estimated_rows, None);
         assert!(task.stats.is_none());
         assert!(!task.deletion_vector.is_present());
@@ -968,7 +981,7 @@ mod tests {
         let single_task = planned_tasks(&single).next().ok_or("expected one task")?;
         assert_eq!(planned_tasks(&single).count(), 1);
         assert_eq!(single_task.path, "single.parquet");
-        assert_eq!(single_task.estimated_bytes, Some(0));
+        assert_eq!(single_task.file_size, Some(0));
         assert_eq!(single.estimated_bytes, Some(0));
         assert_eq!(single.estimated_rows, None);
 
@@ -1002,9 +1015,9 @@ mod tests {
         let last = planned_tasks(&many)
             .find(|task| task.path == "part-1000.parquet")
             .ok_or("expected last task")?;
-        assert_eq!(first.estimated_bytes, Some(0));
+        assert_eq!(first.file_size, Some(0));
         assert_eq!(second.estimated_rows, None);
-        assert_eq!(last.estimated_bytes, Some(1_000));
+        assert_eq!(last.file_size, Some(1_000));
         assert_eq!(last.estimated_rows, Some(1_000));
         assert!(many.scan_metadata_exhausted);
         assert_eq!(many.files_filtered_during_planning, Some(0));
@@ -1603,7 +1616,7 @@ mod tests {
         let grouped = &partitions[0].file_tasks[0];
 
         assert_eq!(grouped.path, "part-with-delta-metadata.parquet");
-        assert_eq!(grouped.estimated_bytes, Some(123));
+        assert_eq!(grouped.file_size, Some(123));
         assert_eq!(grouped.estimated_rows, Some(7));
         assert_eq!(
             grouped.partition_values.get("region").map(String::as_str),

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -286,7 +286,10 @@ async fn repartitioned_scan_preserves_predicates_and_deletion_vector_coordinates
         &context,
         "orders",
         table,
-        DeltaDataFusionScanOptions::default(),
+        DeltaDataFusionScanOptions {
+            target_partitions: Some(8),
+            ..Default::default()
+        },
     )?;
 
     let plan = context
@@ -533,7 +536,10 @@ async fn repartitioned_scan_fails_closed_when_dv_payload_is_missing() -> TestRes
         &context,
         "orders",
         &fixture,
-        DeltaDataFusionScanOptions::default(),
+        DeltaDataFusionScanOptions {
+            target_partitions: Some(8),
+            ..Default::default()
+        },
     )?;
     let plan = context
         .sql("SELECT id FROM orders")

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -306,7 +306,12 @@ async fn repartitioned_scan_preserves_predicates_and_deletion_vector_coordinates
     let metrics = metrics[0].snapshot().reader;
     assert_eq!(metrics.scan_partitions_started, 8);
     assert_eq!(metrics.files_started, 8);
-    assert_eq!(metrics.deletion_vector_payloads_loaded, 1);
+    assert!(
+        (1..=metrics.files_started).contains(&metrics.deletion_vector_payloads_loaded),
+        "unexpected payload load count: {} for {} tasks",
+        metrics.deletion_vector_payloads_loaded,
+        metrics.files_started
+    );
     assert_eq!(metrics.deletion_vectors_applied, 2);
     assert_eq!(metrics.deletion_vector_rows_deleted, 3);
     assert_eq!(metrics.deletion_vector_failures, 0);
@@ -450,7 +455,11 @@ async fn large_repartitioned_dv_scan_matches_unsplit_under_concurrent_reexecutio
         metrics.rows_produced,
         u64::try_from(expected.len())? * executions
     );
-    assert_eq!(metrics.deletion_vector_payloads_loaded, 1);
+    assert!(
+        (1..=expected_tasks).contains(&metrics.deletion_vector_payloads_loaded),
+        "unexpected payload load count: {} for {expected_tasks} tasks",
+        metrics.deletion_vector_payloads_loaded
+    );
     assert_eq!(
         metrics.deletion_vectors_applied,
         u64::try_from(ROW_GROUPS)? * executions

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -4,6 +4,7 @@
 mod support;
 
 use std::{
+    collections::HashSet,
     error::Error,
     fs,
     path::{Path, PathBuf},
@@ -32,7 +33,10 @@ use delta_arrow_reader::{
     DeltaTableBuilder, DeltaTableProvider, collect_delta_datafusion_metrics, register_delta_table,
 };
 use futures_util::StreamExt;
-use parquet::arrow::ArrowWriter;
+use parquet::{
+    arrow::ArrowWriter,
+    file::reader::{FileReader, SerializedFileReader},
+};
 use serde_json::{Value, json};
 
 use support::RealParquetDeltaTable;
@@ -348,6 +352,213 @@ async fn repartitioned_scan_preserves_physical_to_logical_transforms() -> TestRe
         })
         .collect::<Vec<_>>();
     assert_eq!(names, [Some("bob"), None]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn large_repartitioned_dv_scan_matches_unsplit_under_concurrent_reexecution() -> TestResult {
+    const ROW_GROUPS: usize = 32;
+    const ROWS_PER_GROUP: usize = 8_192;
+    const TARGET_PARTITIONS: usize = 64;
+    let rows = ROW_GROUPS
+        .checked_mul(ROWS_PER_GROUP)
+        .ok_or("row overflow")?;
+    let mut stored_deleted_rows = Vec::with_capacity(ROW_GROUPS * 3 + 2);
+    for row_group in 0..ROW_GROUPS {
+        let start = u64::try_from(
+            row_group
+                .checked_mul(ROWS_PER_GROUP)
+                .ok_or("row overflow")?,
+        )?;
+        stored_deleted_rows.extend([
+            start,
+            start + u64::try_from(ROWS_PER_GROUP / 2)?,
+            start + u64::try_from(ROWS_PER_GROUP - 1)?,
+        ]);
+    }
+    stored_deleted_rows.extend([0, u64::try_from(rows - 1)?]);
+    let mut deleted_rows = stored_deleted_rows.clone();
+    deleted_rows.sort_unstable();
+    deleted_rows.dedup();
+
+    let fixture = RealParquetDeltaTable::new_with_row_groups_and_deletion_vector(
+        "provider-large-repartitioned-dv",
+        ROW_GROUPS,
+        ROWS_PER_GROUP,
+        &stored_deleted_rows,
+    )?;
+    assert_eq!(fixture.rows(), rows);
+    let parquet = SerializedFileReader::new(fs::File::open(
+        fixture.path().join(fixture.data_file_path()),
+    )?)?;
+    assert_eq!(parquet.metadata().num_row_groups(), ROW_GROUPS);
+
+    let execution_options = DeltaReaderExecutionOptions::new()
+        .with_parquet_full_file_read_threshold(Some(usize::MAX))?;
+    let options = DeltaDataFusionScanOptions {
+        execution_options,
+        target_partitions: Some(TARGET_PARTITIONS),
+        ..Default::default()
+    };
+    let context = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_batch_size(1_024)
+            .with_target_partitions(TARGET_PARTITIONS)
+            .with_repartition_file_min_size(1),
+    );
+    register_fixture(&context, "orders", &fixture, options.clone())?;
+    let plan = context
+        .sql("SELECT id FROM orders ORDER BY id")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let display = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        display.contains(&format!("partitions={TARGET_PARTITIONS}")),
+        "{display}"
+    );
+    let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+    assert_eq!(metrics.len(), 1);
+
+    let (first, second) = tokio::join!(
+        collect_plan(&context, Arc::clone(&plan)),
+        collect_plan(&context, Arc::clone(&plan)),
+    );
+    let deleted_ids = deleted_rows
+        .iter()
+        .map(|row| i32::try_from(row + 1))
+        .collect::<Result<HashSet<_>, _>>()?;
+    let expected = (1..=i32::try_from(rows)?)
+        .filter(|id| !deleted_ids.contains(id))
+        .collect::<Vec<_>>();
+    for actual in [first?, second?] {
+        assert_eq!(ids(&actual), expected);
+    }
+
+    let metrics = metrics[0].snapshot().reader;
+    let executions = 2_u64;
+    let expected_tasks = u64::try_from(TARGET_PARTITIONS)? * executions;
+    assert_eq!(
+        metrics.scan_partitions_planned,
+        u64::try_from(TARGET_PARTITIONS)?
+    );
+    assert_eq!(metrics.scan_partitions_started, expected_tasks);
+    assert_eq!(metrics.scan_partitions_completed, expected_tasks);
+    assert_eq!(metrics.files_started, expected_tasks);
+    assert_eq!(metrics.files_completed, expected_tasks);
+    assert_eq!(
+        metrics.rows_produced,
+        u64::try_from(expected.len())? * executions
+    );
+    assert_eq!(metrics.deletion_vector_payloads_loaded, 1);
+    assert_eq!(
+        metrics.deletion_vectors_applied,
+        u64::try_from(ROW_GROUPS)? * executions
+    );
+    assert_eq!(
+        metrics.deletion_vector_rows_deleted,
+        u64::try_from(deleted_rows.len())? * executions
+    );
+    assert_eq!(metrics.deletion_vector_failures, 0);
+    assert_eq!(metrics.deletion_vector_rejections, 0);
+    assert_eq!(
+        metrics.parquet_data_file_opened_bytes,
+        Some(fixture.data_file_size() * executions)
+    );
+    assert_eq!(metrics.parquet_data_file_full_get_operations, Some(0));
+    assert!(
+        metrics
+            .parquet_data_file_range_get_operations
+            .is_some_and(|value| value > 0)
+    );
+
+    let control = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_batch_size(1_024)
+            .with_target_partitions(TARGET_PARTITIONS)
+            .with_repartition_file_scans(false),
+    );
+    register_fixture(&control, "orders", &fixture, options)?;
+    let control_plan = control
+        .sql("SELECT id FROM orders ORDER BY id")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let control_display = displayable(control_plan.as_ref()).indent(true).to_string();
+    assert!(
+        control_display.contains("partitions=1"),
+        "{control_display}"
+    );
+    let control_metrics = collect_delta_datafusion_metrics(control_plan.as_ref());
+    assert_eq!(ids(&collect_plan(&control, control_plan).await?), expected);
+    let control_metrics = control_metrics[0].snapshot().reader;
+    assert_eq!(control_metrics.files_started, 1);
+    assert_eq!(control_metrics.deletion_vector_payloads_loaded, 1);
+    assert_eq!(
+        control_metrics.deletion_vector_rows_deleted,
+        u64::try_from(deleted_rows.len())?
+    );
+    assert_eq!(
+        control_metrics.parquet_data_file_full_get_operations,
+        Some(1)
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn repartitioned_scan_fails_closed_when_dv_payload_is_missing() -> TestResult {
+    const DV_FILE: &str = "deletion_vector_61d16c75-6994-46b7-a15b-8b538852e50e.bin";
+    let fixture = RealParquetDeltaTable::new_with_row_groups_and_deletion_vector(
+        "provider-repartitioned-missing-dv",
+        4,
+        2_048,
+        &[0, 2_047, 2_048, 8_191],
+    )?;
+    fs::remove_file(fixture.path().join(DV_FILE))?;
+    let context = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_target_partitions(8)
+            .with_repartition_file_min_size(1),
+    );
+    register_fixture(
+        &context,
+        "orders",
+        &fixture,
+        DeltaDataFusionScanOptions::default(),
+    )?;
+    let plan = context
+        .sql("SELECT id FROM orders")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let display = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(display.contains("partitions=8"), "{display}");
+    let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+
+    let error = datafusion::physical_plan::collect(plan, context.task_ctx())
+        .await
+        .expect_err("missing deletion-vector payload unexpectedly succeeded");
+    let display = error.to_string();
+    assert!(
+        display.contains("deletion_vector_payload_read_failed"),
+        "{display}"
+    );
+    assert!(!display.contains(DV_FILE), "{display}");
+    let metrics = metrics[0].snapshot().reader;
+    assert!(metrics.files_started > 0);
+    assert_eq!(metrics.files_completed, 0);
+    assert_eq!(metrics.batches_produced, 0);
+    assert_eq!(metrics.rows_produced, 0);
+    assert_eq!(metrics.deletion_vector_payloads_loaded, 0);
+    assert!(
+        (1..=metrics.files_started).contains(&metrics.deletion_vector_failures),
+        "unexpected failure count: {} for {} started tasks",
+        metrics.deletion_vector_failures,
+        metrics.files_started
+    );
+    assert_eq!(metrics.deletion_vectors_applied, 0);
+    assert_eq!(metrics.deletion_vector_rows_deleted, 0);
+    assert_eq!(metrics.deletion_vector_rejections, 0);
     Ok(())
 }
 

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -212,6 +212,59 @@ async fn collect_plan(
     Ok(datafusion::physical_plan::collect(plan, context.task_ctx()).await?)
 }
 
+#[tokio::test]
+async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> TestResult {
+    let fixture = TestTable::partitioned("optimizer-file-repartitioning")?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let context = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_target_partitions(4)
+            .with_repartition_file_min_size(1),
+    );
+    register_delta_table(
+        &context,
+        "orders",
+        table,
+        DeltaDataFusionScanOptions::default(),
+    )?;
+
+    let plan = context
+        .sql("SELECT count(*) AS row_count, sum(id) AS id_sum FROM orders")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let display = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        display.contains("DeltaDataFusionExec: snapshot_version=0, partitions=4"),
+        "{display}"
+    );
+
+    let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+    assert_eq!(metrics.len(), 1);
+    assert_eq!(metrics[0].snapshot().reader.scan_partitions_planned, 4);
+    let batches = collect_plan(&context, plan).await?;
+    let batch = batches.first().ok_or("aggregate returned no batch")?;
+    assert_eq!(
+        batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or("count was not Int64")?
+            .value(0),
+        4
+    );
+    assert_eq!(
+        batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or("sum was not Int64")?
+            .value(0),
+        10
+    );
+    Ok(())
+}
+
 fn register_fixture(
     context: &SessionContext,
     name: &str,

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -265,6 +265,92 @@ async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> T
     Ok(())
 }
 
+#[tokio::test]
+async fn repartitioned_scan_preserves_predicates_and_deletion_vector_coordinates() -> TestResult {
+    let fixture = RealParquetDeltaTable::new_with_two_row_groups_and_deletion_vector(
+        "provider-repartitioned-dv",
+        3_000,
+        &[0, 2_999, 3_000, 5_999],
+    )?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let context = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_target_partitions(8)
+            .with_repartition_file_min_size(1),
+    );
+    register_delta_table(
+        &context,
+        "orders",
+        table,
+        DeltaDataFusionScanOptions::default(),
+    )?;
+
+    let plan = context
+        .sql("SELECT id FROM orders WHERE id >= 2999 ORDER BY id")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let display = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(display.contains("partitions=8"), "{display}");
+
+    let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+    let actual = ids(&collect_plan(&context, plan).await?);
+    let expected = (2_999..=6_000)
+        .filter(|id| ![3_000, 3_001, 6_000].contains(id))
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+    let metrics = metrics[0].snapshot().reader;
+    assert_eq!(metrics.scan_partitions_started, 8);
+    assert_eq!(metrics.files_started, 8);
+    assert_eq!(metrics.deletion_vector_payloads_loaded, 1);
+    assert_eq!(metrics.deletion_vectors_applied, 2);
+    assert_eq!(metrics.deletion_vector_rows_deleted, 3);
+    assert_eq!(metrics.deletion_vector_failures, 0);
+    assert_eq!(metrics.deletion_vector_rejections, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn repartitioned_scan_preserves_physical_to_logical_transforms() -> TestResult {
+    let fixture = RealParquetDeltaTable::new_with_column_mapping("provider-repartitioned-mapping")?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let context = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_target_partitions(2)
+            .with_repartition_file_min_size(1),
+    );
+    register_delta_table(
+        &context,
+        "mapped",
+        table,
+        DeltaDataFusionScanOptions::default(),
+    )?;
+
+    let plan = context
+        .sql("SELECT customer_name, id FROM mapped WHERE id >= 2 ORDER BY id")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let display = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(display.contains("partitions=2"), "{display}");
+    let batches = collect_plan(&context, plan).await?;
+
+    assert_eq!(ids(&batches), [2, 3]);
+    let names = batches
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringViewArray>()
+                .expect("customer_name was not Utf8View")
+                .iter()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(names, [Some("bob"), None]);
+    Ok(())
+}
+
 fn register_fixture(
     context: &SessionContext,
     name: &str,

--- a/tests/support/real_parquet_delta_table.rs
+++ b/tests/support/real_parquet_delta_table.rs
@@ -143,20 +143,38 @@ impl RealParquetDeltaTable {
         rows_per_group: usize,
         deleted_rows: &[u64],
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        if rows_per_group == 0 {
-            return Err("row count must be positive".into());
+        Self::new_with_row_groups_and_deletion_vector(name, 2, rows_per_group, deleted_rows)
+    }
+
+    /// Creates a local Delta table whose single DV-backed Parquet file has the
+    /// requested number of equal-sized row groups.
+    pub(crate) fn new_with_row_groups_and_deletion_vector(
+        name: &str,
+        row_groups: usize,
+        rows_per_group: usize,
+        deleted_rows: &[u64],
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        if row_groups == 0 || rows_per_group == 0 {
+            return Err("row-group and row counts must be positive".into());
         }
-        let rows = rows_per_group.saturating_mul(2);
+        let rows = row_groups
+            .checked_mul(rows_per_group)
+            .ok_or("row count overflow")?;
+        let mut batches = Vec::with_capacity(row_groups);
+        for row_group in 0..row_groups {
+            let first_id = row_group
+                .checked_mul(rows_per_group)
+                .and_then(|value| value.checked_add(1))
+                .ok_or("row index overflow")?;
+            batches.push(sequential_batch_starting_at(first_id, rows_per_group)?);
+        }
 
         Self::new_with_protocol_file_batches(
             name,
             DELETION_VECTOR_PROTOCOL_JSON,
             vec![RealParquetDataFile {
                 path: DATA_FILE.to_owned(),
-                batches: vec![
-                    sequential_batch_starting_at(1, rows_per_group)?,
-                    sequential_batch_starting_at(rows_per_group.saturating_add(1), rows_per_group)?,
-                ],
+                batches,
                 stats: AddStats {
                     rows,
                     max_id: i32::try_from(rows)?,
@@ -2343,7 +2361,8 @@ fn sequential_batch_starting_at(
 
     let first_id = i32::try_from(first_id)?;
     let row_count = i32::try_from(rows)?;
-    let ids = (first_id..first_id + row_count).collect::<Vec<_>>();
+    let end_id = first_id.checked_add(row_count).ok_or("row id overflow")?;
+    let ids = (first_id..end_id).collect::<Vec<_>>();
     let names = (1..=row_count)
         .map(|offset| {
             let id = first_id.saturating_add(offset).saturating_sub(1);


### PR DESCRIPTION
## Summary

- let DataFusion split large Parquet files into independent byte-range scan tasks when whole-file planning cannot reach the resolved partition target
- preserve Delta predicates, partition values, physical-to-logical transforms, deletion vectors, metrics, and existing scan ranges across repartitioning
- keep already-full whole-file plans unchanged to avoid extra object-store requests and ordinary-scan overhead
- share Parquet footer metadata once per file and physical plan, with safe retry after failure or cancellation
- share deletion-vector payloads only while active readers need them, then release the large row-index buffer
- reject malformed Parquet ranges and row-group offsets with redacted reader errors
- add adversarial and end-to-end coverage, including a 32-row-group deletion-vector file split across 64 tasks

## Why

A single large Parquet file previously remained one scan task, limiting parallelism even when DataFusion planned more execution partitions. Applying intra-file repartitioning eagerly to scans that already had enough whole-file partitions then added avoidable range requests and ordinary-scan overhead.

This change delegates byte balancing to DataFusion's existing `FileGroupPartitioner`, retains Delta-specific metadata in each file extension, and only fills missing parallelism. Plan-scoped single-flight footer metadata avoids duplicate setup reads for split ranges. A weak deletion-vector cache shares active payloads without extending the lifetime of their large row-index buffers.

## Impact

Large skewed files can use row-group parallelism, including files with deletion vectors. Existing balanced multi-file scans retain their whole-file request pattern. Full but already-target-sized skewed plans are intentionally left for a future explicit policy.

## Validation

- all 8 supported feature configurations on Rust 1.88
- `cargo +1.88.0 clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo +1.88.0 doc --locked --all-features --no-deps`
- `cargo +1.88.0 package --locked --allow-dirty`
- all-features suite: 289 unit tests, 22 DataFusion integration tests, and all direct, portable-fixture, public-API, harness, and doctests
- adversarial metadata single-flight, failure, cancellation, malformed-range, and missing-DV tests
- HIP/schedule, 3 GB StackExchange, and deletion-vector regression benchmarks
- formatting and diff checks
