### PR TITLE
chore: enforce strict Rust quality checks

### DIFF
--- a/.github/path-filters.json
+++ b/.github/path-filters.json
@@ -5,6 +5,7 @@
     ".github/workflows/ci.yml",
     "Cargo.toml",
     "Cargo.lock",
+    "clippy.toml",
     "src/**",
     "tests/**",
     "benches/**"

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -31,9 +31,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - name: Read Rust version
+        id: rust-version
+        run: |
+          version="$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ steps.rust-version.outputs.version }}
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - name: Read Rust version
+        id: rust-version
+        run: |
+          version="$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ steps.rust-version.outputs.version }}
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
@@ -85,9 +91,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - name: Read Rust version
+        id: rust-version
+        run: |
+          version="$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ steps.rust-version.outputs.version }}
           components: clippy, rustfmt
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,14 @@ datafusion = ["dep:datafusion"]
 [package.metadata.docs.rs]
 all-features = true
 
+[lints.rust]
+missing_docs = "deny"
+
+[lints.clippy]
+expect_used = "deny"
+panic = "deny"
+unwrap_used = "deny"
+
 [dependencies]
 async-trait = "0.1"
 arrow = "58.3.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-expect-in-tests = true
+allow-unwrap-in-tests = true

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -1037,6 +1037,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::expect_used)]
     fn ids(batches: &[RecordBatch]) -> Vec<i32> {
         batches
             .iter()

--- a/src/deletion_vector.rs
+++ b/src/deletion_vector.rs
@@ -7,7 +7,7 @@ use arrow::{
     compute::filter_record_batch,
     record_batch::RecordBatch,
 };
-use snafu::ResultExt;
+use snafu::{IntoError, ResultExt};
 
 use crate::{
     DeltaReadMetrics, DeltaReaderError,
@@ -445,10 +445,7 @@ fn dependency_error(
     reason: &'static str,
     source: impl std::error::Error + Send + Sync + 'static,
 ) -> DeltaReaderError {
-    Err::<(), _>(source)
-        .boxed()
-        .context(DeletionVectorReadSnafu { reason })
-        .expect_err("constructed deletion-vector error")
+    DeletionVectorReadSnafu { reason }.into_error(Box::new(source))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(test, allow(clippy::panic))]
 
 mod config;
 #[cfg(feature = "datafusion")]

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -23,7 +23,7 @@ use parquet::arrow::{
 };
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::{SchemaDescriptor, TypePtr};
-use snafu::ResultExt;
+use snafu::{IntoError, ResultExt};
 use tokio::sync::OnceCell;
 
 const ORIGINAL_ROW_INDEX_COLUMN: &str = "__delta_arrow_reader_original_row_index";
@@ -1421,10 +1421,7 @@ fn data_file_error(
     reason: &'static str,
     source: impl std::error::Error + Send + Sync + 'static,
 ) -> DeltaReaderError {
-    Err::<(), _>(source)
-        .boxed()
-        .context(DataFileReadSnafu { reason })
-        .expect_err("constructed data-file error")
+    DataFileReadSnafu { reason }.into_error(Box::new(source))
 }
 
 #[cfg(test)]

--- a/src/official_kernel_reader.rs
+++ b/src/official_kernel_reader.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use arrow::record_batch::RecordBatch;
 use delta_kernel::{FileMeta, engine::arrow_data::EngineDataArrowExt};
 use futures_util::stream;
-use snafu::ResultExt;
+use snafu::{IntoError, ResultExt};
 use tokio::{sync::mpsc, task::JoinHandle};
 
 use crate::{
@@ -203,10 +203,7 @@ fn data_file_error(
     reason: &'static str,
     source: impl std::error::Error + Send + Sync + 'static,
 ) -> DeltaReaderError {
-    Err::<(), _>(source)
-        .boxed()
-        .context(DataFileReadSnafu { reason })
-        .expect_err("constructed data-file error")
+    DataFileReadSnafu { reason }.into_error(Box::new(source))
 }
 
 #[cfg(test)]

--- a/tests/benchmark_harness.rs
+++ b/tests/benchmark_harness.rs
@@ -1,3 +1,5 @@
+//! Test target for the frozen reader benchmark harness.
+
 #![cfg(all(
     feature = "datafusion",
     feature = "native-async",

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -1,4 +1,7 @@
+//! Integration tests for the DataFusion table provider.
+
 #![cfg(all(feature = "datafusion", feature = "native-async"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 #[allow(dead_code)]
 mod support;

--- a/tests/direct_reader.rs
+++ b/tests/direct_reader.rs
@@ -1,4 +1,7 @@
+//! Integration tests for direct reader backends.
+
 #![cfg(any(feature = "native-async", feature = "official-kernel"))]
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
 use std::{
     error::Error,

--- a/tests/portable_fixtures.rs
+++ b/tests/portable_fixtures.rs
@@ -1,3 +1,5 @@
+//! Portable fixture coverage across reader backends.
+
 mod support;
 
 use std::{error::Error, path::Path};

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,3 +1,5 @@
+//! Compile-time and behavioral coverage for the public reader API.
+
 use std::{error::Error as _, future::Future};
 
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};


### PR DESCRIPTION
## Summary

- enforce missing public documentation and deny production unwrap, expect, and panic usage
- use Snafu's native `IntoError` construction in the affected production helpers
- keep test assertions explicitly scoped while preserving strict production lints
- route `clippy.toml` changes through the CI path filter
- derive the CI and cache-warmer Rust version from `Cargo.toml`

## Why

Delta Arrow Reader already ran all-target/all-feature Clippy, but did not enforce the same lint policy as Delta Funnel. The Rust toolchain version was also duplicated across workflows.

## Impact

Production Rust code now follows Delta Funnel's strict quality policy. PR checks remain cache-read-only, the main-branch warmer remains the only cache writer, and the existing feature-test matrix is unchanged.

## Validation

- Rust 1.88 formatting check
- Rust 1.88 Clippy with all targets, all features, and denied warnings
- all eight supported feature combinations
- rustdoc with denied warnings
- cargo package
- workflow YAML, path-filter JSON, and diff checks
