### PR TITLE
chore!: require Rust 1.94 and make release cache read-only

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,12 +9,8 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: sccache-write
-  queue: max
-
 env:
-  RELEASE_PLZ_RUST_VERSION: "1.91"
+  SCCACHE_GHA_RW_MODE: READ_ONLY
 
 jobs:
   release-pr:
@@ -27,7 +23,6 @@ jobs:
       !contains(github.event.head_commit.message, 'release-plz-')
     runs-on: ubuntu-latest
     env:
-      CARGO_PROFILE_DEV_DEBUG: "0"
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     permissions:
@@ -52,10 +47,16 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           persist-credentials: false
 
-      - name: Install release-plz Rust toolchain
+      - name: Read Rust version
+        id: rust-version
         run: |
-          rustup toolchain install "$RELEASE_PLZ_RUST_VERSION" --profile minimal
-          rustup default "$RELEASE_PLZ_RUST_VERSION"
+          version="$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust-version.outputs.version }}
 
       - name: Configure Cargo target
         run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/release-plz-target" >> "$GITHUB_ENV"
@@ -63,8 +64,9 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release-plz
+          shared-key: core-ci
           cache-targets: false
+          save-if: false
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -75,11 +77,6 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-      - name: Verify sccache writes
-        run: >-
-          sccache --show-stats --stats-format json |
-          python -c 'import json, sys; errors = json.load(sys.stdin)["stats"]["cache_write_errors"]; sys.exit(f"sccache reported {errors} cache write errors") if errors else None'
 
   release:
     name: Release-plz release
@@ -98,7 +95,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: crates-io-release
     env:
-      CARGO_PROFILE_DEV_DEBUG: "0"
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     permissions:
@@ -121,10 +117,16 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           persist-credentials: false
 
-      - name: Install release-plz Rust toolchain
+      - name: Read Rust version
+        id: rust-version
         run: |
-          rustup toolchain install "$RELEASE_PLZ_RUST_VERSION" --profile minimal
-          rustup default "$RELEASE_PLZ_RUST_VERSION"
+          version="$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust-version.outputs.version }}
 
       - name: Configure Cargo target
         run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/release-plz-target" >> "$GITHUB_ENV"
@@ -132,8 +134,9 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release-plz
+          shared-key: core-ci
           cache-targets: false
+          save-if: false
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -144,8 +147,3 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-      - name: Verify sccache writes
-        run: >-
-          sccache --show-stats --stats-format json |
-          python -c 'import json, sys; errors = json.load(sys.stdin)["stats"]["cache_write_errors"]; sys.exit(f"sccache reported {errors} cache write errors") if errors else None'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delta-arrow-reader"
 version = "0.3.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 description = "Read-only Delta Lake to Apache Arrow reader"
 license = "Apache-2.0"
 documentation = "https://docs.rs/delta-arrow-reader"


### PR DESCRIPTION
## Summary

- raise the crate MSRV from Rust 1.88 to 1.94 for the planned DataFusion 55 upgrade
- make Release-plz read the toolchain version from Cargo.toml
- make Release-plz restore the shared Cargo and sccache caches without writing them
- keep cache writes owned by the dedicated cache-warmer workflow

## Breaking change

The minimum supported Rust version is now 1.94.

## Validation

- cargo +1.94.0 test --locked --all-targets --all-features
- cargo +1.94.0 clippy --locked --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo +1.94.0 doc --locked --all-features --no-deps
- cargo +1.94.0 fmt --all -- --check
- cargo +1.94.0 package --locked --allow-dirty
- actionlint .github/workflows/release-plz.yml
- git diff --check