### PR TITLE
docs: explain intra-file repartitioning flow

### DIFF
--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -1,4 +1,20 @@
 //! Optional DataFusion physical execution adapter.
+//!
+//! # Intra-file repartitioning
+//!
+//! Scan planning first balances whole Delta data files across the resolved
+//! partition target. If those groups do not fill the target, DataFusion's
+//! `FileGroupPartitioner` flattens them, divides their total bytes across the
+//! target, and returns new groups containing whole files or byte ranges. Its
+//! `repartition_file_min_size` setting is the minimum total input size needed
+//! to attempt this operation, not the size of each generated range.
+//!
+//! Each returned range is stored on its `DeltaScanFileTask`. During
+//! NativeAsync execution, the range containing a Parquet row group's first
+//! column chunk's page offset owns that complete row group. Range ownership and
+//! footer-statistics pruning are intersected before the selected row groups
+//! are passed to the Parquet reader, so a byte boundary never splits a row
+//! group.
 
 use std::{
     collections::HashSet,
@@ -368,9 +384,15 @@ fn scan_properties(schema: &SchemaRef, partition_count: usize) -> Arc<PlanProper
     )
 }
 
-/// Attempts to split file tasks into additional DataFusion execution partitions.
+/// Uses DataFusion to split and regroup file tasks across a partition target.
 ///
-/// `Ok(None)` preserves the existing plan when splitting is unnecessary or unsafe.
+/// DataFusion flattens the current groups and aims for
+/// `ceil(total_input_bytes / target_partitions)` bytes per output group. The
+/// `minimum_total_bytes` argument controls whether the complete input is large
+/// enough to repartition; it is not a generated range size.
+///
+/// `Ok(None)` preserves the existing plan when it already fills the target,
+/// file sizes are unavailable, or DataFusion finds no useful repartitioning.
 fn repartition_file_tasks(
     partitions: &[DeltaScanFileTaskPartition],
     target_partitions: usize,

--- a/src/native_async_reader.rs
+++ b/src/native_async_reader.rs
@@ -326,6 +326,8 @@ impl NativeAsyncFileReader {
             reason: "parquet_row_group_range_invalid",
         })?;
         let builder = match row_groups {
+            // This is where approximate byte ranges become complete Parquet
+            // row-group reads; the reader never slices through a row group.
             Some(row_groups) => builder.with_row_groups(row_groups),
             None => builder,
         };

--- a/src/native_async_row_group_pruning.rs
+++ b/src/native_async_row_group_pruning.rs
@@ -30,6 +30,14 @@ use crate::kernel::DeltaKernelPredicate;
 
 /// Computes the row groups selected by a byte range and footer statistics.
 ///
+/// A row group belongs to the half-open byte range containing its first column
+/// chunk's dictionary-page offset, or its data-page offset when no dictionary
+/// page exists. A row group can therefore belong to at most one non-overlapping
+/// range, and covering ranges assign every row group exactly once rather than
+/// splitting rows at an arbitrary byte boundary. When a predicate is present,
+/// the result is the intersection of range ownership and conservative
+/// footer-statistics pruning.
+///
 /// `None` means there is no byte range or physical predicate to use for pruning.
 /// `Some(Vec::new())` means every row group was proven impossible and the
 /// parquet reader should return no rows.


### PR DESCRIPTION
## Summary

- document how whole-file planning feeds DataFusion file-group repartitioning
- clarify that the minimum-size setting is an eligibility threshold, not a range size
- explain how byte ranges become complete Parquet row-group reads
- document the intersection of range ownership and predicate pruning

## Impact

Maintainers can follow the complete repartitioning path without reconstructing its invariants across three modules. Runtime behavior is unchanged.

## Validation

- private-item Rustdoc with warnings denied
- focused native row-group pruning tests
- formatting and diff checks