### PR TITLE
docs: publish reader benchmark results

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,114 @@
+# Benchmarks
+
+We compared Delta Arrow Reader with delta-rs and DuckDB on four workloads. It
+was faster on the mixed-column projection and on both deletion-vector scans. On
+the large text projection, it was effectively tied with delta-rs. It was faster
+than DuckDB in all four tests.
+
+These results apply to the workloads and machine described below. They are not
+a general guarantee for every Delta table or query.
+
+## Results
+
+The table below shows how long each reader took to load the Delta snapshot and
+stream the full result. Process startup is not included. Each value is the
+median of six runs, after one warmup run.
+
+| Workload | Delta Arrow Reader | delta-rs | DuckDB |
+| --- | ---: | ---: | ---: |
+| Mixed-column projection | 0.801 s | 1.023 s | 10.467 s |
+| 3 GB text projection | 2.655 s | 2.620 s | 13.033 s |
+| Read one row from a table with deletion vectors | 0.0223 s | 0.0803 s | 0.2616 s |
+| Scan a full table with deletion vectors | 0.112 s | 0.811 s | 0.882 s |
+
+On the text projection, Delta Arrow Reader took 2.226-3.244 seconds and delta-rs
+took 2.264-2.839 seconds. Because those ranges overlap, we treat the 1.3%
+difference between their medians as a tie. On the other three workloads, even
+the slowest Delta Arrow Reader run was faster than the fastest run from either
+alternative.
+
+Speed is only part of the picture. The next table shows median CPU time and
+peak memory use:
+
+| Workload | Delta Arrow Reader | delta-rs | DuckDB |
+| --- | ---: | ---: | ---: |
+| Mixed-column projection | 6.610 s / 325 MiB | 6.028 s / 297 MiB | 8.763 s / 713 MiB |
+| 3 GB text projection | 14.663 s / 1,472 MiB | 11.318 s / 1,392 MiB | 30.357 s / 5,208 MiB |
+| Read one row from a table with deletion vectors | 0.0431 s / 66 MiB | 0.2933 s / 278 MiB | 0.7368 s / 309 MiB |
+| Scan a full table with deletion vectors | 0.967 s / 74 MiB | 1.867 s / 276 MiB | 1.246 s / 320 MiB |
+
+Each cell shows CPU time followed by peak memory. Delta Arrow Reader used more
+CPU and memory than delta-rs on the two projection workloads. On the
+deletion-vector workloads, it was faster and used less memory.
+
+## Workloads
+
+The mixed-column workload is based on a real application query. It reads 28
+string, numeric, boolean, and time columns from a 14.5-million-row table. It
+then reads 14 columns from a small reference table with two deletion vectors.
+The larger table contains 1,151 active Parquet files and 448 MB of compressed
+data.
+
+The original schema is private, so the published
+[query shapes](benchmarks/query_shapes.sql) use neutral table and column names.
+They preserve the number and types of projected columns without revealing the
+source data.
+
+The text workload reads six columns from the public version-4 RedPajama
+StackExchange Delta snapshot. It contains 64 Parquet files, 3.03 GB of
+compressed data, and 2,697,774 rows.
+
+Deletion vectors mark rows as deleted without rewriting their Parquet files.
+To test them, we generated a table with 200 files and 200 million physical
+rows. Each file has one deleted row. One query stops after the first available
+row. The other reads all 199,999,800 rows that remain. Together, these queries
+show both the startup cost of handling deletion vectors and the cost of applying
+them across a full scan.
+
+## Method
+
+All three readers used the same Delta snapshots stored in local MinIO. Each
+reader used 16-way parallelism and streamed Arrow batches of 8,192 rows without
+keeping the full result in memory.
+
+For each workload, we ran every reader once to warm up the system and discarded
+those results. We then ran six measured rounds, changing the order each time so
+that every reader appeared first, second, and third twice. The exact
+[run order](benchmarks/run_order.py) is checked in.
+
+Delta Arrow Reader and delta-rs ran in the same Rust program with DataFusion
+54.1.0 and Arrow/Parquet 58.4.0. DuckDB ran in a separate Python process because
+it uses its own query engine. Its time covers the full path from opening the
+Delta table to producing Arrow batches. Linux process accounting recorded wall
+time, CPU use, memory use, page faults, and context switches.
+
+All 72 measured processes completed successfully: four workloads, six rounds,
+and three readers. The row counts matched. Both deletion vectors in the
+reference table removed the same 43 rows, and the generated table removed the
+expected 200 rows.
+
+Each result also had the same logical columns and data types. The readers did
+not always represent those values in memory in exactly the same way. We allowed
+differences in string encoding, timestamp units, and where each reader split
+its Arrow batches because none of them changed the result.
+
+## Environment
+
+We ran the benchmark on August 26, 2026, using one machine with the following
+hardware and software:
+
+- AMD Ryzen 7 8845HS, with 8 cores and 16 threads
+- 27.95 GiB of memory
+- Crucial P3 Plus NVMe SSD
+- Fedora Linux 43 with Linux 6.19.14
+
+| Reader | Version tested |
+| --- | --- |
+| Delta Arrow Reader | 0.3.0 (`aaf6699`) |
+| delta-rs | `fd7e96910243f9e67b4eae994d52ef246cfcea38` |
+| DuckDB | 1.5.5, Delta extension `45c4087` |
+
+We kept all benchmark data in local MinIO so that public-network delays would
+not affect the results. Hardware and system load still affect absolute times,
+so we will rerun these comparisons when the readers or their execution settings
+change.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ batches. It provides a direct pull-driven stream API and an optional DataFusion
 table provider. The caller owns the Tokio runtime, and scans do not collect the
 whole result in memory.
 
