### PR TITLE
refactor!: make table loading explicit and async-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 ## Read a table directly
 
-Use `load_async` from asynchronous code. The returned stream exposes live scan
+Use `load_table` from asynchronous code. The returned stream exposes live scan
 metrics and yields batches as the caller requests them.
 
 ```rust,no_run
@@ -43,7 +43,7 @@ use futures_util::TryStreamExt;
 
 # async fn read_table() -> Result<(), Box<dyn std::error::Error>> {
 let table = DeltaTableBuilder::new("/tmp/example-delta-table")
-    .load_async()
+    .load_table()
     .await?;
 let scan = table
     .scan()
@@ -68,9 +68,6 @@ println!("files={}", metrics.snapshot().files_completed);
 # }
 ```
 
-`DeltaTableBuilder::load` is the blocking table-load alternative. Scan building
-and execution remain asynchronous.
-
 ## Register a DataFusion table
 
 The `datafusion` feature exposes `DeltaTableProvider`, `register_delta_table`,
@@ -87,7 +84,7 @@ use delta_arrow_reader::{
 
 let context = SessionContext::new();
 let table = DeltaTableBuilder::new("/tmp/example-delta-table")
-    .load_async()
+    .load_table()
     .await?;
 register_delta_table(
     &context,

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -1319,7 +1319,8 @@ async fn run_once(
     let table = DeltaTableBuilder::new(&fixture.table_uri)
         .with_storage_options(fixture.storage_options.clone())
         .with_execution_options(execution_options)
-        .load()?;
+        .load_table()
+        .await?;
     register_delta_table(
         &context,
         "orders",

--- a/docs-site/docs/datafusion.md
+++ b/docs-site/docs/datafusion.md
@@ -21,7 +21,7 @@ use delta_arrow_reader::{
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let context = SessionContext::new();
     let table = DeltaTableBuilder::new("/tmp/example-delta-table")
-        .load_async()
+        .load_table()
         .await?;
 
     register_delta_table(

--- a/docs-site/docs/direct-reader.md
+++ b/docs-site/docs/direct-reader.md
@@ -17,7 +17,7 @@ use futures_util::TryStreamExt;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let table = DeltaTableBuilder::new("/tmp/example-delta-table")
-        .load_async()
+        .load_table()
         .await?;
     let scan = table
         .scan()
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Loading the table and reading its rows happen at different times. `load_async`
+Loading the table and reading its rows happen at different times. `load_table`
 loads the Delta metadata, and `build` works out which files and columns the scan
 needs. The data files are not read until `execute` starts the batch stream.
 
@@ -79,9 +79,3 @@ println!("files={}", metrics.snapshot().files_completed);
 
 You can still inspect the handle after the stream finishes or is dropped. If
 you drop the stream early, the reader stops scheduling new files.
-
-## Blocking table loading
-
-If table initialization must happen in synchronous code, use
-`DeltaTableBuilder::load` instead of `load_async`. Building and running the scan
-still requires asynchronous code.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -55,8 +55,7 @@ use crate::{
         protocol::validate_protocol,
         snapshot::{
             LoadedDeltaTableSnapshot, StagedDeltaTableSnapshot, load_delta_table_snapshot_async,
-            load_delta_table_snapshot_blocking, load_staged_delta_table_snapshot_async,
-            load_staged_delta_table_snapshot_blocking,
+            load_staged_delta_table_snapshot_async,
         },
     },
     error::{DataFileReadSnafu, InvalidConfigurationSnafu, ScanPlanningSnafu},
@@ -77,7 +76,7 @@ const TRACING_TARGET: &str = "delta_arrow_reader";
 ///
 /// # async fn read_table() -> Result<(), Box<dyn std::error::Error>> {
 /// let table = DeltaTableBuilder::new("/tmp/example-delta-table")
-///     .load_async()
+///     .load_table()
 ///     .await?;
 /// let scan = table
 ///     .scan()
@@ -134,19 +133,8 @@ impl DeltaTableBuilder {
         self
     }
 
-    /// Loads the snapshot on the calling thread.
-    pub fn load(self) -> Result<DeltaTable, DeltaReaderError> {
-        validate_direct_execution_options(self.execution_options)?;
-        let snapshot = load_delta_table_snapshot_blocking(
-            &self.table_uri,
-            &self.storage_options,
-            self.snapshot_selection,
-        )?;
-        Ok(DeltaTable::new(snapshot, self.execution_options))
-    }
-
-    /// Loads the snapshot through the caller-owned Tokio runtime.
-    pub async fn load_async(self) -> Result<DeltaTable, DeltaReaderError> {
+    /// Loads a ready-to-scan table through the caller-owned Tokio runtime.
+    pub async fn load_table(self) -> Result<DeltaTable, DeltaReaderError> {
         validate_direct_execution_options(self.execution_options)?;
         let snapshot = load_delta_table_snapshot_async(
             self.table_uri,
@@ -157,19 +145,8 @@ impl DeltaTableBuilder {
         Ok(DeltaTable::new(snapshot, self.execution_options))
     }
 
-    /// Loads snapshot metadata without converting its logical Arrow schema.
-    pub fn load_snapshot(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
-        validate_direct_execution_options(self.execution_options)?;
-        let snapshot = load_staged_delta_table_snapshot_blocking(
-            &self.table_uri,
-            &self.storage_options,
-            self.snapshot_selection,
-        )?;
-        Ok(DeltaTableSnapshot::new(snapshot, self.execution_options))
-    }
-
-    /// Loads snapshot metadata through the caller-owned Tokio runtime.
-    pub async fn load_snapshot_async(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
+    /// Loads a Delta Kernel snapshot without converting its logical Arrow schema.
+    pub async fn load_snapshot(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
         validate_direct_execution_options(self.execution_options)?;
         let snapshot = load_staged_delta_table_snapshot_async(
             self.table_uri,

--- a/src/reader/datafusion.rs
+++ b/src/reader/datafusion.rs
@@ -72,8 +72,10 @@ impl Default for DeltaDataFusionScanOptions {
 ///     DeltaDataFusionScanOptions, DeltaTableBuilder, DeltaTableProvider,
 /// };
 ///
-/// # fn build_provider() -> Result<(), Box<dyn std::error::Error>> {
-/// let table = DeltaTableBuilder::new("/tmp/example-delta-table").load()?;
+/// # async fn build_provider() -> Result<(), Box<dyn std::error::Error>> {
+/// let table = DeltaTableBuilder::new("/tmp/example-delta-table")
+///     .load_table()
+///     .await?;
 /// let provider = DeltaTableProvider::try_new(
 ///     table,
 ///     DeltaDataFusionScanOptions::default(),
@@ -381,9 +383,11 @@ pub struct RegisteredDeltaTable {
 ///     DeltaDataFusionScanOptions, DeltaTableBuilder, register_delta_table,
 /// };
 ///
-/// # fn register() -> Result<(), Box<dyn std::error::Error>> {
+/// # async fn register() -> Result<(), Box<dyn std::error::Error>> {
 /// let context = SessionContext::new();
-/// let table = DeltaTableBuilder::new("/tmp/example-delta-table").load()?;
+/// let table = DeltaTableBuilder::new("/tmp/example-delta-table")
+///     .load_table()
+///     .await?;
 /// let registered = register_delta_table(
 ///     &context,
 ///     "orders",

--- a/src/reader/datafusion/execution.rs
+++ b/src/reader/datafusion/execution.rs
@@ -1370,7 +1370,7 @@ mod tests {
     async fn native_repartitioning_reads_each_row_once_and_preserves_byte_accounting() -> TestResult
     {
         let fixture = TestTable::partitioned("file-repartitioning")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let plan = build_plan_with_repartitioning(
             &table,
             None,
@@ -1467,7 +1467,7 @@ mod tests {
     async fn properties_projection_partitions_metrics_and_reexecution_match_provider_behavior()
     -> TestResult {
         let fixture = TestTable::partitioned("properties")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let logical_filter = col("id").gt(lit(1_i32));
         let plan = build_plan(
             &table,
@@ -1581,7 +1581,9 @@ mod tests {
         );
 
         let empty_fixture = TestTable::empty("empty-scan")?;
-        let empty_table = DeltaTableBuilder::new(empty_fixture.uri()).load()?;
+        let empty_table = DeltaTableBuilder::new(empty_fixture.uri())
+            .load_table()
+            .await?;
         let empty_plan = build_plan(
             &empty_table,
             None,
@@ -1622,7 +1624,7 @@ mod tests {
     #[cfg(feature = "native-async")]
     async fn dynamic_filter_hook_prunes_before_file_start_and_counts_once() -> TestResult {
         let fixture = TestTable::partitioned("dynamic")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let plan = build_plan(
             &table,
             None,
@@ -1681,7 +1683,7 @@ mod tests {
     #[cfg(feature = "native-async")]
     async fn physical_pushdown_preserves_dynamic_filters_across_plan_rebuild() -> TestResult {
         let fixture = TestTable::partitioned("dynamic-plan-rebuild")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let plan = build_plan(
             &table,
             None,
@@ -1723,7 +1725,7 @@ mod tests {
     #[cfg(feature = "native-async")]
     async fn late_dynamic_filter_keeps_admitted_file_and_prunes_the_next() -> TestResult {
         let fixture = TestTable::late_dynamic("late-dynamic")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let options = DeltaReaderExecutionOptions::new()
             .with_native_async_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
@@ -1762,11 +1764,11 @@ mod tests {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(feature = "native-async")]
-    fn hook_is_post_only_empty_safe_and_collector_is_ordered_and_distinct() -> TestResult {
+    async fn hook_is_post_only_empty_safe_and_collector_is_ordered_and_distinct() -> TestResult {
         let fixture = TestTable::partitioned("collector")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let first = build_plan(
             &table,
             None,
@@ -1853,9 +1855,9 @@ mod tests {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(feature = "native-async")]
-    fn dynamic_admission_reason_counts_are_once_per_file_and_saturating() -> TestResult {
+    async fn dynamic_admission_reason_counts_are_once_per_file_and_saturating() -> TestResult {
         use crate::{
             delta::kernel::KernelPhysicalToLogicalTransform,
             reader::datafusion::dynamic_filters::DeltaDynamicFilterPlan,
@@ -1863,7 +1865,7 @@ mod tests {
         };
 
         let fixture = TestTable::partitioned("dynamic-counters")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let plan = build_plan(
             &table,
             None,
@@ -1952,14 +1954,14 @@ mod tests {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(feature = "native-async")]
-    fn dynamic_metrics_updates_are_thread_safe() -> TestResult {
+    async fn dynamic_metrics_updates_are_thread_safe() -> TestResult {
         const THREADS: usize = 4;
         const ITERATIONS: usize = 100;
 
         let fixture = TestTable::partitioned("dynamic-metrics-concurrency")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let plan = build_plan(
             &table,
             None,
@@ -2012,7 +2014,9 @@ mod tests {
     #[cfg(feature = "native-async")]
     async fn execution_error_and_stream_drop_preserve_partial_metrics() -> TestResult {
         let missing_fixture = TestTable::missing("error")?;
-        let missing_table = DeltaTableBuilder::new(missing_fixture.uri()).load()?;
+        let missing_table = DeltaTableBuilder::new(missing_fixture.uri())
+            .load_table()
+            .await?;
         let missing_plan = build_plan(
             &missing_table,
             None,
@@ -2035,7 +2039,7 @@ mod tests {
         assert_eq!(failed.snapshot().reader.files_started, 1);
 
         let fixture = TestTable::partitioned("drop")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let options = DeltaReaderExecutionOptions::new()
             .with_native_async_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
@@ -2066,7 +2070,7 @@ mod tests {
     #[cfg(all(feature = "native-async", feature = "official-kernel"))]
     async fn reader_backends_produce_the_same_logical_rows() -> TestResult {
         let fixture = TestTable::partitioned("backends")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let mut outputs = Vec::new();
         for backend in [
             DeltaReaderBackend::NativeAsync,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -205,16 +205,9 @@ fn direct_reader_contract_is_public() {
         .with_storage_options(DeltaStorageOptions::new())
         .with_snapshot_selection(DeltaSnapshotSelection::Version(1))
         .with_execution_options(DeltaReaderExecutionOptions::new());
-    assert_future::<Result<DeltaTable, DeltaReaderError>>(builder.load_async());
-    let load: fn(DeltaTableBuilder) -> Result<DeltaTable, DeltaReaderError> =
-        DeltaTableBuilder::load;
-    let load_snapshot: fn(DeltaTableBuilder) -> Result<DeltaTableSnapshot, DeltaReaderError> =
-        DeltaTableBuilder::load_snapshot;
+    assert_future::<Result<DeltaTable, DeltaReaderError>>(builder.load_table());
     let snapshot_builder = DeltaTableBuilder::new("file:///tmp/table");
-    assert_future::<Result<DeltaTableSnapshot, DeltaReaderError>>(
-        snapshot_builder.load_snapshot_async(),
-    );
-    let _ = (load, load_snapshot);
+    assert_future::<Result<DeltaTableSnapshot, DeltaReaderError>>(snapshot_builder.load_snapshot());
 
     let snapshot_version: fn(&DeltaTableSnapshot) -> u64 = DeltaTableSnapshot::version;
     let snapshot_protocol: for<'a> fn(&'a DeltaTableSnapshot) -> &'a DeltaProtocolInfo =
@@ -350,23 +343,25 @@ fn datafusion_provider_contract_is_public() {
 }
 
 #[cfg(not(feature = "native-async"))]
-#[test]
-fn disabled_native_backend_fails_before_uri_access() {
+#[tokio::test]
+async fn disabled_native_backend_fails_before_uri_access() {
     let error = DeltaTableBuilder::new("this URI must never be inspected")
-        .load()
+        .load_table()
+        .await
         .expect_err("disabled default backend must fail");
     assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
     assert_eq!(error.as_str(), "unsupported_backend");
 }
 
 #[cfg(not(feature = "official-kernel"))]
-#[test]
-fn disabled_official_backend_fails_before_uri_access() -> Result<(), DeltaReaderError> {
+#[tokio::test]
+async fn disabled_official_backend_fails_before_uri_access() -> Result<(), DeltaReaderError> {
     let options = DeltaReaderExecutionOptions::new()
         .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
     let error = DeltaTableBuilder::new("this URI must never be inspected")
         .with_execution_options(options)
-        .load()
+        .load_table()
+        .await
         .expect_err("disabled official backend must fail");
     assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
     assert_eq!(error.as_str(), "unsupported_backend");

--- a/tests/reader/datafusion_adapter.rs
+++ b/tests/reader/datafusion_adapter.rs
@@ -233,7 +233,7 @@ async fn collect_plan(
 #[tokio::test]
 async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> TestResult {
     let fixture = TestTable::partitioned("optimizer-file-repartitioning")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
     let context = SessionContext::new_with_config(
         SessionConfig::new()
             .with_target_partitions(4)
@@ -286,7 +286,7 @@ async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> T
 #[tokio::test]
 async fn intra_file_repartitioning_policy_controls_full_plan_rebalancing() -> TestResult {
     let fixture = TestTable::skewed("optimizer-full-plan-rebalancing")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
 
     for (name, policy, expected_tasks) in [
         (
@@ -352,7 +352,9 @@ async fn repartitioned_scan_preserves_predicates_and_deletion_vector_coordinates
         3_000,
         &[0, 2_999, 3_000, 5_999],
     )?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let context = SessionContext::new_with_config(
         SessionConfig::new()
             .with_target_partitions(8)
@@ -401,7 +403,9 @@ async fn repartitioned_scan_preserves_predicates_and_deletion_vector_coordinates
 #[tokio::test]
 async fn repartitioned_scan_preserves_physical_to_logical_transforms() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_column_mapping("provider-repartitioned-mapping")?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let context = SessionContext::new_with_config(
         SessionConfig::new()
             .with_target_partitions(2)
@@ -491,7 +495,7 @@ async fn large_repartitioned_dv_scan_matches_unsplit_under_concurrent_reexecutio
             .with_target_partitions(TARGET_PARTITIONS)
             .with_repartition_file_min_size(1),
     );
-    register_fixture(&context, "orders", &fixture, options.clone())?;
+    register_fixture(&context, "orders", &fixture, options.clone()).await?;
     let plan = context
         .sql("SELECT id FROM orders ORDER BY id")
         .await?
@@ -567,7 +571,7 @@ async fn large_repartitioned_dv_scan_matches_unsplit_under_concurrent_reexecutio
             .with_target_partitions(TARGET_PARTITIONS)
             .with_repartition_file_scans(false),
     );
-    register_fixture(&control, "orders", &fixture, options)?;
+    register_fixture(&control, "orders", &fixture, options).await?;
     let control_plan = control
         .sql("SELECT id FROM orders ORDER BY id")
         .await?
@@ -617,7 +621,8 @@ async fn repartitioned_scan_fails_closed_when_dv_payload_is_missing() -> TestRes
             target_partitions: Some(8),
             ..Default::default()
         },
-    )?;
+    )
+    .await?;
     let plan = context
         .sql("SELECT id FROM orders")
         .await?
@@ -654,13 +659,15 @@ async fn repartitioned_scan_fails_closed_when_dv_payload_is_missing() -> TestRes
     Ok(())
 }
 
-fn register_fixture(
+async fn register_fixture(
     context: &SessionContext,
     name: &str,
     fixture: &RealParquetDeltaTable,
     options: DeltaDataFusionScanOptions,
 ) -> TestResult {
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     register_delta_table(context, name, table, options)?;
     Ok(())
 }
@@ -695,7 +702,7 @@ fn external_reader_error(error: &DataFusionError) -> TestResult<&DeltaReaderErro
 #[cfg(feature = "native-async")]
 async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract() -> TestResult {
     let fixture = TestTable::partitioned("provider-contract")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
     let defaults = DeltaDataFusionScanOptions::default();
     assert_eq!(
         defaults.execution_options,
@@ -845,7 +852,9 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
     }
 
     let unsupported_fixture = TestTable::unsupported("unsupported-provider")?;
-    let unsupported = DeltaTableBuilder::new(unsupported_fixture.uri()).load()?;
+    let unsupported = DeltaTableBuilder::new(unsupported_fixture.uri())
+        .load_table()
+        .await?;
     let error = DeltaTableProvider::try_new(unsupported, Default::default())
         .expect_err("unsupported protocol must fail");
     assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
@@ -856,7 +865,7 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
 #[cfg(feature = "native-async")]
 async fn registration_sql_metrics_duplicates_and_repeated_scans_are_exact() -> TestResult {
     let fixture = TestTable::partitioned("registration")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
     let context = SessionContext::new();
 
     for invalid in ["", "1orders", "line-items", "select"] {
@@ -970,7 +979,7 @@ async fn registration_sql_metrics_duplicates_and_repeated_scans_are_exact() -> T
 #[cfg(feature = "native-async")]
 async fn caller_runtime_owns_concurrent_dataframe_execution() -> TestResult {
     let fixture = TestTable::partitioned("caller-runtime")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load_async().await?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
     let context = SessionContext::new();
     register_delta_table(
         &context,
@@ -991,7 +1000,7 @@ async fn caller_runtime_owns_concurrent_dataframe_execution() -> TestResult {
 #[cfg(all(feature = "native-async", feature = "official-kernel"))]
 async fn native_exact_and_official_residual_execution_return_the_same_rows() -> TestResult {
     let fixture = TestTable::partitioned("backend-parity")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
     let mut outputs = Vec::new();
 
     for (name, backend) in [
@@ -1061,7 +1070,8 @@ async fn sql_join_dynamic_filter_prunes_before_file_admission() -> TestResult {
             target_partitions: Some(1),
             ..Default::default()
         },
-    )?;
+    )
+    .await?;
 
     let plan = context
         .sql(
@@ -1125,7 +1135,8 @@ async fn dynamic_join_kept_file_still_applies_deletion_vector() -> TestResult {
             target_partitions: Some(1),
             ..Default::default()
         },
-    )?;
+    )
+    .await?;
 
     let plan = context
         .sql(
@@ -1163,7 +1174,9 @@ async fn native_exact_filter_applies_before_deletion_vector_masking() -> TestRes
         3,
         &[4],
     )?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let provider = DeltaTableProvider::try_new(table, DeltaDataFusionScanOptions::default())?;
     let filter = col("id").gt(lit(3_i32));
     assert_eq!(
@@ -1193,7 +1206,9 @@ async fn native_exact_filter_applies_before_deletion_vector_masking() -> TestRes
 #[cfg(feature = "native-async")]
 async fn execution_records_batch_size_and_rejects_invalid_partition() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-execution-options")?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let provider = DeltaTableProvider::try_new(
         table,
         DeltaDataFusionScanOptions {
@@ -1237,7 +1252,7 @@ async fn execution_records_batch_size_and_rejects_invalid_partition() -> TestRes
 #[cfg(feature = "native-async")]
 async fn empty_scan_has_no_partitions_rows_or_execution_metrics() -> TestResult {
     let fixture = TestTable::empty("provider-empty-scan")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
     let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(4));
     let provider = DeltaTableProvider::try_new(table, DeltaDataFusionScanOptions::default())?;
     let plan = provider.scan(&context.state(), None, &[], None).await?;
@@ -1275,7 +1290,9 @@ async fn empty_scan_has_no_partitions_rows_or_execution_metrics() -> TestResult 
 #[cfg(feature = "native-async")]
 async fn execution_error_preserves_reader_source_and_partial_metrics() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-missing-file")?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     fs::remove_file(fixture.path().join(fixture.data_file_path()))?;
     let provider = DeltaTableProvider::try_new(
         table,
@@ -1311,7 +1328,9 @@ async fn execution_error_preserves_reader_source_and_partial_metrics() -> TestRe
 #[cfg(feature = "native-async")]
 async fn execution_stream_drop_preserves_bounded_partial_metrics() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_two_large_files("provider-stream-drop", 20_000)?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let execution_options = DeltaReaderExecutionOptions::new()
         .with_native_async_prefetch_file_count_per_partition(0)?
         .with_max_concurrent_file_reads_per_partition(1)?
@@ -1358,7 +1377,9 @@ async fn execution_stream_drop_preserves_bounded_partial_metrics() -> TestResult
 async fn native_metadata_hint_preserves_rows_and_request_fallback() -> TestResult {
     let fixture =
         RealParquetDeltaTable::new_with_two_large_files("provider-parquet-metadata-hint", 20_000)?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let mut outputs = Vec::new();
     let mut requests = Vec::new();
 
@@ -1440,7 +1461,8 @@ async fn dynamic_join_pruning_preserves_the_sql_residual() -> TestResult {
             target_partitions: Some(1),
             ..Default::default()
         },
-    )?;
+    )
+    .await?;
 
     let plan = context
         .sql(
@@ -1480,7 +1502,9 @@ async fn dynamic_join_pruning_preserves_the_sql_residual() -> TestResult {
 #[cfg(all(feature = "native-async", feature = "official-kernel"))]
 async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-residual-limit")?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let execution_options = DeltaReaderExecutionOptions::new()
         .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
     let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
@@ -1557,7 +1581,9 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
 #[cfg(feature = "native-async")]
 async fn native_scan_decodes_both_string_representations_with_exact_values() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_supported_types("provider-view-values")?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     register_delta_table(
         &context,
@@ -1680,7 +1706,9 @@ async fn native_scan_preserves_views_through_nested_map_reordering() -> TestResu
     let fixture = RealParquetDeltaTable::new_with_reordered_map_value_struct_fields(
         "provider-reordered-map-views",
     )?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     register_delta_table(
         &context,
@@ -1741,7 +1769,9 @@ async fn native_scan_preserves_views_through_nested_map_reordering() -> TestResu
 #[cfg(feature = "native-async")]
 async fn joined_delta_scans_keep_distinct_metrics_and_limit_above_join() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-joined-scans")?;
-    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned()).load()?;
+    let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
+        .load_table()
+        .await?;
     let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     register_delta_table(
         &context,

--- a/tests/reader/direct_reader.rs
+++ b/tests/reader/direct_reader.rs
@@ -252,7 +252,7 @@ fn labels(batches: &[RecordBatch]) -> Vec<Option<String>> {
 
 #[test]
 #[cfg(feature = "native-async")]
-fn table_loads_match_and_public_state_is_redacted() -> TestResult {
+fn table_loads_versions_and_public_state_is_redacted() -> TestResult {
     let fixture = TestTable::two_versions("load")?;
     let secret_uri = fixture.uri();
     let mut storage_options = DeltaStorageOptions::new();
@@ -265,27 +265,27 @@ fn table_loads_match_and_public_state_is_redacted() -> TestResult {
     assert!(!builder_debug.contains("secret-token"));
     assert!(!builder_debug.contains("never-print-this"));
 
-    let latest = DeltaTableBuilder::new(&secret_uri).load()?;
-    let fixed = DeltaTableBuilder::new(&secret_uri)
-        .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
-        .load()?;
     let runtime = runtime()?;
-    let asynchronous = runtime.block_on(DeltaTableBuilder::new(&secret_uri).load_async())?;
-    let asynchronous_fixed = runtime.block_on(
+    let latest = runtime.block_on(DeltaTableBuilder::new(&secret_uri).load_table())?;
+    let fixed_snapshot = runtime.block_on(
         DeltaTableBuilder::new(&secret_uri)
             .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
-            .load_async(),
+            .load_snapshot(),
     )?;
+    assert_eq!(fixed_snapshot.version(), 0);
+    assert_eq!(fixed_snapshot.table_uri(), fixture.normalized_uri()?);
+    assert_eq!(
+        fixed_snapshot.protocol().snapshot_version(),
+        fixed_snapshot.version()
+    );
+    fixed_snapshot.validate_protocol()?;
+    assert!(!format!("{fixed_snapshot:?}").contains(&secret_uri));
+
+    let fixed = fixed_snapshot.into_table()?;
     let cloned = latest.clone();
 
     assert_eq!(latest.version(), 1);
     assert_eq!(fixed.version(), 0);
-    assert_eq!(asynchronous.version(), latest.version());
-    assert_eq!(asynchronous_fixed.version(), fixed.version());
-    assert_eq!(asynchronous.schema(), latest.schema());
-    assert_eq!(asynchronous_fixed.schema(), fixed.schema());
-    assert_eq!(asynchronous.protocol(), latest.protocol());
-    assert_eq!(asynchronous_fixed.protocol(), fixed.protocol());
     assert_eq!(latest.table_uri(), fixture.normalized_uri()?);
     assert!(Arc::ptr_eq(latest.schema(), cloned.schema()));
     assert_eq!(latest.protocol().snapshot_version(), latest.version());
@@ -301,7 +301,7 @@ fn local_end_to_end_example_reads_without_sql() -> TestResult {
         let fixture = TestTable::two_versions("local-example")?;
         let table = DeltaTableBuilder::new(fixture.uri())
             .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
-            .load_async()
+            .load_table()
             .await?;
         let scan = table
             .scan()
@@ -321,19 +321,20 @@ fn local_end_to_end_example_reads_without_sql() -> TestResult {
 #[cfg(feature = "native-async")]
 fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
     let fixture = TestTable::unsupported("unsupported")?;
-    let table = DeltaTableBuilder::new(fixture.uri()).load()?;
+    let runtime = runtime()?;
+    let table = runtime.block_on(DeltaTableBuilder::new(fixture.uri()).load_table())?;
 
     assert_eq!(table.version(), 0);
     assert_eq!(table.protocol().min_reader_version(), 4);
     let validation = table.validate_protocol().expect_err("protocol must fail");
     assert_eq!(validation.phase(), DeltaReaderPhase::Protocol);
-    let build = runtime()?.block_on(table.scan().build());
+    let build = runtime.block_on(table.scan().build());
     let error = match build {
         Ok(_) => panic!("unsupported protocol built a scan"),
         Err(error) => error,
     };
     assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
-    let build = runtime()?.block_on(table.scan().with_projection(vec!["missing".into()]).build());
+    let build = runtime.block_on(table.scan().with_projection(vec!["missing".into()]).build());
     let error = match build {
         Ok(_) => panic!("unsupported protocol built another scan"),
         Err(error) => error,
@@ -347,7 +348,7 @@ fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
 fn projection_predicate_limit_partition_and_metrics_contracts_hold() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("scan")?;
-        let table = DeltaTableBuilder::new(fixture.uri()).load_async().await?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
 
         let full_scan = table.scan().with_target_partitions(2)?.build().await?;
         assert_eq!(full_scan.partition_count(), 2);
@@ -537,7 +538,7 @@ fn stream_is_pull_driven_reports_one_error_and_retains_drop_metrics() -> TestRes
             .with_output_buffer_capacity_per_partition(1)?;
         let table = DeltaTableBuilder::new(fixture.uri())
             .with_execution_options(options)
-            .load_async()
+            .load_table()
             .await?;
 
         let idle = table.scan().with_target_partitions(1)?.build().await?;
@@ -560,7 +561,7 @@ fn stream_is_pull_driven_reports_one_error_and_retains_drop_metrics() -> TestRes
         assert!(snapshot.rows_produced >= u64::try_from(first.num_rows())?);
 
         let missing = TestTable::missing_data_file("error")?;
-        let table = DeltaTableBuilder::new(missing.uri()).load_async().await?;
+        let table = DeltaTableBuilder::new(missing.uri()).load_table().await?;
         let scan = table.scan().with_target_partitions(1)?.build().await?;
         let mut stream = scan.execute().await?;
         let metrics = stream.metrics();
@@ -581,13 +582,13 @@ fn stream_is_pull_driven_reports_one_error_and_retains_drop_metrics() -> TestRes
 fn official_kernel_matches_native_direct_results() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("backend-parity")?;
-        let native = DeltaTableBuilder::new(fixture.uri()).load_async().await?;
+        let native = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let official = DeltaTableBuilder::new(fixture.uri())
             .with_execution_options(
                 DeltaReaderExecutionOptions::new()
                     .with_reader_backend(DeltaReaderBackend::OfficialKernel)?,
             )
-            .load_async()
+            .load_table()
             .await?;
         let official_options = DeltaReaderExecutionOptions::new()
             .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
@@ -676,7 +677,7 @@ fn official_kernel_reads_through_the_direct_surface() -> TestResult {
             .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
         let table = DeltaTableBuilder::new(fixture.uri())
             .with_execution_options(options)
-            .load_async()
+            .load_table()
             .await?;
         let scan = table
             .scan()

--- a/tests/reader/portable_fixtures.rs
+++ b/tests/reader/portable_fixtures.rs
@@ -572,7 +572,7 @@ async fn native_stream(
 ) -> TestResult<DeltaBatchStream> {
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
         .with_execution_options(options)
-        .load_async()
+        .load_table()
         .await?;
     let scan = table
         .scan()
@@ -594,7 +594,7 @@ async fn scan_fixture(
     let options = DeltaReaderExecutionOptions::new().with_reader_backend(backend)?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
         .with_execution_options(options)
-        .load_async()
+        .load_table()
         .await?;
     let scan = table.scan().with_target_partitions(1)?;
     let scan = match projection {


### PR DESCRIPTION
## Summary

- replace the ambiguous blocking and async-suffixed builder methods with `load_table().await` and `load_snapshot().await`
- keep both entry points on the existing caller-owned Tokio and Delta Kernel loading path
- update Rustdocs, guides, benchmarks, and every repository call site
- exercise staged snapshot metadata, redaction, protocol validation, and conversion in an integration test

## Breaking API change

- `load()` and `load_async()` become `load_table().await`
- `load_snapshot_async()` becomes `load_snapshot().await`
- no compatibility aliases are retained

## Validation

- all eight CI feature combinations
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo package --locked`