### PR TITLE
feat: add configurable file repartitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ let scan_options = DeltaDataFusionScanOptions {
 # }
 ```
 
+Whole-file planning normally avoids extra ranged reads once it fills the scan
+partition target. For skewed NativeAsync scans, opt in to DataFusion
+rebalancing with `DeltaFileRepartitioning::Rebalance`.
+DataFusion's `repartition_file_scans` and `repartition_file_min_size` settings
+still control whether repartitioning runs.
+
 ## Features
 
 | Feature | Default | Purpose |

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -1327,6 +1327,7 @@ async fn run_once(
         DeltaDataFusionScanOptions {
             execution_options,
             target_partitions: Some(target_partitions),
+            intra_file_repartitioning: Default::default(),
             use_view_types: true,
         },
     )?;

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -84,7 +84,7 @@ pub enum DeltaFileRepartitioning {
 }
 
 impl DeltaFileRepartitioning {
-    fn applies_to(self, current_partitions: usize, target_partitions: usize) -> bool {
+    fn allows_repartitioning(self, current_partitions: usize, target_partitions: usize) -> bool {
         match self {
             Self::FillMissingParallelism => current_partitions < target_partitions,
             Self::Rebalance => true,
@@ -435,7 +435,7 @@ fn repartition_file_tasks(
     }
     // Whole-file planning already balances up to the requested partition count.
     // The default avoids extra ranged reads unless the scan lacks parallelism.
-    if !policy.applies_to(partitions.len(), target_partitions) {
+    if !policy.allows_repartitioning(partitions.len(), target_partitions) {
         return Ok(None);
     }
 
@@ -1251,9 +1251,9 @@ mod tests {
                 .any(|task| task.parquet_byte_range.is_some())
         );
         assert!(
-            repartition_file_tasks(&input, 4, 1_031, DeltaFileRepartitioning::Rebalance,)?
-                .is_none()
+            repartition_file_tasks(&input, 4, 1_031, DeltaFileRepartitioning::Rebalance)?.is_none()
         );
+        assert!(repartition_file_tasks(&[], 4, 1, DeltaFileRepartitioning::Rebalance)?.is_none());
         assert!(
             input
                 .iter()
@@ -1271,7 +1271,7 @@ mod tests {
         )])?];
 
         assert!(
-            repartition_file_tasks(&input, 4, 121, DeltaFileRepartitioning::default(),)?.is_none()
+            repartition_file_tasks(&input, 4, 121, DeltaFileRepartitioning::default())?.is_none()
         );
         assert!(
             repartition_file_tasks(
@@ -1297,7 +1297,7 @@ mod tests {
             )?
             .is_none()
         );
-        assert!(repartition_file_tasks(&input, 0, 1, DeltaFileRepartitioning::default(),).is_err());
+        assert!(repartition_file_tasks(&input, 0, 1, DeltaFileRepartitioning::default()).is_err());
 
         for range in [90..110, std::ops::Range { start: 90, end: 80 }, 90..90] {
             let mut invalid = sized_file_task("invalid.parquet", Some(100));

--- a/src/datafusion_execution.rs
+++ b/src/datafusion_execution.rs
@@ -3,9 +3,11 @@
 //! # Intra-file repartitioning
 //!
 //! Scan planning first balances whole Delta data files across the resolved
-//! partition target. If those groups do not fill the target, DataFusion's
-//! `FileGroupPartitioner` flattens them, divides their total bytes across the
-//! target, and returns new groups containing whole files or byte ranges. Its
+//! partition target. By default, DataFusion's `FileGroupPartitioner` only
+//! receives those groups when they do not fill the target. The provider can
+//! instead opt in to rebalancing a full plan. In either mode, the partitioner
+//! flattens the groups, divides their total bytes across the target, and
+//! returns new groups containing whole files or byte ranges. Its
 //! `repartition_file_min_size` setting is the minimum total input size needed
 //! to attempt this operation, not the size of each generated range.
 //!
@@ -69,6 +71,26 @@ use crate::{
     planning::{DeltaScanFileTask, DeltaScanFileTaskPartition, DeltaScanPlan, build_partition},
     scheduling::{DeltaScanExecution, FileAdmission, FileAdmissionFn, ScanReadLimiter},
 };
+
+/// Controls when DataFusion may split NativeAsync Parquet files into ranged scan tasks.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DeltaFileRepartitioning {
+    /// Split files only when whole-file planning produced fewer partitions than the target.
+    #[default]
+    FillMissingParallelism,
+    /// Let DataFusion rebalance file groups even when they already fill the target.
+    Rebalance,
+}
+
+impl DeltaFileRepartitioning {
+    fn applies_to(self, current_partitions: usize, target_partitions: usize) -> bool {
+        match self {
+            Self::FillMissingParallelism => current_partitions < target_partitions,
+            Self::Rebalance => true,
+        }
+    }
+}
 
 /// Immutable point-in-time DataFusion scan metrics.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -282,6 +304,7 @@ pub(crate) fn create_datafusion_execution_plan(
     row_predicate: Option<DeltaKernelPredicate>,
     source_name: Option<String>,
     use_view_types: bool,
+    intra_file_repartitioning: DeltaFileRepartitioning,
 ) -> Arc<dyn ExecutionPlan> {
     Arc::new(DeltaDataFusionExec::new(
         plan,
@@ -289,6 +312,7 @@ pub(crate) fn create_datafusion_execution_plan(
         row_predicate,
         source_name,
         use_view_types,
+        intra_file_repartitioning,
     ))
 }
 
@@ -302,6 +326,8 @@ struct DeltaDataFusionExec {
     metrics: DeltaDataFusionMetrics,
     limiter: Arc<ScanReadLimiter>,
     dynamic_filters: Arc<[DeltaRetainedDynamicFilter]>,
+    intra_file_repartitioning: DeltaFileRepartitioning,
+    intra_file_repartitioning_applied: bool,
     #[cfg(feature = "native-async")]
     parquet_metadata_cache: Option<Arc<NativeAsyncParquetMetadataCache>>,
 }
@@ -314,6 +340,7 @@ impl DeltaDataFusionExec {
         row_predicate: Option<DeltaKernelPredicate>,
         source_name: Option<String>,
         use_view_types: bool,
+        intra_file_repartitioning: DeltaFileRepartitioning,
     ) -> Self {
         let schema = planning.projection.output_schema;
         let output_projection = planning.projection.output_projection.map(Arc::from);
@@ -335,6 +362,8 @@ impl DeltaDataFusionExec {
             metrics,
             limiter,
             dynamic_filters: Arc::from([]),
+            intra_file_repartitioning,
+            intra_file_repartitioning_applied: false,
             #[cfg(feature = "native-async")]
             parquet_metadata_cache: None,
         }
@@ -365,6 +394,7 @@ impl DeltaDataFusionExec {
             plan: Arc::new(plan),
             properties: scan_properties(&self.schema, partition_count),
             limiter,
+            intra_file_repartitioning_applied: true,
             #[cfg(feature = "native-async")]
             parquet_metadata_cache: Some(Arc::new(NativeAsyncParquetMetadataCache::default())),
             ..self.clone()
@@ -391,20 +421,21 @@ fn scan_properties(schema: &SchemaRef, partition_count: usize) -> Arc<PlanProper
 /// `minimum_total_bytes` argument controls whether the complete input is large
 /// enough to repartition; it is not a generated range size.
 ///
-/// `Ok(None)` preserves the existing plan when it already fills the target,
-/// file sizes are unavailable, or DataFusion finds no useful repartitioning.
+/// `Ok(None)` preserves the existing plan when the selected policy does not
+/// apply, file sizes are unavailable, or DataFusion finds no useful
+/// repartitioning.
 fn repartition_file_tasks(
     partitions: &[DeltaScanFileTaskPartition],
     target_partitions: usize,
     minimum_total_bytes: usize,
+    policy: DeltaFileRepartitioning,
 ) -> DataFusionResult<Option<Vec<DeltaScanFileTaskPartition>>> {
     if target_partitions == 0 {
         return Err(adapter_error("scan_partition_target_must_be_positive"));
     }
     // Whole-file planning already balances up to the requested partition count.
-    // Intra-file splitting fills missing parallelism; rebalancing a full plan
-    // requires a separate, evidence-backed skew policy.
-    if partitions.len() >= target_partitions {
+    // The default avoids extra ranged reads unless the scan lacks parallelism.
+    if !policy.applies_to(partitions.len(), target_partitions) {
         return Ok(None);
     }
 
@@ -563,7 +594,9 @@ impl ExecutionPlan for DeltaDataFusionExec {
         _datafusion_target_partitions: usize,
         config: &ConfigOptions,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
-        if self.plan.execution_options.reader_backend() != DeltaReaderBackend::NativeAsync {
+        if self.intra_file_repartitioning_applied
+            || self.plan.execution_options.reader_backend() != DeltaReaderBackend::NativeAsync
+        {
             return Ok(None);
         }
         // Scan planning already applied the provider override and resource caps.
@@ -572,6 +605,7 @@ impl ExecutionPlan for DeltaDataFusionExec {
             &self.plan.partitions,
             target_partitions,
             config.optimizer.repartition_file_min_size,
+            self.intra_file_repartitioning,
         )?
         else {
             return Ok(None);
@@ -978,6 +1012,26 @@ mod tests {
         execution_options: DeltaReaderExecutionOptions,
         source_name: Option<String>,
     ) -> Result<Arc<dyn ExecutionPlan>, DeltaReaderError> {
+        build_plan_with_repartitioning(
+            table,
+            projection,
+            filters,
+            target_partitions,
+            execution_options,
+            source_name,
+            DeltaFileRepartitioning::default(),
+        )
+    }
+
+    fn build_plan_with_repartitioning(
+        table: &DeltaTable,
+        projection: Option<&[usize]>,
+        filters: &[datafusion::logical_expr::Expr],
+        target_partitions: usize,
+        execution_options: DeltaReaderExecutionOptions,
+        source_name: Option<String>,
+        intra_file_repartitioning: DeltaFileRepartitioning,
+    ) -> Result<Arc<dyn ExecutionPlan>, DeltaReaderError> {
         let partition_columns = table
             .partition_columns()
             .iter()
@@ -1034,6 +1088,7 @@ mod tests {
             row_predicate,
             source_name,
             true,
+            intra_file_repartitioning,
         ))
     }
 
@@ -1083,7 +1138,8 @@ mod tests {
             sized_file_task("large.parquet", Some(100)),
             sized_file_task("small.parquet", Some(20)),
         ])?];
-        let partitions = repartition_file_tasks(&input, 4, 1)?.ok_or("not repartitioned")?;
+        let partitions = repartition_file_tasks(&input, 4, 1, DeltaFileRepartitioning::default())?
+            .ok_or("not repartitioned")?;
 
         assert_eq!(
             partitions
@@ -1135,8 +1191,13 @@ mod tests {
         let mut task = sized_file_task("partial.parquet", Some(100));
         task.parquet_byte_range = Some(20..80);
         task.estimated_rows = None;
-        let partitions = repartition_file_tasks(&[build_partition(vec![task])?], 3, 1)?
-            .ok_or("partial range was not repartitioned")?;
+        let partitions = repartition_file_tasks(
+            &[build_partition(vec![task])?],
+            3,
+            1,
+            DeltaFileRepartitioning::default(),
+        )?
+        .ok_or("partial range was not repartitioned")?;
 
         assert_eq!(
             partitions
@@ -1157,7 +1218,7 @@ mod tests {
     }
 
     #[test]
-    fn file_repartitioning_does_not_rebalance_a_full_whole_file_plan() -> TestResult {
+    fn file_repartitioning_policy_controls_full_whole_file_plans() -> TestResult {
         let input = vec![
             build_partition(vec![sized_file_task("huge.parquet", Some(1_000))])?,
             build_partition(vec![sized_file_task("small-0.parquet", Some(10))])?,
@@ -1165,7 +1226,34 @@ mod tests {
             build_partition(vec![sized_file_task("small-2.parquet", Some(10))])?,
         ];
 
-        assert!(repartition_file_tasks(&input, 4, 1)?.is_none());
+        assert!(
+            repartition_file_tasks(
+                &input,
+                4,
+                1,
+                DeltaFileRepartitioning::FillMissingParallelism,
+            )?
+            .is_none()
+        );
+        let rebalanced = repartition_file_tasks(&input, 4, 1, DeltaFileRepartitioning::Rebalance)?
+            .ok_or("full plan was not rebalanced")?;
+        assert_eq!(
+            rebalanced
+                .iter()
+                .map(|partition| partition.estimated_bytes)
+                .collect::<Vec<_>>(),
+            [Some(258), Some(258), Some(258), Some(256)]
+        );
+        assert!(
+            rebalanced
+                .iter()
+                .flat_map(|partition| &partition.file_tasks)
+                .any(|task| task.parquet_byte_range.is_some())
+        );
+        assert!(
+            repartition_file_tasks(&input, 4, 1_031, DeltaFileRepartitioning::Rebalance,)?
+                .is_none()
+        );
         assert!(
             input
                 .iter()
@@ -1182,7 +1270,9 @@ mod tests {
             Some(120),
         )])?];
 
-        assert!(repartition_file_tasks(&input, 4, 121)?.is_none());
+        assert!(
+            repartition_file_tasks(&input, 4, 121, DeltaFileRepartitioning::default(),)?.is_none()
+        );
         assert!(
             repartition_file_tasks(
                 &[build_partition(vec![sized_file_task(
@@ -1190,7 +1280,8 @@ mod tests {
                     None,
                 )])?],
                 4,
-                1
+                1,
+                DeltaFileRepartitioning::default(),
             )?
             .is_none()
         );
@@ -1201,16 +1292,25 @@ mod tests {
                     Some(0),
                 )])?],
                 4,
-                1
+                1,
+                DeltaFileRepartitioning::default(),
             )?
             .is_none()
         );
-        assert!(repartition_file_tasks(&input, 0, 1).is_err());
+        assert!(repartition_file_tasks(&input, 0, 1, DeltaFileRepartitioning::default(),).is_err());
 
         for range in [90..110, std::ops::Range { start: 90, end: 80 }, 90..90] {
             let mut invalid = sized_file_task("invalid.parquet", Some(100));
             invalid.parquet_byte_range = Some(range);
-            assert!(repartition_file_tasks(&[build_partition(vec![invalid])?], 4, 1).is_err());
+            assert!(
+                repartition_file_tasks(
+                    &[build_partition(vec![invalid])?],
+                    4,
+                    1,
+                    DeltaFileRepartitioning::default(),
+                )
+                .is_err()
+            );
         }
 
         let oversized = u64::try_from(i64::MAX)? + 1;
@@ -1222,6 +1322,7 @@ mod tests {
                 )])?],
                 2,
                 1,
+                DeltaFileRepartitioning::default(),
             )
             .is_err()
         );
@@ -1264,13 +1365,14 @@ mod tests {
     {
         let fixture = TestTable::partitioned("file-repartitioning")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load()?;
-        let plan = build_plan(
+        let plan = build_plan_with_repartitioning(
             &table,
             None,
             &[],
             4,
             DeltaReaderExecutionOptions::new(),
             None,
+            DeltaFileRepartitioning::Rebalance,
         )?;
         let expected_bytes = collect_delta_datafusion_metrics(plan.as_ref())[0]
             .snapshot()
@@ -1281,6 +1383,7 @@ mod tests {
         let repartitioned = plan
             .repartitioned(4, &config)?
             .ok_or("native scan was not repartitioned")?;
+        assert!(repartitioned.repartitioned(4, &config)?.is_none());
 
         assert_eq!(
             repartitioned
@@ -1315,7 +1418,7 @@ mod tests {
 
         #[cfg(feature = "official-kernel")]
         {
-            let official = build_plan(
+            let official = build_plan_with_repartitioning(
                 &table,
                 None,
                 &[],
@@ -1323,6 +1426,7 @@ mod tests {
                 DeltaReaderExecutionOptions::new()
                     .with_reader_backend(DeltaReaderBackend::OfficialKernel)?,
                 None,
+                DeltaFileRepartitioning::Rebalance,
             )?;
             assert!(official.repartitioned(4, &config)?.is_none());
         }

--- a/src/datafusion_provider.rs
+++ b/src/datafusion_provider.rs
@@ -15,7 +15,7 @@ use datafusion::{
 
 use crate::{
     DeltaReaderBackend, DeltaReaderError, DeltaReaderExecutionOptions, DeltaTable,
-    datafusion_execution::create_datafusion_execution_plan,
+    datafusion_execution::{DeltaFileRepartitioning, create_datafusion_execution_plan},
     datafusion_planning::{
         DataFusionFilterCapabilities, plan_datafusion_filters, plan_datafusion_scan,
     },
@@ -35,6 +35,8 @@ pub struct DeltaDataFusionScanOptions {
     pub execution_options: DeltaReaderExecutionOptions,
     /// Optional explicit scan partition target.
     pub target_partitions: Option<usize>,
+    /// Controls when DataFusion may split NativeAsync Parquet files into ranged scan tasks.
+    pub intra_file_repartitioning: DeltaFileRepartitioning,
     /// Decode string and binary data-file columns into Arrow view arrays.
     pub use_view_types: bool,
 }
@@ -44,6 +46,7 @@ impl Default for DeltaDataFusionScanOptions {
         Self {
             execution_options: DeltaReaderExecutionOptions::default(),
             target_partitions: None,
+            intra_file_repartitioning: DeltaFileRepartitioning::default(),
             use_view_types: true,
         }
     }
@@ -223,6 +226,7 @@ impl DeltaTableProvider {
                 row_predicate,
                 self.source_name.clone(),
                 self.options.use_view_types,
+                self.options.intra_file_repartitioning,
             )
         };
         Ok((plan, partition_count))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@ pub use config::{
 };
 #[cfg(feature = "datafusion")]
 pub use datafusion_execution::{
-    DeltaDataFusionMetrics, DeltaDataFusionMetricsSnapshot, collect_delta_datafusion_metrics,
+    DeltaDataFusionMetrics, DeltaDataFusionMetricsSnapshot, DeltaFileRepartitioning,
+    collect_delta_datafusion_metrics,
 };
 #[cfg(feature = "datafusion")]
 pub use datafusion_provider::{

--- a/tests/datafusion_provider.rs
+++ b/tests/datafusion_provider.rs
@@ -32,8 +32,9 @@ use datafusion::{
 };
 use delta_arrow_reader::DeltaReaderBackend;
 use delta_arrow_reader::{
-    DeltaDataFusionScanOptions, DeltaReaderError, DeltaReaderExecutionOptions, DeltaReaderPhase,
-    DeltaTableBuilder, DeltaTableProvider, collect_delta_datafusion_metrics, register_delta_table,
+    DeltaDataFusionScanOptions, DeltaFileRepartitioning, DeltaReaderError,
+    DeltaReaderExecutionOptions, DeltaReaderPhase, DeltaTableBuilder, DeltaTableProvider,
+    collect_delta_datafusion_metrics, register_delta_table,
 };
 use futures_util::StreamExt;
 use parquet::{
@@ -62,8 +63,22 @@ impl TestTable {
         table.write_log(&[
             protocol(1),
             metadata(),
-            add("west.parquet", west, "west", 1, 2),
-            add("east.parquet", east, "east", 3, 4),
+            add("west.parquet", west, "west", 2, 1, 2),
+            add("east.parquet", east, "east", 2, 3, 4),
+        ])?;
+        Ok(table)
+    }
+
+    fn skewed(name: &str) -> TestResult<Self> {
+        let table = Self::new(name)?;
+        let large_ids = (1..=10_000).collect::<Vec<_>>();
+        let large = table.write_parquet("large.parquet", &large_ids)?;
+        let small = table.write_parquet("small.parquet", &[10_001, 10_002])?;
+        table.write_log(&[
+            protocol(1),
+            metadata(),
+            add("large.parquet", large, "west", 10_000, 1, 10_000),
+            add("small.parquet", small, "east", 2, 10_001, 10_002),
         ])?;
         Ok(table)
     }
@@ -149,9 +164,9 @@ fn metadata() -> Value {
     })
 }
 
-fn add(path: &str, size: u64, region: &str, min_id: i32, max_id: i32) -> Value {
+fn add(path: &str, size: u64, region: &str, num_records: u64, min_id: i32, max_id: i32) -> Value {
     let stats = json!({
-        "numRecords": 2,
+        "numRecords": num_records,
         "minValues": {"id": min_id},
         "maxValues": {"id": max_id},
         "nullCount": {"id": 0}
@@ -269,6 +284,68 @@ async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> T
             .value(0),
         10
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn intra_file_repartitioning_policy_controls_full_plan_rebalancing() -> TestResult {
+    let fixture = TestTable::skewed("optimizer-full-plan-rebalancing")?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+
+    for (name, policy, expected_tasks) in [
+        (
+            "default_orders",
+            DeltaFileRepartitioning::FillMissingParallelism,
+            2,
+        ),
+        ("rebalanced_orders", DeltaFileRepartitioning::Rebalance, 3),
+    ] {
+        let context = SessionContext::new_with_config(
+            SessionConfig::new()
+                .with_target_partitions(2)
+                .with_repartition_file_min_size(1),
+        );
+        register_delta_table(
+            &context,
+            name,
+            table.clone(),
+            DeltaDataFusionScanOptions {
+                target_partitions: Some(2),
+                intra_file_repartitioning: policy,
+                ..Default::default()
+            },
+        )?;
+        let plan = context
+            .sql(&format!(
+                "SELECT count(*) AS row_count, sum(id) AS id_sum FROM {name}"
+            ))
+            .await?
+            .create_physical_plan()
+            .await?;
+        let metrics = collect_delta_datafusion_metrics(plan.as_ref());
+        let batches = collect_plan(&context, plan).await?;
+        let batch = batches.first().ok_or("aggregate returned no batch")?;
+        assert_eq!(
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or("count was not Int64")?
+                .value(0),
+            10_002
+        );
+        assert_eq!(
+            batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or("sum was not Int64")?
+                .value(0),
+            50_025_003
+        );
+        assert_eq!(metrics[0].snapshot().reader.files_started, expected_tasks);
+    }
+
     Ok(())
 }
 
@@ -409,6 +486,7 @@ async fn large_repartitioned_dv_scan_matches_unsplit_under_concurrent_reexecutio
     let options = DeltaDataFusionScanOptions {
         execution_options,
         target_partitions: Some(TARGET_PARTITIONS),
+        intra_file_repartitioning: DeltaFileRepartitioning::Rebalance,
         ..Default::default()
     };
     let context = SessionContext::new_with_config(
@@ -629,6 +707,10 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
     );
     assert_eq!(defaults.target_partitions, None);
     assert!(defaults.use_view_types);
+    assert_eq!(
+        defaults.intra_file_repartitioning,
+        DeltaFileRepartitioning::FillMissingParallelism
+    );
 
     let provider = DeltaTableProvider::try_new(table.clone(), defaults)?;
     assert_eq!(table.schema().field(1).data_type(), &DataType::Utf8);
@@ -927,6 +1009,7 @@ async fn native_exact_and_official_residual_execution_return_the_same_rows() -> 
             DeltaDataFusionScanOptions {
                 execution_options,
                 target_partitions: Some(2),
+                intra_file_repartitioning: Default::default(),
                 use_view_types: true,
             },
         )?;
@@ -1243,6 +1326,7 @@ async fn execution_stream_drop_preserves_bounded_partial_metrics() -> TestResult
         DeltaDataFusionScanOptions {
             execution_options,
             target_partitions: Some(1),
+            intra_file_repartitioning: Default::default(),
             use_view_types: true,
         },
     )?;
@@ -1294,6 +1378,7 @@ async fn native_metadata_hint_preserves_rows_and_request_fallback() -> TestResul
             DeltaDataFusionScanOptions {
                 execution_options,
                 target_partitions: Some(1),
+                intra_file_repartitioning: Default::default(),
                 use_view_types: true,
             },
         )?;
@@ -1410,6 +1495,7 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
         DeltaDataFusionScanOptions {
             execution_options,
             target_partitions: Some(1),
+            intra_file_repartitioning: Default::default(),
             use_view_types: true,
         },
     )?;
@@ -1450,6 +1536,7 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
         DeltaDataFusionScanOptions {
             execution_options,
             target_partitions: Some(1),
+            intra_file_repartitioning: Default::default(),
             use_view_types: false,
         },
     )?;

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -317,8 +317,8 @@ fn datafusion_metrics_contract_is_public() {
 #[test]
 fn datafusion_provider_contract_is_public() {
     use delta_arrow_reader::{
-        DeltaDataFusionScanOptions, DeltaReaderError, DeltaTable, DeltaTableProvider,
-        RegisteredDeltaTable, register_delta_table,
+        DeltaDataFusionScanOptions, DeltaFileRepartitioning, DeltaReaderError, DeltaTable,
+        DeltaTableProvider, RegisteredDeltaTable, register_delta_table,
     };
 
     fn assert_clone<T: Clone>() {}
@@ -327,6 +327,11 @@ fn datafusion_provider_contract_is_public() {
 
     assert_debug_clone::<DeltaDataFusionScanOptions>();
     assert!(DeltaDataFusionScanOptions::default().use_view_types);
+    assert_result_traits::<DeltaFileRepartitioning>();
+    assert_eq!(
+        DeltaDataFusionScanOptions::default().intra_file_repartitioning,
+        DeltaFileRepartitioning::FillMissingParallelism
+    );
     assert_clone::<DeltaTableProvider>();
     assert_result_traits::<RegisteredDeltaTable>();
     let construct: fn(


### PR DESCRIPTION
## Summary

- add `DeltaFileRepartitioning` as a coherent DataFusion scan policy
- preserve the existing fill-missing-parallelism behavior by default
- allow skewed NativeAsync scans to opt into full file-group rebalancing
- prevent repeated repartitioning while preserving DataFusion disable and minimum-size controls
- document the execution behavior and cover public API, skew, deletion vectors, transforms, malformed inputs, and backend isolation

## Why

Whole-file planning avoids unnecessary ranged reads once it reaches the target partition count, but that can leave skewed file layouts imbalanced. This adds an explicit opt-in policy for rebalancing without changing existing users or introducing a separate threshold or planning layer.

## Validation

- complete Cargo feature test matrix
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `cargo package --locked --allow-dirty`
- `cargo fmt --all -- --check`
- `git diff --check`