+See [reader benchmarks](BENCHMARKS.md) for a comparison with delta-rs and
+DuckDB on projection and deletion-vector workloads.
+
 ## Installation
 
 The 0.2.0 package declaration is:

--- a/benchmarks/query_shapes.sql
+++ b/benchmarks/query_shapes.sql
@@ -1,0 +1,58 @@
+-- The mixed-column workload is schematic. These generic names preserve its
+-- projection width and data-type mix without publishing the private schema.
+SELECT
+    record_id,
+    group_id,
+    event_id,
+    source_name,
+    entity_id,
+    entity_number,
+    entity_role,
+    measure_x,
+    measure_y,
+    measure_z,
+    CAST(event_time AS TIMESTAMP) AS event_time,
+    event_year,
+    event_month,
+    event_day,
+    ingestion_year,
+    ingestion_month,
+    ingestion_day,
+    entity_processed_year,
+    entity_processed_month,
+    entity_processed_day,
+    record_processed_year,
+    record_processed_month,
+    record_processed_day,
+    resolution_note,
+    resolved_key,
+    verified_path,
+    tier,
+    category
+FROM representative_events;
+
+SELECT
+    reference_key,
+    entity_id,
+    entity_name,
+    parent_entity_id,
+    parent_entity_name,
+    status_code,
+    event_type,
+    description,
+    processed_year,
+    processed_month,
+    processed_day,
+    official_date,
+    event_date,
+    tier
+FROM representative_reference;
+
+-- The public and generated workloads use these exact projections after their
+-- Delta tables are registered under the aliases below.
+SELECT text, language, url, timestamp, source, question_score
+FROM stackexchange;
+
+SELECT id FROM deletion_vector_stress LIMIT 1;
+
+SELECT id FROM deletion_vector_stress;

--- a/benchmarks/run_order.py
+++ b/benchmarks/run_order.py
@@ -1,0 +1,26 @@
+"""Counterbalanced order used for each three-reader workload."""
+
+CANDIDATES = ("delta-arrow-reader", "delta-rs", "duckdb")
+RUN_ORDER = (
+    ("delta-arrow-reader", "delta-rs", "duckdb"),
+    ("delta-rs", "duckdb", "delta-arrow-reader"),
+    ("duckdb", "delta-arrow-reader", "delta-rs"),
+    ("duckdb", "delta-rs", "delta-arrow-reader"),
+    ("delta-rs", "delta-arrow-reader", "duckdb"),
+    ("delta-arrow-reader", "duckdb", "delta-rs"),
+)
+
+
+def validate() -> None:
+    assert all(set(run) == set(CANDIDATES) for run in RUN_ORDER)
+    for position in range(len(CANDIDATES)):
+        assert all(
+            sum(run[position] == candidate for run in RUN_ORDER) == 2
+            for candidate in CANDIDATES
+        )
+
+
+if __name__ == "__main__":
+    validate()
+    for run in RUN_ORDER:
+        print(" -> ".join(run))


### PR DESCRIPTION
## Summary

- publish the three-reader benchmark results and test environment
- document anonymized query shapes and the counterbalanced run order
- link the benchmark report from the main README

## Validation

- run-order self-check passes
- formatting and privacy checks pass