### PR TITLE
refactor!: simplify Parquet reader backend selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,18 +44,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Minimal
-            base: --no-default-features
-            official: --no-default-features --features official-kernel
+          - name: Direct API
+            features: ""
           - name: DataFusion
-            base: --no-default-features --features datafusion
-            official: --no-default-features --features datafusion,official-kernel
-          - name: Native
-            base: ""
-            official: --features official-kernel
-          - name: Native + DataFusion
-            base: --features datafusion
-            official: --all-features
+            features: --features datafusion
 
     steps:
       - uses: actions/checkout@v5
@@ -76,8 +68,7 @@ jobs:
           save-if: false
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10
-      - run: cargo test --locked ${{ matrix.base }}
-      - run: cargo test --locked ${{ matrix.official }}
+      - run: cargo test --locked ${{ matrix.features }}
 
   checks:
     name: ${{ matrix.task }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,10 @@ exclude = [
 [[bench]]
 name = "reader"
 harness = false
-required-features = ["datafusion", "native-async", "official-kernel"]
+required-features = ["datafusion"]
 test = false
 
 [features]
-default = ["native-async"]
-native-async = []
-official-kernel = []
 datafusion = ["dep:datafusion"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -119,22 +119,21 @@ let scan_options = DeltaDataFusionScanOptions {
 ```
 
 Whole-file planning normally avoids extra ranged reads once it fills the scan
-partition target. For skewed NativeAsync scans, opt in to DataFusion
+partition target. For skewed direct Parquet scans, opt in to DataFusion
 rebalancing with `DeltaFileRepartitioning::Rebalance`.
 DataFusion's `repartition_file_scans` and `repartition_file_min_size` settings
 still control whether repartitioning runs.
 
-## Features
+## Optional feature
 
 | Feature | Default | Purpose |
 | --- | --- | --- |
-| `native-async` | Yes | Native asynchronous Parquet data-file reader and I/O metrics. |
-| `official-kernel` | No | Official Delta Kernel data-file reader backend. |
 | `datafusion` | No | DataFusion provider, registration, filtering, execution, and metrics. |
 
-At least one reader backend must be enabled to execute a scan. Select the
-backend for a scan with `DeltaReaderExecutionOptions::with_reader_backend`.
-When default features are enabled, NativeAsync is selected by default.
+The direct API and both data-file reader backends are always available.
+`ParquetReaderBackend::DirectParquet` is the default. Advanced callers can select
+`ParquetReaderBackend::DeltaKernel` with
+`DeltaReaderExecutionOptions::with_reader_backend`.
 
 ## Runtime, errors, and metrics
 
@@ -146,14 +145,14 @@ When default features are enabled, NativeAsync is selected by default.
   redacted categories. Dependency failures remain available through the
   standard error source chain.
 - `DeltaReadMetrics` is a cloneable live handle. `snapshot` returns an
-  immutable point-in-time view. NativeAsync Parquet I/O counters are `None`
-  when the OfficialKernel backend is selected.
+  immutable point-in-time view. Direct Parquet I/O counters are `None` when
+  the Delta Kernel backend is selected.
 
 ## Scope
 
 The crate supports the extracted read path: snapshot selection, protocol and
 schema loading, projections, predicates, deletion vectors, partition planning,
-bounded scheduling, NativeAsync and OfficialKernel data-file reads, and the
+bounded scheduling, direct Parquet and Delta Kernel data-file reads, and the
 optional DataFusion adapter.
 
 It does not write Delta tables, manage transactions, create a Tokio runtime,

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -17,9 +17,9 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use delta_arrow_reader::{
-    DeltaDataFusionMetricsSnapshot, DeltaDataFusionScanOptions, DeltaReaderBackend,
-    DeltaReaderExecutionOptions, DeltaStorageOptions, DeltaTableBuilder,
-    collect_delta_datafusion_metrics, register_delta_table,
+    DeltaDataFusionMetricsSnapshot, DeltaDataFusionScanOptions, DeltaReaderExecutionOptions,
+    DeltaStorageOptions, DeltaTableBuilder, ParquetReaderBackend, collect_delta_datafusion_metrics,
+    register_delta_table,
 };
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
 use delta_kernel::actions::deletion_vector_writer::{
@@ -30,7 +30,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 
 const MIB: u64 = 1024 * 1024;
-const BENCHMARK_SCHEMA_VERSION: u32 = 22;
+const BENCHMARK_SCHEMA_VERSION: u32 = 23;
 const DEFAULT_REPETITIONS: usize = 3;
 const MAX_REPETITIONS: usize = 128;
 const MODIFICATION_TIME_MS: i64 = 1_587_968_586_000;
@@ -66,7 +66,7 @@ const CSV_HEADER: [&str; 80] = [
     "max_concurrent_file_reads_per_scan",
     "max_concurrent_file_reads_per_partition",
     "output_buffer_capacity_per_partition",
-    "native_async_prefetch_file_count_per_partition",
+    "prefetch_file_count_per_partition",
     "repetitions",
     "file_count",
     "row_count",
@@ -139,7 +139,7 @@ struct Config {
     storage: StorageProfile,
     workload: Workload,
     query: Query,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     repetitions: usize,
     metadata_hint: Option<usize>,
     full_read_threshold: Option<usize>,
@@ -304,7 +304,7 @@ impl Config {
             storage: StorageProfile::local(),
             workload: Workload::FewLarger,
             query: Query::FullRows,
-            backend: DeltaReaderBackend::NativeAsync,
+            backend: ParquetReaderBackend::DirectParquet,
             repetitions: DEFAULT_REPETITIONS,
             metadata_hint: Some(65_536),
             full_read_threshold: None,
@@ -338,8 +338,8 @@ impl Config {
                         .replace('-', "_")
                         .as_str()
                     {
-                        "native_async" => DeltaReaderBackend::NativeAsync,
-                        "official_kernel" => DeltaReaderBackend::OfficialKernel,
+                        "direct_parquet" => ParquetReaderBackend::DirectParquet,
+                        "delta_kernel" => ParquetReaderBackend::DeltaKernel,
                         other => return Err(invalid(format!("unknown backend: {other}")).into()),
                     }
                 }
@@ -393,56 +393,56 @@ impl Config {
             (
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync | DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DirectParquet | ParquetReaderBackend::DeltaKernel,
                 "local",
                 Some(65_536),
                 None,
             ) | (
                 Workload::FewLarger,
                 Query::ProjectId,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 "local",
                 Some(65_536),
                 None,
             ) | (
                 Workload::ManyUnequal,
                 Query::FilterTailIds,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 "local",
                 Some(65_536),
                 None,
             ) | (
                 Workload::ManySmall,
                 Query::ProjectId,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 "local",
                 Some(65_536),
                 None,
             ) | (
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 "local",
                 None | Some(8),
                 None,
             ) | (
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 "local",
                 Some(65_536),
                 Some(1_000 | 1_000_000),
             ) | (
                 Workload::FewLargerSparseDv,
                 Query::ProjectId,
-                DeltaReaderBackend::NativeAsync | DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DirectParquet | ParquetReaderBackend::DeltaKernel,
                 "local",
                 Some(65_536),
                 None,
             ) | (
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 "s3_throttled",
                 Some(65_536),
                 None,
@@ -1313,7 +1313,7 @@ async fn run_once(
         .with_max_concurrent_file_reads_per_scan(Some(target_partitions.saturating_mul(3).max(1)))?
         .with_max_concurrent_file_reads_per_partition(3)?
         .with_output_buffer_capacity_per_partition(1)?
-        .with_native_async_prefetch_file_count_per_partition(2)?
+        .with_prefetch_file_count_per_partition(2)?
         .with_parquet_metadata_size_hint(config.metadata_hint)?
         .with_parquet_full_file_read_threshold(config.full_read_threshold)?;
     let table = DeltaTableBuilder::new(&fixture.table_uri)
@@ -1708,10 +1708,10 @@ fn csv_row(
     row
 }
 
-fn backend_name(backend: DeltaReaderBackend) -> &'static str {
+fn backend_name(backend: ParquetReaderBackend) -> &'static str {
     match backend {
-        DeltaReaderBackend::NativeAsync => "native_async",
-        DeltaReaderBackend::OfficialKernel => "official_kernel",
+        ParquetReaderBackend::DirectParquet => "direct_parquet",
+        ParquetReaderBackend::DeltaKernel => "delta_kernel",
     }
 }
 
@@ -1787,7 +1787,7 @@ mod tests {
     fn config(
         workload: Workload,
         query: Query,
-        backend: DeltaReaderBackend,
+        backend: ParquetReaderBackend,
         storage: StorageProfile,
         metadata_hint: Option<usize>,
         full_read_threshold: Option<usize>,
@@ -1815,7 +1815,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(65_536),
                 None,
@@ -1823,7 +1823,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::ProjectId,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(65_536),
                 None,
@@ -1831,7 +1831,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DeltaKernel,
                 local,
                 Some(65_536),
                 None,
@@ -1839,7 +1839,7 @@ mod tests {
             config(
                 Workload::ManyUnequal,
                 Query::FilterTailIds,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(65_536),
                 None,
@@ -1847,7 +1847,7 @@ mod tests {
             config(
                 Workload::ManySmall,
                 Query::ProjectId,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(65_536),
                 None,
@@ -1855,7 +1855,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 None,
                 None,
@@ -1863,7 +1863,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(8),
                 None,
@@ -1871,7 +1871,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(65_536),
                 Some(1_000_000),
@@ -1879,7 +1879,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(65_536),
                 Some(1_000),
@@ -1887,7 +1887,7 @@ mod tests {
             config(
                 Workload::FewLargerSparseDv,
                 Query::ProjectId,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 local,
                 Some(65_536),
                 None,
@@ -1895,7 +1895,7 @@ mod tests {
             config(
                 Workload::FewLargerSparseDv,
                 Query::ProjectId,
-                DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DeltaKernel,
                 local,
                 Some(65_536),
                 None,
@@ -1903,7 +1903,7 @@ mod tests {
             config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 throttled,
                 Some(65_536),
                 None,
@@ -1916,7 +1916,7 @@ mod tests {
         let outside = config(
             Workload::ManySmall,
             Query::ProjectId,
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             local,
             Some(65_536),
             None,
@@ -1940,7 +1940,7 @@ mod tests {
                 "--provider-exec-query",
                 "full_rows",
                 "--provider-exec-backend",
-                "native_async",
+                "direct_parquet",
                 "--provider-exec-scheduling-profile",
                 "prefetch_2_ap_target_scan_3x",
                 "--provider-exec-parquet-metadata-size-hint",
@@ -1961,7 +1961,10 @@ mod tests {
         assert_eq!(parsed.storage.name, "local");
         assert_eq!(parsed.workload.name(), "provider_few_larger_files");
         assert_eq!(parsed.query.name(), "full_rows");
-        assert!(matches!(parsed.backend, DeltaReaderBackend::NativeAsync));
+        assert!(matches!(
+            parsed.backend,
+            ParquetReaderBackend::DirectParquet
+        ));
         assert_eq!(parsed.repetitions, 5);
         assert_eq!(parsed.metadata_hint, Some(65_536));
         assert_eq!(parsed.full_read_threshold, None);
@@ -1974,7 +1977,10 @@ mod tests {
         assert_eq!(defaults.storage.name, "local");
         assert_eq!(defaults.workload.name(), "provider_few_larger_files");
         assert_eq!(defaults.query.name(), "full_rows");
-        assert!(matches!(defaults.backend, DeltaReaderBackend::NativeAsync));
+        assert!(matches!(
+            defaults.backend,
+            ParquetReaderBackend::DirectParquet
+        ));
         assert_eq!(defaults.repetitions, DEFAULT_REPETITIONS);
         assert_eq!(defaults.metadata_hint, Some(65_536));
         assert_eq!(defaults.full_read_threshold, None);
@@ -2045,7 +2051,7 @@ mod tests {
             let unequal_config = config(
                 Workload::ManyUnequal,
                 Query::FilterTailIds,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 StorageProfile::local(),
                 Some(65_536),
                 None,
@@ -2063,7 +2069,7 @@ mod tests {
             let http_config = config(
                 Workload::FewLarger,
                 Query::FullRows,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 StorageProfile::throttled(),
                 Some(65_536),
                 None,
@@ -2114,7 +2120,7 @@ mod tests {
             let config = config(
                 Workload::FewLargerSparseDv,
                 Query::ProjectId,
-                DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DeltaKernel,
                 StorageProfile::local(),
                 Some(65_536),
                 None,
@@ -2126,7 +2132,7 @@ mod tests {
             let summary = summarize(&measurements);
             let row = csv_row(&config, &fixture, Some(4), 4, &measurements);
             assert_eq!(row.len(), CSV_HEADER.len());
-            assert_eq!(row[0], "22");
+            assert_eq!(row[0], "23");
             assert_eq!(row[1], "provider_exec");
             assert_eq!(row[2], env::consts::OS);
             assert_eq!(row[3], env::consts::ARCH);
@@ -2136,7 +2142,7 @@ mod tests {
             assert_eq!(row[7], "provider_few_larger_files_sparse_dv");
             assert_eq!(row[8], "local");
             assert_eq!(row[9], "project_id");
-            assert_eq!(row[10], "official_kernel");
+            assert_eq!(row[10], "delta_kernel");
             assert_eq!(row[11], "prefetch_2_ap_target_scan_3x");
             assert_eq!(&row[12..17], ["4", "12", "3", "1", "2"]);
             assert_eq!(row[17], "1");

--- a/docs-site/docs/architecture.md
+++ b/docs-site/docs/architecture.md
@@ -39,9 +39,9 @@ building reports, and sending the results elsewhere.
 
 ## Reader backends
 
-The default backend, NativeAsync, reads Parquet data asynchronously through the
-same object store used to load the snapshot. The optional OfficialKernel
-backend reads data files through Delta Kernel's synchronous iterator API.
+The default `DirectParquet` backend reads Parquet data asynchronously through
+the same object store used to load the snapshot. The `DeltaKernel` backend
+reads data files through Delta Kernel's synchronous iterator API.
 Whichever backend you choose, the rest of the scan behaves the same.
 
 ## Cancellation

--- a/docs-site/docs/benchmark-parity.md
+++ b/docs-site/docs/benchmark-parity.md
@@ -18,7 +18,7 @@ five measured repetitions. Inputs retained the frozen seed, fixture, query,
 backend, storage model, scheduling profile, Parquet controls, and schema-22
 CSV fields.
 
-The extracted invocation is:
+The current equivalent invocation is:
 
 ```bash
 cargo bench --locked -p delta-arrow-reader --bench reader --all-features -- \
@@ -26,13 +26,18 @@ cargo bench --locked -p delta-arrow-reader --bench reader --all-features -- \
   --provider-exec-storage-profile local \
   --provider-exec-workload provider_few_larger_files \
   --provider-exec-query full_rows \
-  --provider-exec-backend native_async \
+  --provider-exec-backend direct_parquet \
   --provider-exec-scheduling-profile prefetch_2_ap_target_scan_3x \
   --provider-exec-parquet-metadata-size-hint 65536 \
   --provider-exec-parquet-full-file-read-threshold disabled \
   --provider-exec-repetitions 5 \
   --output target/delta-arrow-reader-benchmark.csv
 ```
+
+The captured rows predate the backend naming cleanup and retain their original
+schema-22 `native_async` and `official_kernel` values. The current harness uses
+`direct_parquet` and `delta_kernel` and writes schema 23. The workloads and
+measurements are unchanged.
 
 Change only the workload, query, backend, storage profile, and Parquet controls
 to reproduce the other frozen cases listed below. The harness rejects cases
@@ -79,8 +84,8 @@ The focused `benchmark_harness` integration target includes the applicable
 frozen assertions for the 12-case matrix, accepted and rejected options,
 fixture shapes and fingerprints, retained-fixture ownership, unequal-file
 pruning, delayed HTTP reads, percentile and optional-value edges, Linux memory
-parsing, CSV width, deletion-vector fields, and unavailable OfficialKernel I/O
-metrics.
+parsing, CSV width, deletion-vector fields, and the Delta Kernel backend's
+unavailable Parquet I/O metrics.
 
 The remaining tests from the 71-test frozen benchmark binary stay in Delta
 Funnel because they exercise code that did not move: synthetic partition

--- a/docs-site/docs/installation.md
+++ b/docs-site/docs/installation.md
@@ -31,19 +31,18 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 You can now continue to the [DataFusion quickstart](datafusion.md).
 
-## Optional features
+## Optional feature
 
-Most applications can keep the default features. Change them only when you
-need DataFusion or want to select the other reader backend.
+The direct API and both data-file reader backends are always available. The
+only optional feature adds the DataFusion integration.
 
 | Feature | Default | Purpose |
 | --- | --- | --- |
-| `native-async` | Yes | Read Parquet files asynchronously and report data-file I/O metrics. |
-| `official-kernel` | No | Use the official Delta Kernel data-file reader backend. |
 | `datafusion` | No | Register Delta tables with DataFusion and expose execution metrics. |
 
-A scan needs at least one reader backend. Unless you turn off the default
-features, the reader uses `native-async`.
+The direct Parquet backend is selected by default. Rust callers can choose the
+Delta Kernel backend through `DeltaReaderExecutionOptions` without changing
+Cargo features.
 
 Both APIs run on your application's Tokio runtime. Delta Arrow Reader does not
 create a separate runtime.

--- a/docs-site/docs/provenance.md
+++ b/docs-site/docs/provenance.md
@@ -63,15 +63,15 @@ Delta Funnel adopted the released crate.
 | Permit/environment portions of `crates/delta-funnel/src/query_engine/datafusion/execution/environment.rs` | `crates/delta-arrow-reader/src/reader/scheduling.rs` | #481 |
 | Handoff/cancellation portions of `crates/delta-funnel/src/query_engine/datafusion/execution/file_reader.rs` and `planning_exec.rs` | `crates/delta-arrow-reader/src/reader/scheduling.rs` and `src/reader/planning.rs` | #481 |
 | Execution-counter portions of `crates/delta-funnel/src/query_engine/datafusion/execution/read_stats.rs` | `crates/delta-arrow-reader/src/reader/metrics.rs` and `src/reader/scheduling.rs` | #481 |
-| `crates/delta-funnel/src/query_engine/datafusion/execution/native_async_reader.rs` | `crates/delta-arrow-reader/src/reader/backend/native_async.rs` | #464 |
-| `crates/delta-funnel/src/query_engine/datafusion/execution/native_async_row_group_pruning.rs` | `crates/delta-arrow-reader/src/reader/backend/native_async/row_group_pruning.rs` | #464 |
-| `crates/delta-funnel/src/query_engine/datafusion/execution/metered_object_store.rs` | `crates/delta-arrow-reader/src/reader/backend/native_async/metered_object_store.rs` | #464 |
-| NativeAsync file-producer and default-backend portions of `crates/delta-funnel/src/query_engine/datafusion/execution/file_reader.rs` and `reader_backend.rs` | `crates/delta-arrow-reader/src/reader/backend/native_async.rs` and `src/reader/options.rs` | #464 |
-| NativeAsync Parquet I/O counter portions of `crates/delta-funnel/src/query_engine/datafusion/execution/read_stats.rs` | `crates/delta-arrow-reader/src/reader/backend/native_async/metered_object_store.rs`, `src/reader/metrics.rs`, and `src/reader/backend/native_async.rs` | #464 |
-| OfficialKernel data-file portions of `crates/delta-funnel/src/table_formats/delta/read.rs` | `crates/delta-arrow-reader/src/reader/backend/official_kernel.rs` and `src/delta/kernel.rs` | #465 |
-| OfficialKernel file-correctness portions of `crates/delta-funnel/src/query_engine/datafusion/execution/file_reader.rs` and `reader_backend.rs` | `crates/delta-arrow-reader/src/reader/backend/official_kernel.rs`, `src/reader/deletion_vector.rs`, and `src/delta/kernel.rs` | #465 |
-| OfficialKernel blocking-producer portions of `crates/delta-funnel/src/query_engine/datafusion/execution/scheduling.rs` and `planning_exec.rs` | `crates/delta-arrow-reader/src/reader/backend/official_kernel.rs` over `src/reader/scheduling.rs` | #465 |
-| OfficialKernel metric-availability portions of `crates/delta-funnel/src/query_engine/datafusion/execution/read_stats.rs` | `crates/delta-arrow-reader/src/reader/metrics.rs` | #465 |
+| `crates/delta-funnel/src/query_engine/datafusion/execution/native_async_reader.rs` | `crates/delta-arrow-reader/src/reader/backend/direct_parquet.rs` | #464 |
+| `crates/delta-funnel/src/query_engine/datafusion/execution/native_async_row_group_pruning.rs` | `crates/delta-arrow-reader/src/reader/backend/direct_parquet/row_group_pruning.rs` | #464 |
+| `crates/delta-funnel/src/query_engine/datafusion/execution/metered_object_store.rs` | `crates/delta-arrow-reader/src/reader/backend/direct_parquet/metered_object_store.rs` | #464 |
+| Direct Parquet file-producer and default-backend portions of `crates/delta-funnel/src/query_engine/datafusion/execution/file_reader.rs` and `reader_backend.rs` | `crates/delta-arrow-reader/src/reader/backend/direct_parquet.rs` and `src/reader/options.rs` | #464 |
+| Direct Parquet I/O counter portions of `crates/delta-funnel/src/query_engine/datafusion/execution/read_stats.rs` | `crates/delta-arrow-reader/src/reader/backend/direct_parquet/metered_object_store.rs`, `src/reader/metrics.rs`, and `src/reader/backend/direct_parquet.rs` | #464 |
+| Delta Kernel data-file portions of `crates/delta-funnel/src/table_formats/delta/read.rs` | `crates/delta-arrow-reader/src/reader/backend/kernel_reader.rs` and `src/delta/kernel.rs` | #465 |
+| Delta Kernel file-correctness portions of `crates/delta-funnel/src/query_engine/datafusion/execution/file_reader.rs` and `reader_backend.rs` | `crates/delta-arrow-reader/src/reader/backend/kernel_reader.rs`, `src/reader/deletion_vector.rs`, and `src/delta/kernel.rs` | #465 |
+| Delta Kernel blocking-producer portions of `crates/delta-funnel/src/query_engine/datafusion/execution/scheduling.rs` and `planning_exec.rs` | `crates/delta-arrow-reader/src/reader/backend/kernel_reader.rs` over `src/reader/scheduling.rs` | #465 |
+| Delta Kernel metric-availability portions of `crates/delta-funnel/src/query_engine/datafusion/execution/read_stats.rs` | `crates/delta-arrow-reader/src/reader/metrics.rs` | #465 |
 | Direct table-loading, scan-building, and Arrow stream composition over the extracted services | `crates/delta-arrow-reader/src/reader.rs` | #466 |
 | `crates/delta-funnel/src/query_engine/datafusion/planning/projection.rs` | `crates/delta-arrow-reader/src/reader/datafusion/planning.rs` | #467 |
 | `crates/delta-funnel/src/query_engine/datafusion/planning/filters.rs` | `crates/delta-arrow-reader/src/reader/datafusion/planning.rs` | #467 |
@@ -101,17 +101,18 @@ Delta Funnel adopted the released crate.
 - #481 ports limiter, lazy admission, ordered prefetch, bounded handoff,
   first-error, cancellation, cleanup, and execution-counter assertions into
   `src/reader/scheduling.rs` and `src/reader/planning.rs`.
-- #464 ports the NativeAsync async Parquet reader, object-store metering,
+- #464 ports the direct asynchronous Parquet reader, object-store metering,
   metadata prefetch, per-file buffering, physical projection and schema
   matching, conservative row-group pruning, original row indexes, DV and
   transform pipeline, cancellation, resource lifetime, errors, and focused
   scheduler integration assertions. Full public direct certification remains
   with #482, and DataFusion adaptation and certification remain with #483.
-- #465 ports OfficialKernel data-file reads, the bounded blocking handoff,
+- #465 ports Delta Kernel data-file reads, the bounded blocking handoff,
   projection, predicates, transforms, ordered DV masking, capability fallback,
   cancellation-safe cleanup, errors, metrics availability, and focused parity
-  assertions against NativeAsync. Full public direct certification remains with
-  #482, and DataFusion adaptation and certification remain with #483.
+  assertions against the direct Parquet reader. Full public direct certification
+  remains with #482, and DataFusion adaptation and certification remain with
+  #483.
 - #484 adapts the focused comparison, scalar, Boolean, null, and Kernel
   conversion assertions into the staged crate, then adds schema-validation,
   three-valued residual, pruning-parity, concurrency, and redaction coverage.
@@ -133,7 +134,7 @@ Delta Funnel adopted the released crate.
   direct load, projection, predicate, limit, partition merge, backend parity,
   error, drop, redaction, and retained-metrics contracts.
 - #482 carries the remaining frozen direct/backend contract through the public
-  API. It preserves the 24 frozen NativeAsync/OfficialKernel equivalence cases
+  API. It preserves the 24 frozen direct-Parquet/Delta-Kernel equivalence cases
   against static expected rows, plus four additional backend comparisons among
   the nine deletion-vector predicate/boundary/failure cases. It also preserves
   four missing-required-field failures and seven ordering/error/resource cases

--- a/docs-site/docs/read-scheduling.md
+++ b/docs-site/docs/read-scheduling.md
@@ -21,15 +21,16 @@ that cannot get both permits waits without opening the data file.
 
 ## Prefetch the next files
 
-NativeAsync can prepare a small number of future file streams while the current
-one is being consumed. The default prefetch depth is two per partition. A value
-of zero waits until the current file is drained before starting the next one.
+The direct Parquet reader can prepare a small number of future file streams
+while the current one is being consumed. The default prefetch depth is two per
+partition. A value of zero waits until the current file is drained before
+starting the next one.
 
 Prefetching preserves task order within each partition. Prepared streams still
 hold read permits, so they count against both concurrency limits.
 
-OfficialKernel does not prefetch future files. Within each partition, its
-synchronous iterator reads one admitted file at a time through a bounded
+The Delta Kernel reader does not prefetch future files. Within each partition,
+its synchronous iterator reads one admitted file at a time through a bounded
 blocking handoff. Several partitions can still run at once.
 
 ## Apply dynamic partition pruning
@@ -50,13 +51,13 @@ rows that might match.
 
 ## Choose between ranged and full-file reads
 
-NativeAsync normally asks the object store for the Parquet footer and the data
+The direct Parquet reader normally asks the object store for the footer and data
 ranges needed by the query. This is useful for narrow projections, especially
 when the file is large.
 
 For small files that are read broadly, several remote range requests can cost
 more than one full request. Setting `parquet_full_file_read_threshold` allows
-NativeAsync to fetch an eligible whole-file task once and serve its later range
+the reader to fetch an eligible whole-file task once and serve its later range
 reads from an in-memory copy. Tasks created by intra-file repartitioning keep
 using remote range requests even when the physical file is below the threshold.
 
@@ -75,7 +76,7 @@ Each execution partition sends batches through a bounded output channel. Its
 default capacity is one batch. When the caller stops polling, producers wait
 instead of filling an unbounded queue.
 
-Within a partition, batches stay in task order even when NativeAsync has
+Within a partition, batches stay in task order even when the direct reader has
 prefetched later files. DataFusion may still execute several partitions at the
 same time.
 
@@ -85,7 +86,7 @@ Dropping the output stream tells the scheduler to stop admitting new tasks and
 releases queued streams and permits. Errors follow the same bounded path and
 prevent unrelated later work from being drained.
 
-Asynchronous reads stop at cancellation boundaries. Synchronous OfficialKernel
+Asynchronous reads stop at cancellation boundaries. Synchronous Delta Kernel
 work that has already entered a dependency call may continue until its next
 safe handoff, but it cannot start a later file after cancellation.
 

--- a/docs-site/docs/reference/execution-options.md
+++ b/docs-site/docs/reference/execution-options.md
@@ -10,13 +10,13 @@ them, see [scan planning](../scan-planning.md) and
 
 | Setting | Default | Meaning |
 | --- | --- | --- |
-| `reader_backend` | `NativeAsync` | Data-file reader used by the scan. |
+| `reader_backend` | `DirectParquet` | Data-file reader used by the scan. |
 | `max_concurrent_file_reads_per_scan` | `None` | Scan-wide active-read cap. `None` resolves to the partition target multiplied by the per-partition cap. |
 | `max_concurrent_file_reads_per_partition` | `3` | Active-read cap for one execution partition. |
 | `output_buffer_capacity_per_partition` | `1` | Batches held between a partition producer and its consumer. |
-| `native_async_prefetch_file_count_per_partition` | `2` | Future NativeAsync file streams prepared per partition. `0` is fully lazy. |
-| `parquet_metadata_size_hint` | `Some(65_536)` | Parquet footer bytes prefetched by NativeAsync. `None` disables the hint. |
-| `parquet_full_file_read_threshold` | `None` | Largest file NativeAsync may fetch once and buffer for local range reads. `None` disables full-file buffering. |
+| `prefetch_file_count_per_partition` | `2` | Future direct Parquet file streams prepared per partition. `0` is fully lazy. |
+| `parquet_metadata_size_hint` | `Some(65_536)` | Parquet footer bytes prefetched by the direct reader. `None` disables the hint. |
+| `parquet_full_file_read_threshold` | `None` | Largest file the direct reader may fetch once and buffer for local range reads. `None` disables full-file buffering. |
 
 The concurrency limits, output capacity, and enabled byte-size values must be
 greater than zero. Prefetch depth may be zero.
@@ -25,9 +25,9 @@ The Parquet metadata hint is only a first request size. If the footer is larger,
 the Parquet reader safely requests more data. A hint at least as large as the
 file can fetch the whole object while loading metadata.
 
-The OfficialKernel backend uses the same concurrency and output limits. The
-NativeAsync prefetch, metadata hint, and full-file threshold do not change its
-data-file reader.
+The `DeltaKernel` backend uses the same concurrency and output limits. The
+direct-reader prefetch, metadata hint, and full-file threshold do not change
+its data-file reader.
 
 ## DataFusion scan options
 

--- a/docs-site/docs/reference/metrics.md
+++ b/docs-site/docs/reference/metrics.md
@@ -27,17 +27,17 @@ usable after its batch stream finishes or is dropped.
 | `deletion_vector_rows_deleted` | Rows removed by those masks. |
 | `deletion_vector_failures` | Deletion-vector read or masking failures. |
 | `deletion_vector_rejections` | Deletion-vector reads rejected by safety checks. |
-| `parquet_data_file_range_get_operations` | NativeAsync data-file GET operations with a range. |
-| `parquet_data_file_full_get_operations` | NativeAsync data-file GET operations without a range. |
-| `parquet_data_file_bytes_received` | Bytes delivered successfully through the NativeAsync data-file object store. |
-| `parquet_data_file_opened_bytes` | Estimated bytes assigned to NativeAsync tasks admitted to a reader. A ranged task contributes its range length. |
+| `parquet_data_file_range_get_operations` | Direct Parquet data-file GET operations with a range. |
+| `parquet_data_file_full_get_operations` | Direct Parquet data-file GET operations without a range. |
+| `parquet_data_file_bytes_received` | Bytes delivered successfully through the direct reader's object store. |
+| `parquet_data_file_opened_bytes` | Estimated bytes assigned to direct-reader tasks. A ranged task contributes its range length. |
 
 `files_filtered_during_planning` is not an exact active-file count. Delta
 Kernel's final selection also reconciles Add and Remove actions.
 
-The four Parquet I/O fields are `Some`, including `Some(0)`, for NativeAsync.
-They are `None` for OfficialKernel because its object-store calls happen behind
-the Kernel reader boundary.
+The four Parquet I/O fields are `Some`, including `Some(0)`, for
+`DirectParquet`. They are `None` for `DeltaKernel` because its object-store
+calls happen behind the Kernel reader boundary.
 
 ## DataFusion metrics
 
@@ -63,7 +63,7 @@ and returns each distinct Delta scan metric handle once.
 
 ## Parquet I/O boundaries
 
-The I/O counters observe calls made through NativeAsync's data-file
+The I/O counters observe calls made through the direct reader's data-file
 `object_store` wrapper. They are useful for comparing scan choices, but they
 are not network billing counters.
 
@@ -75,6 +75,6 @@ are not network billing counters.
   contributes its file size, while a ranged task contributes its range length.
 
 The wrapper cannot see lower-level HTTP retries, wire compression, provider
-billing units, or object-store work hidden behind OfficialKernel. A local file
+billing units, or object-store work hidden behind `DeltaKernel`. A local file
 read may also begin before a result is delivered through the wrapper, so a
 failed or dropped local result can leave the received-byte counter at zero.

--- a/docs-site/docs/scan-planning.md
+++ b/docs-site/docs/scan-planning.md
@@ -61,7 +61,7 @@ optional step that can divide files more finely.
 
 ## Split files with DataFusion
 
-Intra-file repartitioning is available only for NativeAsync scans through the
+Intra-file repartitioning is available only for direct Parquet scans through the
 DataFusion adapter. `DeltaFileRepartitioning` controls when the reader offers
 its whole-file groups to DataFusion:
 

--- a/src/delta/kernel.rs
+++ b/src/delta/kernel.rs
@@ -2,7 +2,6 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-#[cfg(any(feature = "native-async", test))]
 use arrow::array::BooleanArray;
 use arrow::{
     array::Array as _, datatypes::SchemaRef, error::ArrowError, record_batch::RecordBatch,
@@ -86,7 +85,6 @@ pub(crate) struct KernelScanSchemas {
 }
 
 impl KernelScanSchemas {
-    #[cfg(feature = "official-kernel")]
     pub(crate) fn physical(&self) -> KernelSchemaRef {
         Arc::clone(&self.physical)
     }
@@ -419,7 +417,6 @@ impl DeltaKernelEngineContext {
         &self.table_url
     }
 
-    #[cfg(feature = "official-kernel")]
     pub(crate) fn engine(&self) -> &(dyn Engine + Send + Sync) {
         self.engine.as_ref()
     }
@@ -429,7 +426,6 @@ impl DeltaKernelEngineContext {
         Arc::clone(&self.object_store)
     }
 
-    #[cfg(any(feature = "native-async", test))]
     pub(crate) fn evaluate_predicate(
         &self,
         schemas: &KernelScanSchemas,

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,15 +155,6 @@ pub enum DeltaReaderError {
         /// Fixed redacted reason category.
         reason: &'static str,
     },
-    /// The requested reader backend is unavailable.
-    #[non_exhaustive]
-    #[snafu(display(
-        "delta reader error: phase=configuration error=unsupported_backend reason={reason}"
-    ))]
-    UnsupportedBackend {
-        /// Fixed redacted reason category.
-        reason: &'static str,
-    },
     /// A Delta data file could not be read.
     #[non_exhaustive]
     #[snafu(display(
@@ -236,7 +227,6 @@ impl DeltaReaderError {
             Self::UnsupportedPredicate { .. } => "unsupported_predicate",
             Self::ScanPlanning { .. } => "scan_planning",
             Self::ScanPartitionPlanning { .. } => "scan_partition_planning",
-            Self::UnsupportedBackend { .. } => "unsupported_backend",
             Self::DataFileRead { .. } => "data_file_read",
             Self::DeletionVectorRead { .. } => "deletion_vector_read",
             Self::PhysicalToLogicalTransform { .. } => "physical_to_logical_transform",
@@ -259,7 +249,6 @@ impl DeltaReaderError {
             | Self::UnsupportedPredicate { .. }
             | Self::ScanPlanning { .. }
             | Self::ScanPartitionPlanning { .. } => DeltaReaderPhase::ScanPlanning,
-            Self::UnsupportedBackend { .. } => DeltaReaderPhase::Configuration,
             Self::Cancelled { .. } => DeltaReaderPhase::Execution,
             Self::DataFileRead { .. } => DeltaReaderPhase::DataFileRead,
             Self::DeletionVectorRead { .. } => DeltaReaderPhase::DeletionVector,
@@ -389,14 +378,6 @@ mod tests {
                 },
                 "scan_partition_planning",
                 DeltaReaderPhase::ScanPlanning,
-                false,
-            ),
-            (
-                DeltaReaderError::UnsupportedBackend {
-                    reason: "unsupported_backend",
-                },
-                "unsupported_backend",
-                DeltaReaderPhase::Configuration,
                 false,
             ),
             (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ pub use reader::partition_target::{
 };
 pub use reader::{
     DeltaBatchStream, DeltaComparison, DeltaPredicate, DeltaReadMetrics, DeltaReadMetricsSnapshot,
-    DeltaReaderBackend, DeltaReaderExecutionOptions, DeltaScalar, DeltaScan, DeltaScanBuilder,
-    DeltaSnapshotSelection, DeltaStorageOptions, DeltaTable, DeltaTableBuilder, DeltaTableSnapshot,
+    DeltaReaderExecutionOptions, DeltaScalar, DeltaScan, DeltaScanBuilder, DeltaSnapshotSelection,
+    DeltaStorageOptions, DeltaTable, DeltaTableBuilder, DeltaTableSnapshot, ParquetReaderBackend,
 };
 #[cfg(feature = "datafusion")]
 pub use reader::{

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -21,7 +21,7 @@ pub use datafusion::{
 };
 pub use metrics::{DeltaReadMetrics, DeltaReadMetricsSnapshot};
 pub use options::{
-    DeltaReaderBackend, DeltaReaderExecutionOptions, DeltaSnapshotSelection, DeltaStorageOptions,
+    DeltaReaderExecutionOptions, DeltaSnapshotSelection, DeltaStorageOptions, ParquetReaderBackend,
 };
 pub use predicate::{DeltaComparison, DeltaPredicate, DeltaScalar};
 
@@ -38,9 +38,7 @@ use futures_util::Stream;
 use snafu::ResultExt;
 
 use self::{
-    planning::{
-        DeltaScanPartitionTargetOptions, DeltaScanPlan, plan_scan, validate_backend_available,
-    },
+    planning::{DeltaScanPartitionTargetOptions, DeltaScanPlan, plan_scan},
     predicate::{evaluate_predicate, referenced_columns, validate_predicate},
     scheduling::{
         DeltaScanExecution, FileAdmission, FileAdmissionFn, FileBatchStream, FileExecutor,
@@ -135,7 +133,7 @@ impl DeltaTableBuilder {
 
     /// Loads a ready-to-scan table through the caller-owned Tokio runtime.
     pub async fn load_table(self) -> Result<DeltaTable, DeltaReaderError> {
-        validate_direct_execution_options(self.execution_options)?;
+        self.execution_options.validate()?;
         let snapshot = load_delta_table_snapshot_async(
             self.table_uri,
             self.storage_options,
@@ -147,7 +145,7 @@ impl DeltaTableBuilder {
 
     /// Loads a Delta Kernel snapshot without converting its logical Arrow schema.
     pub async fn load_snapshot(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
-        validate_direct_execution_options(self.execution_options)?;
+        self.execution_options.validate()?;
         let snapshot = load_staged_delta_table_snapshot_async(
             self.table_uri,
             self.storage_options,
@@ -353,7 +351,7 @@ impl<'table> DeltaScanBuilder<'table> {
         mut self,
         value: DeltaReaderExecutionOptions,
     ) -> Result<Self, DeltaReaderError> {
-        validate_direct_execution_options(value)?;
+        value.validate()?;
         self.execution_options = value;
         Ok(self)
     }
@@ -361,7 +359,7 @@ impl<'table> DeltaScanBuilder<'table> {
     /// Builds one immutable single-use scan plan without reading data files.
     pub async fn build(self) -> Result<DeltaScan, DeltaReaderError> {
         self.table.validate_protocol()?;
-        validate_direct_execution_options(self.execution_options)?;
+        self.execution_options.validate()?;
         if let Some(predicate) = self.predicate.as_ref() {
             validate_predicate(predicate, self.table.schema().as_ref())?;
         }
@@ -479,14 +477,14 @@ impl DeltaScan {
             let execution = DeltaScanExecution::new(Arc::clone(&self.plan));
             let admission: FileAdmissionFn<_> = Arc::new(|_| Ok(FileAdmission::Admit));
             let executor = match backend {
-                DeltaReaderBackend::NativeAsync => native_async_executor(
+                ParquetReaderBackend::DirectParquet => direct_parquet_executor(
                     &self.plan,
                     None,
                     self.enforce_physical_predicate_rows
                         .then(|| self.plan.physical_predicate.clone())
                         .flatten(),
                 )?,
-                DeltaReaderBackend::OfficialKernel => official_kernel_executor(&self.plan)?,
+                ParquetReaderBackend::DeltaKernel => delta_kernel_executor(&self.plan)?,
             };
             for partition in 0..partition_count {
                 partitions.push_back(execution.partition_stream(
@@ -533,7 +531,7 @@ pub struct DeltaBatchStream {
     projection: Option<Vec<usize>>,
     remaining: Option<usize>,
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     partition_count: usize,
     started: bool,
     done: bool,
@@ -656,59 +654,25 @@ impl Drop for DeltaBatchStream {
     }
 }
 
-fn validate_direct_execution_options(
-    options: DeltaReaderExecutionOptions,
-) -> Result<(), DeltaReaderError> {
-    options.validate()?;
-    validate_backend_available(options)?;
-    Ok(())
-}
-
-#[cfg(feature = "native-async")]
-pub(crate) fn native_async_executor(
+pub(crate) fn direct_parquet_executor(
     plan: &Arc<DeltaScanPlan>,
     output_batch_size: Option<usize>,
     row_predicate: Option<crate::delta::kernel::DeltaKernelPredicate>,
 ) -> Result<FileExecutor<planning::DeltaScanFileTask, FileBatchStream>, DeltaReaderError> {
-    Ok(backend::native_async::native_async_file_executor(
+    Ok(backend::direct_parquet::direct_parquet_file_executor(
         plan,
         output_batch_size,
         row_predicate,
     ))
 }
 
-#[cfg(not(feature = "native-async"))]
-pub(crate) fn native_async_executor(
-    _plan: &Arc<DeltaScanPlan>,
-    _output_batch_size: Option<usize>,
-    _row_predicate: Option<crate::delta::kernel::DeltaKernelPredicate>,
-) -> Result<FileExecutor<planning::DeltaScanFileTask, FileBatchStream>, DeltaReaderError> {
-    crate::error::UnsupportedBackendSnafu {
-        reason: "native_async_feature_disabled",
-    }
-    .fail()
-}
-
-#[cfg(feature = "official-kernel")]
-pub(crate) fn official_kernel_executor(
+pub(crate) fn delta_kernel_executor(
     plan: &Arc<DeltaScanPlan>,
 ) -> Result<FileExecutor<planning::DeltaScanFileTask, FileBatchStream>, DeltaReaderError> {
-    Ok(backend::official_kernel::official_kernel_file_executor(
-        plan,
-    ))
+    Ok(backend::kernel_reader::delta_kernel_file_executor(plan))
 }
 
-#[cfg(not(feature = "official-kernel"))]
-pub(crate) fn official_kernel_executor(
-    _plan: &Arc<DeltaScanPlan>,
-) -> Result<FileExecutor<planning::DeltaScanFileTask, FileBatchStream>, DeltaReaderError> {
-    crate::error::UnsupportedBackendSnafu {
-        reason: "official_kernel_feature_disabled",
-    }
-    .fail()
-}
-
-fn trace_planning_started(snapshot_version: u64, backend: DeltaReaderBackend) {
+fn trace_planning_started(snapshot_version: u64, backend: ParquetReaderBackend) {
     tracing::debug!(
         target: TRACING_TARGET,
         event = "scan_planning.started",
@@ -721,7 +685,7 @@ fn trace_planning_started(snapshot_version: u64, backend: DeltaReaderBackend) {
 
 fn trace_planning_completed(
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     partition_count: usize,
 ) {
     tracing::debug!(
@@ -736,7 +700,7 @@ fn trace_planning_completed(
 
 fn trace_planning_failed(
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     error: &DeltaReaderError,
 ) {
     tracing::debug!(
@@ -753,7 +717,7 @@ fn trace_planning_failed(
 
 fn trace_execution_started(
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     partition_count: usize,
 ) {
     tracing::debug!(
@@ -768,7 +732,7 @@ fn trace_execution_started(
 
 fn trace_execution_completed(
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     partition_count: usize,
 ) {
     tracing::debug!(
@@ -783,7 +747,7 @@ fn trace_execution_completed(
 
 fn trace_execution_failed(
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     partition_count: usize,
     error: &DeltaReaderError,
 ) {
@@ -801,7 +765,7 @@ fn trace_execution_failed(
 
 fn trace_execution_dropped(
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     partition_count: usize,
 ) {
     tracing::debug!(
@@ -842,7 +806,7 @@ mod tests {
         trace_planning_failed, trace_planning_started,
     };
     use crate::{
-        DeltaReadMetrics, DeltaReaderBackend, DeltaReaderExecutionOptions,
+        DeltaReadMetrics, DeltaReaderExecutionOptions, ParquetReaderBackend,
         error::InvalidConfigurationSnafu,
         reader::{
             metrics::DeltaReadMetricsConfig,
@@ -922,7 +886,7 @@ mod tests {
 
     fn execution_options() -> Result<DeltaReaderExecutionOptions, crate::DeltaReaderError> {
         DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(2))?
             .with_output_buffer_capacity_per_partition(1)
@@ -931,7 +895,7 @@ mod tests {
     fn metrics() -> DeltaReadMetrics {
         DeltaReadMetrics::new(DeltaReadMetricsConfig {
             snapshot_version: 7,
-            reader_backend: DeltaReaderBackend::NativeAsync,
+            reader_backend: ParquetReaderBackend::DirectParquet,
             scan_metadata_exhausted: Some(true),
             scan_partitions_planned: 2,
             files_planned: 2,
@@ -981,7 +945,7 @@ mod tests {
             projection: None,
             remaining: None,
             snapshot_version: 7,
-            backend: DeltaReaderBackend::NativeAsync,
+            backend: ParquetReaderBackend::DirectParquet,
             partition_count: 2,
             started: false,
             done: false,
@@ -1057,13 +1021,13 @@ mod tests {
         let _ = tracing::subscriber::set_global_default(EventFields::default());
         with_default(subscriber, || {
             tracing::callsite::rebuild_interest_cache();
-            trace_planning_started(7, DeltaReaderBackend::NativeAsync);
-            trace_planning_completed(7, DeltaReaderBackend::NativeAsync, 2);
-            trace_planning_failed(7, DeltaReaderBackend::NativeAsync, &error);
-            trace_execution_started(7, DeltaReaderBackend::NativeAsync, 2);
-            trace_execution_completed(7, DeltaReaderBackend::NativeAsync, 2);
-            trace_execution_failed(7, DeltaReaderBackend::NativeAsync, 2, &error);
-            trace_execution_dropped(7, DeltaReaderBackend::NativeAsync, 2);
+            trace_planning_started(7, ParquetReaderBackend::DirectParquet);
+            trace_planning_completed(7, ParquetReaderBackend::DirectParquet, 2);
+            trace_planning_failed(7, ParquetReaderBackend::DirectParquet, &error);
+            trace_execution_started(7, ParquetReaderBackend::DirectParquet, 2);
+            trace_execution_completed(7, ParquetReaderBackend::DirectParquet, 2);
+            trace_execution_failed(7, ParquetReaderBackend::DirectParquet, 2, &error);
+            trace_execution_dropped(7, ParquetReaderBackend::DirectParquet, 2);
         });
         tracing::callsite::rebuild_interest_cache();
 

--- a/src/reader/backend.rs
+++ b/src/reader/backend.rs
@@ -1,8 +1,4 @@
 //! Data-file reader backend implementations.
 
-#[cfg(feature = "native-async")]
-#[allow(dead_code)]
-pub(crate) mod native_async;
-#[cfg(feature = "official-kernel")]
-#[allow(dead_code)]
-pub(crate) mod official_kernel;
+pub(crate) mod direct_parquet;
+pub(crate) mod kernel_reader;

--- a/src/reader/backend/direct_parquet.rs
+++ b/src/reader/backend/direct_parquet.rs
@@ -1,4 +1,4 @@
-//! NativeAsync Parquet data-file reader.
+//! Direct asynchronous Parquet data-file reader.
 
 mod metered_object_store;
 mod row_group_pruning;
@@ -31,7 +31,7 @@ use tokio::sync::OnceCell;
 
 use self::{
     metered_object_store::MeteredParquetObjectStore,
-    row_group_pruning::native_async_pruned_row_groups,
+    row_group_pruning::direct_parquet_pruned_row_groups,
 };
 
 const ORIGINAL_ROW_INDEX_COLUMN: &str = "__delta_arrow_reader_original_row_index";
@@ -55,7 +55,7 @@ use crate::{
     },
 };
 
-struct NativeAsyncFileReader {
+struct DirectParquetFileReader {
     engine_context: Arc<DeltaKernelEngineContext>,
     store: Arc<dyn ObjectStore>,
     execution_options: DeltaReaderExecutionOptions,
@@ -64,14 +64,14 @@ struct NativeAsyncFileReader {
 
 /// Parquet footer metadata shared by ranged tasks within one physical scan.
 #[derive(Default)]
-pub(crate) struct NativeAsyncParquetMetadataCache {
+pub(crate) struct DirectParquetMetadataCache {
     /// In-flight or completed footer loads keyed by file path and planned size.
     entries: Mutex<HashMap<(Path, u64), Arc<ParquetMetadataCell>>>,
 }
 
 type ParquetMetadataCell = OnceCell<Arc<ParquetMetaData>>;
 
-impl NativeAsyncParquetMetadataCache {
+impl DirectParquetMetadataCache {
     fn entry(&self, path: &Path, file_size: u64) -> Arc<ParquetMetadataCell> {
         Arc::clone(
             self.entries
@@ -83,20 +83,20 @@ impl NativeAsyncParquetMetadataCache {
     }
 }
 
-struct NativeAsyncParquetObject {
+struct DirectParquetObject {
     store: Arc<dyn ObjectStore>,
     path: Path,
     file_size: u64,
 }
 
-struct NativeAsyncParquetStream {
+struct DirectParquetStream {
     stream: ParquetRecordBatchStream<ParquetObjectReader>,
-    schema_match: NativeAsyncSchemaMatch,
+    schema_match: DirectParquetSchemaMatch,
     include_original_row_index: bool,
 }
 
-struct NativeAsyncFileReadStream {
-    parquet: NativeAsyncParquetStream,
+struct DirectParquetFileReadStream {
+    parquet: DirectParquetStream,
     engine_context: Arc<DeltaKernelEngineContext>,
     kernel_schemas: KernelScanSchemas,
     logical_schema: SchemaRef,
@@ -107,7 +107,7 @@ struct NativeAsyncFileReadStream {
     _permit: FileReadPermit,
 }
 
-struct NativeAsyncFileReadRequest {
+struct DirectParquetFileReadRequest {
     task: DeltaScanFileTask,
     physical_schema: SchemaRef,
     logical_schema: SchemaRef,
@@ -120,62 +120,62 @@ struct NativeAsyncFileReadRequest {
 }
 
 #[derive(Clone)]
-struct NativeAsyncSchemaMatch {
+struct DirectParquetSchemaMatch {
     provider_schema: SchemaRef,
     projected_roots: Vec<usize>,
-    provider_columns: Vec<NativeAsyncProviderColumn>,
+    provider_columns: Vec<DirectParquetProviderColumn>,
     needs_batch_reshape: bool,
 }
 
 #[derive(Clone)]
-enum NativeAsyncProviderColumn {
+enum DirectParquetProviderColumn {
     ProjectedStreamColumn {
         stream_index: usize,
-        field_plan: NativeAsyncFieldPlan,
+        field_plan: DirectParquetFieldPlan,
     },
     Null,
 }
 
 #[derive(Clone)]
-enum NativeAsyncFieldPlan {
+enum DirectParquetFieldPlan {
     Identity,
     Cast {
         target_type: DataType,
     },
     Struct {
-        children: Vec<NativeAsyncStructChild>,
+        children: Vec<DirectParquetStructChild>,
     },
     List {
-        element_plan: Box<NativeAsyncFieldPlan>,
+        element_plan: Box<DirectParquetFieldPlan>,
     },
     Map {
-        key_plan: Box<NativeAsyncFieldPlan>,
-        value_plan: Box<NativeAsyncFieldPlan>,
+        key_plan: Box<DirectParquetFieldPlan>,
+        value_plan: Box<DirectParquetFieldPlan>,
     },
 }
 
-impl NativeAsyncFieldPlan {
+impl DirectParquetFieldPlan {
     fn is_identity(&self) -> bool {
         matches!(self, Self::Identity)
     }
 }
 
 #[derive(Clone)]
-enum NativeAsyncStructChild {
+enum DirectParquetStructChild {
     ProjectedChild {
         child_index: usize,
-        field_plan: NativeAsyncFieldPlan,
+        field_plan: DirectParquetFieldPlan,
     },
     Null,
 }
 
 #[derive(Clone)]
-struct NativeAsyncRootMatch {
+struct DirectParquetRootMatch {
     parquet_root_index: usize,
-    field_plan: NativeAsyncFieldPlan,
+    field_plan: DirectParquetFieldPlan,
 }
 
-impl NativeAsyncFileReader {
+impl DirectParquetFileReader {
     fn new(
         engine_context: Arc<DeltaKernelEngineContext>,
         execution_options: DeltaReaderExecutionOptions,
@@ -195,7 +195,7 @@ impl NativeAsyncFileReader {
 
     async fn load_split_parquet_metadata(
         &self,
-        metadata_cache: Option<&NativeAsyncParquetMetadataCache>,
+        metadata_cache: Option<&DirectParquetMetadataCache>,
         path: &Path,
         file_size: u64,
         reader: &mut ParquetObjectReader,
@@ -217,7 +217,7 @@ impl NativeAsyncFileReader {
     async fn parquet_object_for_task(
         &self,
         task: &DeltaScanFileTask,
-    ) -> Result<NativeAsyncParquetObject, DeltaReaderError> {
+    ) -> Result<DirectParquetObject, DeltaReaderError> {
         let object = self.resolve_parquet_object(task)?;
         if task.parquet_byte_range.is_some() {
             return Ok(object);
@@ -225,6 +225,7 @@ impl NativeAsyncFileReader {
         self.buffer_small_parquet_object(object).await
     }
 
+    #[cfg(test)]
     async fn open_parquet_stream(
         &self,
         task: &DeltaScanFileTask,
@@ -233,7 +234,7 @@ impl NativeAsyncFileReader {
         physical_predicate: Option<&DeltaKernelPredicate>,
         row_predicate: Option<(&DeltaKernelPredicate, &KernelScanSchemas)>,
         include_original_row_index: bool,
-    ) -> Result<NativeAsyncParquetStream, DeltaReaderError> {
+    ) -> Result<DirectParquetStream, DeltaReaderError> {
         self.open_parquet_stream_with_metadata_cache(
             task,
             provider_schema,
@@ -255,8 +256,8 @@ impl NativeAsyncFileReader {
         physical_predicate: Option<&DeltaKernelPredicate>,
         row_predicate: Option<(&DeltaKernelPredicate, &KernelScanSchemas)>,
         include_original_row_index: bool,
-        metadata_cache: Option<&NativeAsyncParquetMetadataCache>,
-    ) -> Result<NativeAsyncParquetStream, DeltaReaderError> {
+        metadata_cache: Option<&DirectParquetMetadataCache>,
+    ) -> Result<DirectParquetStream, DeltaReaderError> {
         let object = self.parquet_object_for_task(task).await?;
         let file_size = object.file_size;
         let path = object.path;
@@ -265,7 +266,7 @@ impl NativeAsyncFileReader {
             Some(hint) => reader.with_footer_size_hint(hint),
             None => reader,
         };
-        let reader_options = native_async_arrow_reader_options(include_original_row_index)
+        let reader_options = direct_parquet_arrow_reader_options(include_original_row_index)
             .boxed()
             .context(DataFileReadSnafu {
                 reason: "parquet_row_index_setup_failed",
@@ -317,7 +318,7 @@ impl NativeAsyncFileReader {
                     reason: "parquet_read_setup_failed",
                 })?
         };
-        let schema_match = build_native_async_schema_match(
+        let schema_match = build_direct_parquet_schema_match(
             builder.parquet_schema(),
             builder.schema(),
             provider_schema,
@@ -325,7 +326,7 @@ impl NativeAsyncFileReader {
         .map_err(|error| data_file_error("parquet_schema_match_failed", error))?;
         let projection =
             ProjectionMask::roots(builder.parquet_schema(), schema_match.projected_roots());
-        let row_groups = native_async_pruned_row_groups(
+        let row_groups = direct_parquet_pruned_row_groups(
             builder.metadata(),
             file_size,
             task.parquet_byte_range.as_ref(),
@@ -342,7 +343,7 @@ impl NativeAsyncFileReader {
             None => builder,
         };
         let row_filter = row_predicate.map(|(predicate, kernel_schemas)| {
-            self.native_async_row_filter(
+            self.direct_parquet_row_filter(
                 predicate,
                 kernel_schemas,
                 &schema_match,
@@ -366,7 +367,7 @@ impl NativeAsyncFileReader {
                 reason: "parquet_read_setup_failed",
             })?;
 
-        Ok(NativeAsyncParquetStream {
+        Ok(DirectParquetStream {
             stream,
             schema_match,
             include_original_row_index,
@@ -375,17 +376,17 @@ impl NativeAsyncFileReader {
 
     async fn open_logical_file_stream(
         self: &Arc<Self>,
-        request: NativeAsyncFileReadRequest,
-    ) -> Result<NativeAsyncFileReadStream, DeltaReaderError> {
+        request: DirectParquetFileReadRequest,
+    ) -> Result<DirectParquetFileReadStream, DeltaReaderError> {
         self.open_logical_file_stream_with_metadata_cache(request, None)
             .await
     }
 
     async fn open_logical_file_stream_with_metadata_cache(
         self: &Arc<Self>,
-        request: NativeAsyncFileReadRequest,
-        metadata_cache: Option<&NativeAsyncParquetMetadataCache>,
-    ) -> Result<NativeAsyncFileReadStream, DeltaReaderError> {
+        request: DirectParquetFileReadRequest,
+        metadata_cache: Option<&DirectParquetMetadataCache>,
+    ) -> Result<DirectParquetFileReadStream, DeltaReaderError> {
         let include_original_row_index = request.task.deletion_vector.is_present();
         let parquet = tokio::select! {
             biased;
@@ -416,7 +417,7 @@ impl NativeAsyncFileReader {
             return Err(cancelled_error());
         }
 
-        Ok(NativeAsyncFileReadStream {
+        Ok(DirectParquetFileReadStream {
             parquet,
             engine_context: Arc::clone(&self.engine_context),
             kernel_schemas: request.kernel_schemas,
@@ -429,11 +430,11 @@ impl NativeAsyncFileReader {
         })
     }
 
-    fn native_async_row_filter(
+    fn direct_parquet_row_filter(
         &self,
         predicate: &DeltaKernelPredicate,
         kernel_schemas: &KernelScanSchemas,
-        schema_match: &NativeAsyncSchemaMatch,
+        schema_match: &DirectParquetSchemaMatch,
         parquet_schema: &SchemaDescriptor,
     ) -> RowFilter {
         let projection = ProjectionMask::roots(parquet_schema, schema_match.projected_roots());
@@ -456,7 +457,7 @@ impl NativeAsyncFileReader {
     fn resolve_parquet_object(
         &self,
         task: &DeltaScanFileTask,
-    ) -> Result<NativeAsyncParquetObject, DeltaReaderError> {
+    ) -> Result<DirectParquetObject, DeltaReaderError> {
         let location = self
             .engine_context
             .table_url()
@@ -473,11 +474,11 @@ impl NativeAsyncFileReader {
         let file_size = task.file_size.ok_or_else(|| {
             data_file_error(
                 "data_file_size_missing",
-                delta_kernel::Error::generic("file size is required for NativeAsync reads"),
+                delta_kernel::Error::generic("file size is required for direct Parquet reads"),
             )
         })?;
 
-        Ok(NativeAsyncParquetObject {
+        Ok(DirectParquetObject {
             store: Arc::clone(&self.store),
             path,
             file_size,
@@ -486,8 +487,8 @@ impl NativeAsyncFileReader {
 
     async fn buffer_small_parquet_object(
         &self,
-        mut object: NativeAsyncParquetObject,
-    ) -> Result<NativeAsyncParquetObject, DeltaReaderError> {
+        mut object: DirectParquetObject,
+    ) -> Result<DirectParquetObject, DeltaReaderError> {
         let should_buffer = self
             .execution_options
             .parquet_full_file_read_threshold()
@@ -548,17 +549,17 @@ fn metadata_with_view_types(
     })
 }
 
-pub(crate) fn native_async_file_executor(
+pub(crate) fn direct_parquet_file_executor(
     plan: &Arc<DeltaScanPlan>,
     output_batch_size: Option<usize>,
     row_predicate: Option<DeltaKernelPredicate>,
 ) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
-    let reader = Arc::new(NativeAsyncFileReader::new(
+    let reader = Arc::new(DirectParquetFileReader::new(
         Arc::clone(&plan.engine_context),
         plan.execution_options,
         plan.metrics.clone(),
     ));
-    native_async_file_executor_from_reader::<false>(
+    direct_parquet_file_executor_from_reader::<false>(
         plan,
         output_batch_size,
         row_predicate,
@@ -567,17 +568,18 @@ pub(crate) fn native_async_file_executor(
     )
 }
 
-pub(crate) fn native_async_file_executor_with_metadata_cache(
+#[cfg(feature = "datafusion")]
+pub(crate) fn direct_parquet_file_executor_with_metadata_cache(
     plan: &Arc<DeltaScanPlan>,
     output_batch_size: Option<usize>,
     row_predicate: Option<DeltaKernelPredicate>,
-    metadata_cache: Arc<NativeAsyncParquetMetadataCache>,
+    metadata_cache: Arc<DirectParquetMetadataCache>,
 ) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
-    native_async_file_executor_from_reader::<true>(
+    direct_parquet_file_executor_from_reader::<true>(
         plan,
         output_batch_size,
         row_predicate,
-        Arc::new(NativeAsyncFileReader::new(
+        Arc::new(DirectParquetFileReader::new(
             Arc::clone(&plan.engine_context),
             plan.execution_options,
             plan.metrics.clone(),
@@ -586,12 +588,12 @@ pub(crate) fn native_async_file_executor_with_metadata_cache(
     )
 }
 
-fn native_async_file_executor_from_reader<const SHARED_METADATA: bool>(
+fn direct_parquet_file_executor_from_reader<const SHARED_METADATA: bool>(
     plan: &Arc<DeltaScanPlan>,
     output_batch_size: Option<usize>,
     row_predicate: Option<DeltaKernelPredicate>,
-    reader: Arc<NativeAsyncFileReader>,
-    metadata_cache: Option<Arc<NativeAsyncParquetMetadataCache>>,
+    reader: Arc<DirectParquetFileReader>,
+    metadata_cache: Option<Arc<DirectParquetMetadataCache>>,
 ) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
     let physical_schema = Arc::clone(&plan.physical_schema);
     let logical_schema = Arc::clone(&plan.logical_schema);
@@ -610,7 +612,7 @@ fn native_async_file_executor_from_reader<const SHARED_METADATA: bool>(
         let row_predicate = row_predicate.clone();
         let metadata_cache = metadata_cache.clone();
         Box::pin(async move {
-            let request = NativeAsyncFileReadRequest {
+            let request = DirectParquetFileReadRequest {
                 task,
                 physical_schema,
                 logical_schema,
@@ -641,7 +643,8 @@ fn native_async_file_executor_from_reader<const SHARED_METADATA: bool>(
     })
 }
 
-impl NativeAsyncParquetStream {
+impl DirectParquetStream {
+    #[cfg(test)]
     async fn next_batch(&mut self) -> Result<Option<RecordBatch>, DeltaReaderError> {
         self.next_batch_with_original_row_indexes()
             .await
@@ -690,7 +693,7 @@ impl NativeAsyncParquetStream {
     }
 }
 
-impl NativeAsyncFileReadStream {
+impl DirectParquetFileReadStream {
     async fn next_batch(&mut self) -> Result<Option<RecordBatch>, DeltaReaderError> {
         let next = tokio::select! {
             biased;
@@ -721,7 +724,7 @@ impl NativeAsyncFileReadStream {
         let logical_batch = align_batch_to_logical_schema(
             logical_batch,
             &self.logical_schema,
-            "NativeAsync output does not match the planned logical schema",
+            "Direct Parquet output does not match the planned logical schema",
         )?;
         let logical_batch = match self.deletion_vector.as_mut() {
             Some(deletion_vector) => deletion_vector
@@ -732,7 +735,7 @@ impl NativeAsyncFileReadStream {
     }
 }
 
-fn native_async_arrow_reader_options(
+fn direct_parquet_arrow_reader_options(
     include_original_row_index: bool,
 ) -> parquet::errors::Result<ArrowReaderOptions> {
     if !include_original_row_index {
@@ -752,7 +755,7 @@ fn cancelled_error() -> DeltaReaderError {
     .build()
 }
 
-impl NativeAsyncSchemaMatch {
+impl DirectParquetSchemaMatch {
     fn projected_roots(&self) -> impl Iterator<Item = usize> + '_ {
         self.projected_roots.iter().copied()
     }
@@ -766,7 +769,7 @@ impl NativeAsyncSchemaMatch {
             .iter()
             .zip(self.provider_schema.fields())
             .map(|(column, field)| match column {
-                NativeAsyncProviderColumn::ProjectedStreamColumn {
+                DirectParquetProviderColumn::ProjectedStreamColumn {
                     stream_index,
                     field_plan,
                 } => reshape_array_to_provider_field(
@@ -774,7 +777,7 @@ impl NativeAsyncSchemaMatch {
                     field,
                     field_plan,
                 ),
-                NativeAsyncProviderColumn::Null => {
+                DirectParquetProviderColumn::Null => {
                     Ok(new_null_array(field.data_type(), batch.num_rows()))
                 }
             })
@@ -785,11 +788,11 @@ impl NativeAsyncSchemaMatch {
     }
 }
 
-fn build_native_async_schema_match(
+fn build_direct_parquet_schema_match(
     parquet_schema: &SchemaDescriptor,
     parquet_arrow_schema: &SchemaRef,
     provider_schema: SchemaRef,
-) -> Result<NativeAsyncSchemaMatch, delta_kernel::Error> {
+) -> Result<DirectParquetSchemaMatch, delta_kernel::Error> {
     let root_matches = provider_schema
         .fields()
         .iter()
@@ -819,7 +822,7 @@ fn build_native_async_schema_match(
                 .iter()
                 .position(|root| *root == root_match.parquet_root_index)
                 .map(
-                    |stream_index| NativeAsyncProviderColumn::ProjectedStreamColumn {
+                    |stream_index| DirectParquetProviderColumn::ProjectedStreamColumn {
                         stream_index,
                         field_plan: root_match.field_plan.clone(),
                     },
@@ -827,7 +830,7 @@ fn build_native_async_schema_match(
                 .ok_or_else(|| {
                     delta_kernel::Error::generic("matched Parquet root was not projected")
                 }),
-            None if provider_field.is_nullable() => Ok(NativeAsyncProviderColumn::Null),
+            None if provider_field.is_nullable() => Ok(DirectParquetProviderColumn::Null),
             None => Err(delta_kernel::Error::generic(format!(
                 "non-nullable provider field '{}' is missing from the Parquet file",
                 provider_field.name()
@@ -839,7 +842,7 @@ fn build_native_async_schema_match(
         .zip(provider_schema.fields())
         .enumerate()
         .any(|(provider_index, (column, provider_field))| match column {
-            NativeAsyncProviderColumn::ProjectedStreamColumn {
+            DirectParquetProviderColumn::ProjectedStreamColumn {
                 stream_index,
                 field_plan,
             } => {
@@ -850,10 +853,10 @@ fn build_native_async_schema_match(
                         .and_then(|root| parquet_arrow_schema.fields().get(*root))
                         .is_none_or(|file_field| file_field.name() != provider_field.name())
             }
-            NativeAsyncProviderColumn::Null => true,
+            DirectParquetProviderColumn::Null => true,
         });
 
-    Ok(NativeAsyncSchemaMatch {
+    Ok(DirectParquetSchemaMatch {
         provider_schema,
         projected_roots,
         provider_columns,
@@ -865,7 +868,7 @@ fn match_provider_field_to_parquet_root(
     provider_field: &Field,
     parquet_roots: &[TypePtr],
     parquet_arrow_schema: &SchemaRef,
-) -> Result<Option<NativeAsyncRootMatch>, delta_kernel::Error> {
+) -> Result<Option<DirectParquetRootMatch>, delta_kernel::Error> {
     if let Some(field_id) = arrow_field_id(provider_field)? {
         let matches = parquet_roots
             .iter()
@@ -874,7 +877,7 @@ fn match_provider_field_to_parquet_root(
             .collect::<Vec<_>>();
         match matches.as_slice() {
             [index] => {
-                return Ok(Some(NativeAsyncRootMatch {
+                return Ok(Some(DirectParquetRootMatch {
                     parquet_root_index: *index,
                     field_plan: build_matched_field_plan(
                         provider_field,
@@ -902,7 +905,7 @@ fn match_provider_field_to_parquet_root(
         return Ok(None);
     };
 
-    Ok(Some(NativeAsyncRootMatch {
+    Ok(Some(DirectParquetRootMatch {
         parquet_root_index: index,
         field_plan: build_matched_field_plan(
             provider_field,
@@ -918,7 +921,7 @@ fn build_matched_field_plan(
     file_field: &Field,
     parquet_field: &parquet::schema::types::Type,
     path: &str,
-) -> Result<NativeAsyncFieldPlan, delta_kernel::Error> {
+) -> Result<DirectParquetFieldPlan, delta_kernel::Error> {
     match (provider_field.data_type(), file_field.data_type()) {
         (DataType::Struct(provider_fields), DataType::Struct(file_fields)) => {
             build_matched_struct_field_plan(
@@ -950,10 +953,10 @@ fn build_matched_field_plan(
                 path,
             )
         }
-        _ => native_async_leaf_cast_plan(provider_field.data_type(), file_field.data_type())
+        _ => direct_parquet_leaf_cast_plan(provider_field.data_type(), file_field.data_type())
             .map(|target_type| match target_type {
-                Some(target_type) => NativeAsyncFieldPlan::Cast { target_type },
-                None => NativeAsyncFieldPlan::Identity,
+                Some(target_type) => DirectParquetFieldPlan::Cast { target_type },
+                None => DirectParquetFieldPlan::Identity,
             })
             .map_err(|()| {
                 incompatible_parquet_type(path, provider_field.data_type(), file_field.data_type())
@@ -968,7 +971,7 @@ fn build_matched_map_field_plan(
     file_entries: &Arc<Field>,
     parquet_field: &parquet::schema::types::Type,
     path: &str,
-) -> Result<NativeAsyncFieldPlan, delta_kernel::Error> {
+) -> Result<DirectParquetFieldPlan, delta_kernel::Error> {
     let (provider_key, provider_value) = map_entry_fields(provider_entries, path)?;
     let (file_key, file_value) = map_entry_fields(file_entries, path)?;
     let key_plan = build_matched_field_plan(
@@ -988,12 +991,12 @@ fn build_matched_map_field_plan(
         || !key_plan.is_identity()
         || !value_plan.is_identity()
     {
-        Ok(NativeAsyncFieldPlan::Map {
+        Ok(DirectParquetFieldPlan::Map {
             key_plan: Box::new(key_plan),
             value_plan: Box::new(value_plan),
         })
     } else {
-        Ok(NativeAsyncFieldPlan::Identity)
+        Ok(DirectParquetFieldPlan::Identity)
     }
 }
 
@@ -1057,7 +1060,7 @@ fn build_matched_list_field_plan(
     file_element: &Arc<Field>,
     parquet_field: &parquet::schema::types::Type,
     path: &str,
-) -> Result<NativeAsyncFieldPlan, delta_kernel::Error> {
+) -> Result<DirectParquetFieldPlan, delta_kernel::Error> {
     let element_path = format!("{path}.element");
     let element_plan = build_matched_field_plan(
         provider_element,
@@ -1065,7 +1068,7 @@ fn build_matched_list_field_plan(
         parquet_list_element_field(parquet_field, path)?,
         &element_path,
     )?;
-    if matches!(element_plan, NativeAsyncFieldPlan::Cast { .. }) {
+    if matches!(element_plan, DirectParquetFieldPlan::Cast { .. }) {
         return Err(incompatible_parquet_type(
             &element_path,
             provider_element.data_type(),
@@ -1073,11 +1076,11 @@ fn build_matched_list_field_plan(
         ));
     }
     if file_field.data_type() != provider_field.data_type() || !element_plan.is_identity() {
-        Ok(NativeAsyncFieldPlan::List {
+        Ok(DirectParquetFieldPlan::List {
             element_plan: Box::new(element_plan),
         })
     } else {
-        Ok(NativeAsyncFieldPlan::Identity)
+        Ok(DirectParquetFieldPlan::Identity)
     }
 }
 
@@ -1112,7 +1115,7 @@ fn build_matched_struct_field_plan(
     file_fields: &Fields,
     parquet_field: &parquet::schema::types::Type,
     path: &str,
-) -> Result<NativeAsyncFieldPlan, delta_kernel::Error> {
+) -> Result<DirectParquetFieldPlan, delta_kernel::Error> {
     let parquet_children = parquet_field.get_fields();
     if parquet_children.len() != file_fields.len() {
         return Err(delta_kernel::Error::generic(format!(
@@ -1133,7 +1136,7 @@ fn build_matched_struct_field_plan(
     let needs_reshape = file_field.data_type() != provider_field.data_type()
         || children.iter().zip(provider_fields.iter()).enumerate().any(
             |(provider_index, (child, provider_child))| match child {
-                NativeAsyncStructChild::ProjectedChild {
+                DirectParquetStructChild::ProjectedChild {
                     child_index,
                     field_plan,
                 } => {
@@ -1143,13 +1146,13 @@ fn build_matched_struct_field_plan(
                             .get(*child_index)
                             .is_none_or(|file_child| file_child.name() != provider_child.name())
                 }
-                NativeAsyncStructChild::Null => true,
+                DirectParquetStructChild::Null => true,
             },
         );
     if needs_reshape {
-        Ok(NativeAsyncFieldPlan::Struct { children })
+        Ok(DirectParquetFieldPlan::Struct { children })
     } else {
-        Ok(NativeAsyncFieldPlan::Identity)
+        Ok(DirectParquetFieldPlan::Identity)
     }
 }
 
@@ -1158,7 +1161,7 @@ fn match_provider_struct_child(
     file_fields: &Fields,
     parquet_children: &[TypePtr],
     path: &str,
-) -> Result<NativeAsyncStructChild, delta_kernel::Error> {
+) -> Result<DirectParquetStructChild, delta_kernel::Error> {
     if let Some(field_id) = arrow_field_id(provider_child)? {
         let matches = parquet_children
             .iter()
@@ -1174,7 +1177,7 @@ fn match_provider_struct_child(
                         "provider field '{path}' matched Parquet field id {field_id} without Arrow metadata"
                     ))
                 })?;
-                return Ok(NativeAsyncStructChild::ProjectedChild {
+                return Ok(DirectParquetStructChild::ProjectedChild {
                     child_index: *index,
                     field_plan: build_matched_field_plan(
                         provider_child,
@@ -1198,14 +1201,14 @@ fn match_provider_struct_child(
         .find(|(_, file_child)| file_child.name() == provider_child.name())
     else {
         return if provider_child.is_nullable() {
-            Ok(NativeAsyncStructChild::Null)
+            Ok(DirectParquetStructChild::Null)
         } else {
             Err(delta_kernel::Error::generic(format!(
                 "non-nullable provider field '{path}' is missing from the Parquet file"
             )))
         };
     };
-    Ok(NativeAsyncStructChild::ProjectedChild {
+    Ok(DirectParquetStructChild::ProjectedChild {
         child_index: index,
         field_plan: build_matched_field_plan(
             provider_child,
@@ -1226,7 +1229,7 @@ fn incompatible_parquet_type(
     ))
 }
 
-fn native_async_leaf_cast_plan(
+fn direct_parquet_leaf_cast_plan(
     provider_type: &DataType,
     file_type: &DataType,
 ) -> Result<Option<DataType>, ()> {
@@ -1242,7 +1245,7 @@ fn native_async_leaf_cast_plan(
         (Int32, Int64 | Float64) => Ok(Some(provider_type.clone())),
         (Float32, Float64) => Ok(Some(provider_type.clone())),
         (source_type, Decimal128(precision, scale))
-            if native_async_can_upcast_to_decimal(source_type, *precision, *scale) =>
+            if direct_parquet_can_upcast_to_decimal(source_type, *precision, *scale) =>
         {
             Ok(Some(provider_type.clone()))
         }
@@ -1255,7 +1258,7 @@ fn native_async_leaf_cast_plan(
     }
 }
 
-fn native_async_can_upcast_to_decimal(
+fn direct_parquet_can_upcast_to_decimal(
     source_type: &DataType,
     target_precision: u8,
     target_scale: i8,
@@ -1298,14 +1301,14 @@ fn parquet_field_id(parquet_field: &TypePtr) -> Option<i32> {
 fn reshape_array_to_provider_field(
     array: ArrayRef,
     provider_field: &Field,
-    field_plan: &NativeAsyncFieldPlan,
+    field_plan: &DirectParquetFieldPlan,
 ) -> Result<ArrayRef, delta_kernel::Error> {
     match field_plan {
-        NativeAsyncFieldPlan::Identity => Ok(array),
-        NativeAsyncFieldPlan::Cast { target_type } => {
+        DirectParquetFieldPlan::Identity => Ok(array),
+        DirectParquetFieldPlan::Cast { target_type } => {
             cast(array.as_ref(), target_type).map_err(delta_kernel::Error::from)
         }
-        NativeAsyncFieldPlan::Struct { children } => {
+        DirectParquetFieldPlan::Struct { children } => {
             let DataType::Struct(provider_fields) = provider_field.data_type() else {
                 return Err(delta_kernel::Error::generic(format!(
                     "provider field '{}' expected struct reshape plan but has type {}",
@@ -1327,7 +1330,7 @@ fn reshape_array_to_provider_field(
                 .iter()
                 .zip(provider_fields.iter())
                 .map(|(child, provider_child)| match child {
-                    NativeAsyncStructChild::ProjectedChild {
+                    DirectParquetStructChild::ProjectedChild {
                         child_index,
                         field_plan,
                     } => reshape_array_to_provider_field(
@@ -1335,7 +1338,7 @@ fn reshape_array_to_provider_field(
                         provider_child,
                         field_plan,
                     ),
-                    NativeAsyncStructChild::Null => Ok(new_null_array(
+                    DirectParquetStructChild::Null => Ok(new_null_array(
                         provider_child.data_type(),
                         struct_array.len(),
                     )),
@@ -1347,7 +1350,7 @@ fn reshape_array_to_provider_field(
                 struct_array.nulls().cloned(),
             )))
         }
-        NativeAsyncFieldPlan::List { element_plan } => {
+        DirectParquetFieldPlan::List { element_plan } => {
             let DataType::List(provider_element) = provider_field.data_type() else {
                 return Err(delta_kernel::Error::generic(format!(
                     "provider field '{}' expected list reshape plan but has type {}",
@@ -1376,7 +1379,7 @@ fn reshape_array_to_provider_field(
             .map(|array| Arc::new(array) as ArrayRef)
             .map_err(delta_kernel::Error::from)
         }
-        NativeAsyncFieldPlan::Map {
+        DirectParquetFieldPlan::Map {
             key_plan,
             value_plan,
         } => {
@@ -1478,21 +1481,20 @@ mod tests {
     use parquet::file::properties::{EnabledStatistics, WriterProperties};
 
     use super::{
-        NativeAsyncFileReadRequest, NativeAsyncFileReader, NativeAsyncParquetMetadataCache,
-        data_file_error, native_async_file_executor,
+        DirectParquetFileReadRequest, DirectParquetFileReader, DirectParquetMetadataCache,
+        data_file_error, direct_parquet_file_executor,
     };
-    #[cfg(feature = "official-kernel")]
-    use crate::reader::backend::official_kernel::official_kernel_file_executor;
+    use crate::reader::backend::kernel_reader::delta_kernel_file_executor;
     use crate::{
-        DeltaReadMetrics, DeltaReaderBackend, DeltaReaderError, DeltaReaderExecutionOptions,
-        DeltaSnapshotSelection, DeltaStorageOptions,
+        DeltaReadMetrics, DeltaReaderError, DeltaReaderExecutionOptions, DeltaSnapshotSelection,
+        DeltaStorageOptions, ParquetReaderBackend,
         delta::kernel::{
             DeltaKernelEngineContext, DeltaKernelPredicate, KernelPhysicalToLogicalTransform,
             KernelScanFileMetadata,
         },
         delta::snapshot::load_delta_table_snapshot_blocking,
         reader::{
-            backend::native_async::metered_object_store::MeteredParquetObjectStore,
+            backend::direct_parquet::metered_object_store::MeteredParquetObjectStore,
             metrics::DeltaReadMetricsConfig,
             planning::{DeltaScanFileTask, DeltaScanPartitionTargetOptions, plan_scan},
             scheduling::{
@@ -1760,7 +1762,7 @@ mod tests {
     fn metrics() -> DeltaReadMetrics {
         DeltaReadMetrics::new(DeltaReadMetricsConfig {
             snapshot_version: 1,
-            reader_backend: DeltaReaderBackend::NativeAsync,
+            reader_backend: ParquetReaderBackend::DirectParquet,
             scan_metadata_exhausted: Some(true),
             scan_partitions_planned: 1,
             files_planned: 1,
@@ -1774,14 +1776,18 @@ mod tests {
         root: &TestDir,
         options: DeltaReaderExecutionOptions,
         metrics: DeltaReadMetrics,
-    ) -> Result<NativeAsyncFileReader, Box<dyn std::error::Error>> {
+    ) -> Result<DirectParquetFileReader, Box<dyn std::error::Error>> {
         let table_url = url::Url::from_directory_path(root.path())
             .map_err(|()| "temporary table path cannot become a file URL")?;
         let engine_context = Arc::new(DeltaKernelEngineContext::build(
             table_url,
             &DeltaStorageOptions::default(),
         )?);
-        Ok(NativeAsyncFileReader::new(engine_context, options, metrics))
+        Ok(DirectParquetFileReader::new(
+            engine_context,
+            options,
+            metrics,
+        ))
     }
 
     fn task(path: &str, file_size: Option<u64>) -> Result<DeltaScanFileTask, DeltaReaderError> {
@@ -1918,7 +1924,7 @@ mod tests {
         });
         let metadata = serde_json::json!({
             "metaData": {
-                "id": "native-async-pipeline-test",
+                "id": "direct-parquet-pipeline-test",
                 "format": {"provider": "parquet", "options": {}},
                 "schemaString": schema.to_string(),
                 "partitionColumns": ["region"],
@@ -2005,7 +2011,7 @@ mod tests {
             root,
             full_file_threshold,
             Some(64 * 1024),
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             true,
         )
     }
@@ -2014,7 +2020,7 @@ mod tests {
         root: &TestDir,
         full_file_threshold: Option<usize>,
         metadata_size_hint: Option<usize>,
-        backend: DeltaReaderBackend,
+        backend: ParquetReaderBackend,
         with_predicate: bool,
     ) -> Result<Arc<crate::reader::planning::DeltaScanPlan>, Box<dyn std::error::Error>> {
         pipeline_plan_for_backend_at(
@@ -2033,7 +2039,7 @@ mod tests {
         root: &TestDir,
         full_file_threshold: Option<usize>,
         metadata_size_hint: Option<usize>,
-        backend: DeltaReaderBackend,
+        backend: ParquetReaderBackend,
         with_predicate: bool,
         selection: DeltaSnapshotSelection,
         target_partitions: usize,
@@ -2067,10 +2073,9 @@ mod tests {
         )?))
     }
 
-    #[cfg(feature = "official-kernel")]
     fn predicate_pipeline_plan_for_backend(
         root: &TestDir,
-        backend: DeltaReaderBackend,
+        backend: ParquetReaderBackend,
         predicate: Predicate,
     ) -> Result<Arc<crate::reader::planning::DeltaScanPlan>, Box<dyn std::error::Error>> {
         let snapshot = load_delta_table_snapshot_blocking(
@@ -2126,7 +2131,7 @@ mod tests {
         row_predicate: Option<DeltaKernelPredicate>,
     ) -> Result<Vec<RecordBatch>, DeltaReaderError> {
         let execution = DeltaScanExecution::new(Arc::clone(&plan));
-        let executor = native_async_file_executor(&plan, Some(2), row_predicate);
+        let executor = direct_parquet_file_executor(&plan, Some(2), row_predicate);
         let mut batches = Vec::new();
         for partition in 0..plan.partitions.len() {
             let mut stream = execution.partition_stream(
@@ -2141,12 +2146,11 @@ mod tests {
         Ok(batches)
     }
 
-    #[cfg(feature = "official-kernel")]
-    async fn execute_official_plan(
+    async fn execute_kernel_plan(
         plan: Arc<crate::reader::planning::DeltaScanPlan>,
     ) -> Result<Vec<RecordBatch>, DeltaReaderError> {
         let execution = DeltaScanExecution::new(Arc::clone(&plan));
-        let executor = official_kernel_file_executor(&plan);
+        let executor = delta_kernel_file_executor(&plan);
         let mut batches = Vec::new();
         for partition in 0..plan.partitions.len() {
             let mut stream = execution.partition_stream(
@@ -2182,14 +2186,14 @@ mod tests {
         gate_request: GateRequest,
     ) -> Result<
         (
-            Arc<NativeAsyncFileReader>,
+            Arc<DirectParquetFileReader>,
             Arc<GatedObjectStore>,
             DeltaScanFileTask,
         ),
         Box<dyn std::error::Error>,
     > {
         let task = plan.partitions[0].file_tasks[0].clone();
-        let mut reader = NativeAsyncFileReader::new(
+        let mut reader = DirectParquetFileReader::new(
             Arc::clone(&plan.engine_context),
             plan.execution_options,
             plan.metrics.clone(),
@@ -2212,11 +2216,11 @@ mod tests {
         gate_request: GateRequest,
     ) -> Result<
         (
-            Arc<NativeAsyncFileReader>,
+            Arc<DirectParquetFileReader>,
             Arc<GatedObjectStore>,
             DeltaScanFileTask,
             Arc<Schema>,
-            Arc<NativeAsyncParquetMetadataCache>,
+            Arc<DirectParquetMetadataCache>,
         ),
         Box<dyn std::error::Error>,
     > {
@@ -2244,7 +2248,7 @@ mod tests {
             gated,
             task,
             schema,
-            Arc::new(NativeAsyncParquetMetadataCache::default()),
+            Arc::new(DirectParquetMetadataCache::default()),
         ))
     }
 
@@ -2253,8 +2257,8 @@ mod tests {
         task: DeltaScanFileTask,
         permit: FileReadPermit,
         cancellation: ScanCancellation,
-    ) -> NativeAsyncFileReadRequest {
-        NativeAsyncFileReadRequest {
+    ) -> DirectParquetFileReadRequest {
+        DirectParquetFileReadRequest {
             task,
             physical_schema: Arc::clone(&plan.physical_schema),
             logical_schema: Arc::clone(&plan.logical_schema),
@@ -2271,7 +2275,7 @@ mod tests {
         options: DeltaReaderExecutionOptions,
     ) -> Result<Arc<ScanReadLimiter>, DeltaReaderError> {
         let options = options
-            .with_native_async_prefetch_file_count_per_partition(1)?
+            .with_prefetch_file_count_per_partition(1)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?;
         Ok(ScanReadLimiter::new(options, 1, 1))
@@ -2380,7 +2384,7 @@ mod tests {
         writer.write(&batch)?;
         writer.close()?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(fs::File::open(file_path)?)?;
-        let schema_match = super::build_native_async_schema_match(
+        let schema_match = super::build_direct_parquet_schema_match(
             builder.parquet_schema(),
             builder.schema(),
             provider_schema,
@@ -2399,7 +2403,7 @@ mod tests {
     #[tokio::test]
     async fn resolves_table_relative_paths_and_requires_file_size()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-object-resolution")?;
+        let root = TestDir::new("direct-object-resolution")?;
         fs::write(root.path().join("part.parquet"), b"data")?;
         let metrics = metrics();
         let reader = reader(&root, DeltaReaderExecutionOptions::new(), metrics.clone())?;
@@ -2439,7 +2443,7 @@ mod tests {
             &DeltaStorageOptions::default(),
         )?);
         let store = engine_context.object_store();
-        let reader = NativeAsyncFileReader::new(
+        let reader = DirectParquetFileReader::new(
             engine_context,
             DeltaReaderExecutionOptions::new(),
             metrics(),
@@ -2473,7 +2477,7 @@ mod tests {
     #[tokio::test]
     async fn regression_invalid_parquet_range_is_redacted_at_the_reader_boundary()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-invalid-parquet-range")?;
+        let root = TestDir::new("direct-invalid-parquet-range")?;
         let bytes = parquet_bytes()?;
         fs::write(root.path().join("secret.parquet"), &bytes)?;
         let file_size = u64::try_from(bytes.len())?;
@@ -2504,7 +2508,7 @@ mod tests {
     async fn split_tasks_share_one_concurrent_parquet_metadata_load()
     -> Result<(), Box<dyn std::error::Error>> {
         let (reader, gated, mut first_task, schema, metadata_cache) = gated_split_metadata_reader(
-            "native-split-metadata-single-flight",
+            "direct-split-metadata-single-flight",
             GateRequest::Range(1),
         )
         .await?;
@@ -2567,7 +2571,7 @@ mod tests {
     #[tokio::test]
     async fn failed_split_metadata_load_can_be_retried() -> Result<(), Box<dyn std::error::Error>> {
         let (reader, gated, task, schema, metadata_cache) = gated_split_metadata_reader(
-            "native-split-metadata-retry",
+            "direct-split-metadata-retry",
             GateRequest::Range(usize::MAX),
         )
         .await?;
@@ -2616,7 +2620,7 @@ mod tests {
     async fn cancelled_split_metadata_load_wakes_a_retrying_task()
     -> Result<(), Box<dyn std::error::Error>> {
         let (reader, gated, task, schema, metadata_cache) = gated_split_metadata_reader(
-            "native-split-metadata-cancellation",
+            "direct-split-metadata-cancellation",
             GateRequest::Range(1),
         )
         .await?;
@@ -2731,7 +2735,7 @@ mod tests {
     #[tokio::test]
     async fn buffered_store_is_owned_only_by_its_file_object()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-file-local-buffer")?;
+        let root = TestDir::new("direct-file-local-buffer")?;
         let bytes = parquet_bytes()?;
         fs::write(root.path().join("part.parquet"), &bytes)?;
         let metrics = metrics();
@@ -2762,7 +2766,7 @@ mod tests {
     #[tokio::test]
     async fn buffered_file_stream_holds_exactly_one_admission_permit_until_drop()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-buffer-permit-bound")?;
+        let root = TestDir::new("direct-buffer-permit-bound")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -2773,7 +2777,7 @@ mod tests {
         )?;
         write_partitioned_dv_table(&root, &parquet_bytes)?;
         let plan = pipeline_plan(&root, Some(parquet_bytes.len()))?;
-        let reader = Arc::new(NativeAsyncFileReader::new(
+        let reader = Arc::new(DirectParquetFileReader::new(
             Arc::clone(&plan.engine_context),
             plan.execution_options,
             plan.metrics.clone(),
@@ -2808,7 +2812,7 @@ mod tests {
     #[tokio::test]
     async fn opens_projected_parquet_stream_with_configured_batch_size()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-projected-stream")?;
+        let root = TestDir::new("direct-projected-stream")?;
         let bytes = parquet_bytes()?;
         fs::write(root.path().join("part.parquet"), &bytes)?;
         let reader = reader(&root, DeltaReaderExecutionOptions::new(), metrics())?;
@@ -2848,7 +2852,7 @@ mod tests {
     #[tokio::test]
     async fn reads_full_ordered_and_empty_physical_projections()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-projection-shapes")?;
+        let root = TestDir::new("direct-projection-shapes")?;
         let bytes = parquet_bytes()?;
         fs::write(root.path().join("part.parquet"), &bytes)?;
         let reader = reader(&root, DeltaReaderExecutionOptions::new(), metrics())?;
@@ -2898,7 +2902,7 @@ mod tests {
     #[tokio::test]
     async fn footer_hint_controls_metadata_request_count_and_bytes()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-footer-hint")?;
+        let root = TestDir::new("direct-footer-hint")?;
         let bytes = parquet_bytes()?;
         fs::write(root.path().join("part.parquet"), &bytes)?;
         let file_size = u64::try_from(bytes.len())?;
@@ -2941,7 +2945,7 @@ mod tests {
     #[tokio::test]
     async fn row_group_pruning_is_conservative_and_preserves_rows_when_disabled()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-row-group-pruning")?;
+        let root = TestDir::new("direct-row-group-pruning")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let columns = || vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5, 6])) as ArrayRef];
         let properties = WriterProperties::builder()
@@ -3039,7 +3043,7 @@ mod tests {
     #[tokio::test]
     async fn row_group_pruning_preserves_negative_fixed_len_decimal_stats()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-row-group-negative-decimal")?;
+        let root = TestDir::new("direct-row-group-negative-decimal")?;
         let schema = Arc::new(Schema::new(vec![Field::new(
             "amount",
             DataType::Decimal128(10, 2),
@@ -3079,7 +3083,7 @@ mod tests {
     #[tokio::test]
     async fn scheduler_pipeline_applies_transform_then_dv_and_preserves_hidden_columns()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-scheduler-pipeline")?;
+        let root = TestDir::new("direct-scheduler-pipeline")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let properties = WriterProperties::builder()
             .set_max_row_group_row_count(Some(3))
@@ -3168,7 +3172,7 @@ mod tests {
     #[tokio::test]
     async fn row_predicate_filters_before_scheduler_metrics_and_deletion_vector()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-row-predicate-dv")?;
+        let root = TestDir::new("direct-row-predicate-dv")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -3191,7 +3195,7 @@ mod tests {
                 &root,
                 None,
                 Some(64 * 1024),
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 false,
             )?;
             let metrics = plan.metrics.clone();
@@ -3221,11 +3225,10 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_matches_native_for_transform_relative_dv_and_controls()
+    async fn delta_kernel_matches_direct_for_transform_relative_dv_and_controls()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("official-native-relative-dv-parity")?;
+        let root = TestDir::new("kernel-direct-relative-dv-parity")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -3236,32 +3239,27 @@ mod tests {
         )?;
         write_partitioned_dv_table(&root, &parquet_bytes)?;
 
-        let native_plan = pipeline_plan_for_backend(
+        let direct_plan = pipeline_plan_for_backend(
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             false,
         )?;
-        let native = execute_pipeline_plan(native_plan).await?;
-        let official_default_plan = pipeline_plan_for_backend(
-            &root,
-            None,
-            None,
-            DeltaReaderBackend::OfficialKernel,
-            false,
-        )?;
-        let official_default_metrics = official_default_plan.metrics.clone();
-        let official_default = execute_official_plan(official_default_plan).await?;
-        let official_tuned_plan = pipeline_plan_for_backend(
+        let direct = execute_pipeline_plan(direct_plan).await?;
+        let kernel_default_plan =
+            pipeline_plan_for_backend(&root, None, None, ParquetReaderBackend::DeltaKernel, false)?;
+        let kernel_default_metrics = kernel_default_plan.metrics.clone();
+        let kernel_default = execute_kernel_plan(kernel_default_plan).await?;
+        let kernel_tuned_plan = pipeline_plan_for_backend(
             &root,
             Some(parquet_bytes.len()),
             Some(1),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?;
-        let official_tuned_metrics = official_tuned_plan.metrics.clone();
-        let official_tuned = execute_official_plan(official_tuned_plan).await?;
+        let kernel_tuned_metrics = kernel_tuned_plan.metrics.clone();
+        let kernel_tuned = execute_kernel_plan(kernel_tuned_plan).await?;
 
         let rows = |batches: &[RecordBatch]| -> Result<Vec<(i32, String)>, &'static str> {
             let mut rows = Vec::new();
@@ -3290,25 +3288,25 @@ mod tests {
             (4, "west".to_owned()),
             (6, "west".to_owned()),
         ];
-        assert_eq!(rows(&native)?, expected);
-        assert_eq!(rows(&official_default)?, expected);
-        assert_eq!(rows(&official_tuned)?, expected);
+        assert_eq!(rows(&direct)?, expected);
+        assert_eq!(rows(&kernel_default)?, expected);
+        assert_eq!(rows(&kernel_tuned)?, expected);
         assert!(
-            native
+            direct
                 .iter()
-                .chain(official_default.iter())
-                .chain(official_tuned.iter())
+                .chain(kernel_default.iter())
+                .chain(kernel_tuned.iter())
                 .all(|batch| batch.schema().fields()[0].name() == "id"
                     && batch.schema().fields()[1].name() == "region")
         );
-        let expected_batches = u64::try_from(official_default.len())?;
-        assert_eq!(official_tuned.len(), official_default.len());
+        let expected_batches = u64::try_from(kernel_default.len())?;
+        assert_eq!(kernel_tuned.len(), kernel_default.len());
 
         for metrics in [
-            official_default_metrics.snapshot(),
-            official_tuned_metrics.snapshot(),
+            kernel_default_metrics.snapshot(),
+            kernel_tuned_metrics.snapshot(),
         ] {
-            assert_eq!(metrics.reader_backend, DeltaReaderBackend::OfficialKernel);
+            assert_eq!(metrics.reader_backend, ParquetReaderBackend::DeltaKernel);
             assert_eq!(metrics.scan_partitions_started, 1);
             assert_eq!(metrics.scan_partitions_completed, 1);
             assert_eq!(metrics.files_started, 1);
@@ -3326,11 +3324,10 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_dv_predicate_fallback_preserves_rows_for_residual_filtering()
+    async fn delta_kernel_dv_predicate_fallback_preserves_rows_for_residual_filtering()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("official-dv-predicate-fallback")?;
+        let root = TestDir::new("kernel-dv-predicate-fallback")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -3341,19 +3338,19 @@ mod tests {
         )?;
         write_partitioned_dv_table(&root, &parquet_bytes)?;
 
-        let native = execute_pipeline_plan(pipeline_plan_for_backend(
+        let direct = execute_pipeline_plan(pipeline_plan_for_backend(
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             true,
         )?)
         .await?;
-        let official = execute_official_plan(pipeline_plan_for_backend(
+        let kernel = execute_kernel_plan(pipeline_plan_for_backend(
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             true,
         )?)
         .await?;
@@ -3371,26 +3368,25 @@ mod tests {
                 .collect::<Result<Vec<_>, _>>()
                 .map(|ids| ids.into_iter().flatten().collect())
         };
-        let native_ids = ids(&native)?;
-        let official_ids = ids(&official)?;
+        let direct_ids = ids(&direct)?;
+        let kernel_ids = ids(&kernel)?;
 
-        assert_eq!(native_ids, [4, 6]);
-        assert_eq!(official_ids, [1, 2, 3, 4, 6]);
+        assert_eq!(direct_ids, [4, 6]);
+        assert_eq!(kernel_ids, [1, 2, 3, 4, 6]);
         assert_eq!(
-            official_ids
+            kernel_ids
                 .into_iter()
                 .filter(|id| *id > 3)
                 .collect::<Vec<_>>(),
-            native_ids
+            direct_ids
         );
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_matches_native_for_snapshots_projection_and_non_dv_predicate()
+    async fn delta_kernel_matches_direct_for_snapshots_projection_and_non_dv_predicate()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("official-native-snapshot-predicate-parity")?;
+        let root = TestDir::new("kernel-direct-snapshot-predicate-parity")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -3405,33 +3401,33 @@ mod tests {
             DeltaSnapshotSelection::Latest,
             DeltaSnapshotSelection::Version(0),
         ] {
-            let native = execute_pipeline_plan(pipeline_plan_for_backend_at(
+            let direct = execute_pipeline_plan(pipeline_plan_for_backend_at(
                 &root,
                 None,
                 Some(64 * 1024),
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 true,
                 selection,
                 1,
             )?)
             .await?;
-            let official = execute_official_plan(pipeline_plan_for_backend_at(
+            let kernel = execute_kernel_plan(pipeline_plan_for_backend_at(
                 &root,
                 Some(parquet_bytes.len()),
                 Some(1),
-                DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DeltaKernel,
                 true,
                 selection,
                 1,
             )?)
             .await?;
 
-            assert_eq!(int32_ids(&native)?, [4, 5, 6]);
-            assert_eq!(int32_ids(&official)?, [4, 5, 6]);
+            assert_eq!(int32_ids(&direct)?, [4, 5, 6]);
+            assert_eq!(int32_ids(&kernel)?, [4, 5, 6]);
             assert!(
-                native
+                direct
                     .iter()
-                    .chain(official.iter())
+                    .chain(kernel.iter())
                     .all(|batch| batch.schema().field(0).name() == "id"
                         && batch.schema().field(1).name() == "region")
             );
@@ -3439,11 +3435,10 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_matches_native_for_partition_statistics_and_zero_file_predicates()
+    async fn delta_kernel_matches_direct_for_partition_statistics_and_zero_file_predicates()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("official-native-pruning-parity")?;
+        let root = TestDir::new("kernel-direct-pruning-parity")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let west = parquet_bytes_for(
             Arc::clone(&schema),
@@ -3481,17 +3476,17 @@ mod tests {
         ];
 
         for (predicate, expected, expected_files) in cases {
-            let native_plan = predicate_pipeline_plan_for_backend(
+            let direct_plan = predicate_pipeline_plan_for_backend(
                 &root,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 predicate.clone(),
             )?;
-            let official_plan = predicate_pipeline_plan_for_backend(
+            let kernel_plan = predicate_pipeline_plan_for_backend(
                 &root,
-                DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DeltaKernel,
                 predicate,
             )?;
-            for plan in [&native_plan, &official_plan] {
+            for plan in [&direct_plan, &kernel_plan] {
                 assert_eq!(
                     plan.partitions
                         .iter()
@@ -3500,37 +3495,36 @@ mod tests {
                     expected_files
                 );
             }
-            let native = execute_pipeline_plan(native_plan).await?;
-            let official = execute_official_plan(official_plan).await?;
-            assert_eq!(int32_ids(&native)?, expected);
-            assert_eq!(int32_ids(&official)?, expected);
+            let direct = execute_pipeline_plan(direct_plan).await?;
+            let kernel = execute_kernel_plan(kernel_plan).await?;
+            assert_eq!(int32_ids(&direct)?, expected);
+            assert_eq!(int32_ids(&kernel)?, expected);
         }
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_matches_native_for_inline_deletion_vectors()
+    async fn delta_kernel_matches_direct_for_inline_deletion_vectors()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("official-native-inline-dv-parity")?;
+        let root = TestDir::new("kernel-direct-inline-dv-parity")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes =
             parquet_bytes_for(schema, vec![Arc::new(Int32Array::from_iter_values(1..=30))])?;
         write_partitioned_inline_dv_table(&root, &parquet_bytes)?;
 
-        let native = execute_pipeline_plan(pipeline_plan_for_backend(
+        let direct = execute_pipeline_plan(pipeline_plan_for_backend(
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             false,
         )?)
         .await?;
-        let official = execute_official_plan(pipeline_plan_for_backend(
+        let kernel = execute_kernel_plan(pipeline_plan_for_backend(
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?)
         .await?;
@@ -3538,16 +3532,15 @@ mod tests {
             .filter(|id| ![4, 5, 8, 12, 19, 30].contains(id))
             .collect::<Vec<_>>();
 
-        assert_eq!(int32_ids(&native)?, expected);
-        assert_eq!(int32_ids(&official)?, expected);
+        assert_eq!(int32_ids(&direct)?, expected);
+        assert_eq!(int32_ids(&kernel)?, expected);
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_matches_native_for_empty_and_multiple_partitions()
+    async fn delta_kernel_matches_direct_for_empty_and_multiple_partitions()
     -> Result<(), Box<dyn std::error::Error>> {
-        let empty_root = TestDir::new("official-native-empty-parity")?;
+        let empty_root = TestDir::new("kernel-direct-empty-parity")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let empty_bytes = parquet_bytes_for(
             Arc::clone(&schema),
@@ -3555,33 +3548,33 @@ mod tests {
         )?;
         write_partitioned_non_dv_table(&empty_root, &empty_bytes)?;
         remove_all_data_files_from_log(&empty_root)?;
-        let native_empty_plan = pipeline_plan_for_backend_at(
+        let direct_empty_plan = pipeline_plan_for_backend_at(
             &empty_root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             false,
             DeltaSnapshotSelection::Latest,
             2,
         )?;
-        let official_empty_plan = pipeline_plan_for_backend_at(
+        let kernel_empty_plan = pipeline_plan_for_backend_at(
             &empty_root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
             DeltaSnapshotSelection::Latest,
             2,
         )?;
-        assert!(native_empty_plan.partitions.is_empty());
-        assert!(official_empty_plan.partitions.is_empty());
-        let official_empty_metrics = official_empty_plan.metrics.clone();
-        assert!(execute_pipeline_plan(native_empty_plan).await?.is_empty());
-        assert!(execute_official_plan(official_empty_plan).await?.is_empty());
-        assert_eq!(official_empty_metrics.snapshot().scan_partitions_started, 0);
-        assert_eq!(official_empty_metrics.snapshot().files_started, 0);
+        assert!(direct_empty_plan.partitions.is_empty());
+        assert!(kernel_empty_plan.partitions.is_empty());
+        let kernel_empty_metrics = kernel_empty_plan.metrics.clone();
+        assert!(execute_pipeline_plan(direct_empty_plan).await?.is_empty());
+        assert!(execute_kernel_plan(kernel_empty_plan).await?.is_empty());
+        assert_eq!(kernel_empty_metrics.snapshot().scan_partitions_started, 0);
+        assert_eq!(kernel_empty_metrics.snapshot().files_started, 0);
 
-        let root = TestDir::new("official-native-multi-partition-parity")?;
+        let root = TestDir::new("kernel-direct-multi-partition-parity")?;
         let west = parquet_bytes_for(
             Arc::clone(&schema),
             vec![Arc::new(Int32Array::from_iter_values(1..=6))],
@@ -3589,50 +3582,50 @@ mod tests {
         let east = parquet_bytes_for(schema, vec![Arc::new(Int32Array::from_iter_values(7..=12))])?;
         write_partitioned_non_dv_table(&root, &west)?;
         add_second_partition_file(&root, &east)?;
-        let native_plan = pipeline_plan_for_backend_at(
+        let direct_plan = pipeline_plan_for_backend_at(
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             false,
             DeltaSnapshotSelection::Latest,
             2,
         )?;
-        let official_first_plan = pipeline_plan_for_backend_at(
+        let kernel_first_plan = pipeline_plan_for_backend_at(
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
             DeltaSnapshotSelection::Latest,
             2,
         )?;
-        let official_second_plan = pipeline_plan_for_backend_at(
+        let kernel_second_plan = pipeline_plan_for_backend_at(
             &root,
             Some(east.len()),
             Some(1),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
             DeltaSnapshotSelection::Latest,
             2,
         )?;
-        assert_eq!(native_plan.partitions.len(), 2);
-        assert_eq!(official_first_plan.partitions.len(), 2);
-        assert_eq!(official_second_plan.partitions.len(), 2);
+        assert_eq!(direct_plan.partitions.len(), 2);
+        assert_eq!(kernel_first_plan.partitions.len(), 2);
+        assert_eq!(kernel_second_plan.partitions.len(), 2);
 
-        let official_first_metrics = official_first_plan.metrics.clone();
-        let official_second_metrics = official_second_plan.metrics.clone();
-        let native = execute_pipeline_plan(native_plan).await?;
-        let (official_first, official_second) = tokio::try_join!(
-            execute_official_plan(official_first_plan),
-            execute_official_plan(official_second_plan)
+        let kernel_first_metrics = kernel_first_plan.metrics.clone();
+        let kernel_second_metrics = kernel_second_plan.metrics.clone();
+        let direct = execute_pipeline_plan(direct_plan).await?;
+        let (kernel_first, kernel_second) = tokio::try_join!(
+            execute_kernel_plan(kernel_first_plan),
+            execute_kernel_plan(kernel_second_plan)
         )?;
-        assert_eq!(int32_ids(&native)?, int32_ids(&official_first)?);
-        assert_eq!(int32_ids(&official_first)?, int32_ids(&official_second)?);
-        assert_eq!(int32_ids(&official_first)?.len(), 12);
+        assert_eq!(int32_ids(&direct)?, int32_ids(&kernel_first)?);
+        assert_eq!(int32_ids(&kernel_first)?, int32_ids(&kernel_second)?);
+        assert_eq!(int32_ids(&kernel_first)?.len(), 12);
         for metrics in [
-            official_first_metrics.snapshot(),
-            official_second_metrics.snapshot(),
+            kernel_first_metrics.snapshot(),
+            kernel_second_metrics.snapshot(),
         ] {
             assert_eq!(metrics.scan_partitions_started, 2);
             assert_eq!(metrics.scan_partitions_completed, 2);
@@ -3643,11 +3636,10 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_partition_drop_before_first_poll_starts_no_work()
+    async fn delta_kernel_partition_drop_before_first_poll_starts_no_work()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("official-drop-before-poll")?;
+        let root = TestDir::new("kernel-drop-before-poll")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes =
             parquet_bytes_for(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])?;
@@ -3656,14 +3648,14 @@ mod tests {
             &root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?;
         let execution = DeltaScanExecution::new(Arc::clone(&plan));
         let stream = execution.partition_stream(
             0,
             Arc::new(|_| Ok(FileAdmission::Admit)),
-            official_kernel_file_executor(&plan),
+            delta_kernel_file_executor(&plan),
         )?;
 
         drop(stream);
@@ -3676,11 +3668,10 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_matches_native_for_column_mapping_transform()
+    async fn delta_kernel_matches_direct_for_column_mapping_transform()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("official-native-column-mapping-parity")?;
+        let root = TestDir::new("kernel-direct-column-mapping-parity")?;
         let field = Field::new("phys_id", DataType::Int32, false).with_metadata(HashMap::from([(
             PARQUET_FIELD_ID_META_KEY.to_owned(),
             "1".to_owned(),
@@ -3714,7 +3705,7 @@ mod tests {
         });
         let metadata = serde_json::json!({
             "metaData": {
-                "id": "official-native-column-mapping-parity",
+                "id": "kernel-direct-column-mapping-parity",
                 "format": {"provider": "parquet", "options": {}},
                 "schemaString": schema.to_string(),
                 "partitionColumns": [],
@@ -3758,23 +3749,22 @@ mod tests {
             )
             .map(Arc::new)
         };
-        let native = execute_pipeline_plan(plan(DeltaReaderBackend::NativeAsync)?).await?;
-        let official = execute_official_plan(plan(DeltaReaderBackend::OfficialKernel)?).await?;
+        let direct = execute_pipeline_plan(plan(ParquetReaderBackend::DirectParquet)?).await?;
+        let kernel = execute_kernel_plan(plan(ParquetReaderBackend::DeltaKernel)?).await?;
 
-        assert_eq!(int32_ids(&native)?, [1, 2, 3]);
-        assert_eq!(int32_ids(&official)?, [1, 2, 3]);
+        assert_eq!(int32_ids(&direct)?, [1, 2, 3]);
+        assert_eq!(int32_ids(&kernel)?, [1, 2, 3]);
         assert!(
-            native
+            direct
                 .iter()
-                .chain(official.iter())
+                .chain(kernel.iter())
                 .all(|batch| batch.schema().field(0).name() == "id")
         );
         Ok(())
     }
 
-    #[cfg(feature = "official-kernel")]
     #[tokio::test]
-    async fn official_kernel_reports_redacted_file_dv_transform_and_schema_failures()
+    async fn delta_kernel_reports_redacted_file_dv_transform_and_schema_failures()
     -> Result<(), Box<dyn std::error::Error>> {
         let assert_failed_metrics = |metrics: &crate::DeltaReadMetricsSnapshot,
                                      deletion_vector_failures| {
@@ -3796,13 +3786,13 @@ mod tests {
             vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
         )?;
 
-        let metadata_root = TestDir::new("official-metadata-failure")?;
+        let metadata_root = TestDir::new("kernel-metadata-failure")?;
         write_partitioned_non_dv_table(&metadata_root, &parquet_bytes)?;
         let mut metadata_plan = pipeline_plan_for_backend(
             &metadata_root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?;
         Arc::get_mut(&mut metadata_plan)
@@ -3811,7 +3801,7 @@ mod tests {
             .file_tasks[0]
             .file_size = None;
         let metadata_metrics = metadata_plan.metrics.clone();
-        let error = execute_official_plan(metadata_plan)
+        let error = execute_kernel_plan(metadata_plan)
             .await
             .expect_err("missing size must fail");
         assert_eq!(error.as_str(), "data_file_read");
@@ -3822,13 +3812,13 @@ mod tests {
                 .contains(metadata_root.path().to_string_lossy().as_ref())
         );
 
-        let parquet_root = TestDir::new("official-parquet-failure")?;
+        let parquet_root = TestDir::new("kernel-parquet-failure")?;
         write_partitioned_non_dv_table(&parquet_root, &parquet_bytes)?;
         let parquet_plan = pipeline_plan_for_backend(
             &parquet_root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?;
         let parquet_metrics = parquet_plan.metrics.clone();
@@ -3836,37 +3826,37 @@ mod tests {
             parquet_root.path().join("part.parquet"),
             vec![0; parquet_bytes.len()],
         )?;
-        let error = execute_official_plan(parquet_plan)
+        let error = execute_kernel_plan(parquet_plan)
             .await
             .expect_err("corrupt Parquet must fail");
         assert_eq!(error.as_str(), "data_file_read");
         assert_failed_metrics(&parquet_metrics.snapshot(), 0);
         assert!(!error.to_string().contains("part.parquet"));
 
-        let dv_root = TestDir::new("official-dv-failure")?;
+        let dv_root = TestDir::new("kernel-dv-failure")?;
         write_partitioned_dv_table(&dv_root, &parquet_bytes)?;
         let dv_plan = pipeline_plan_for_backend(
             &dv_root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?;
         let dv_metrics = dv_plan.metrics.clone();
         fs::remove_file(dv_root.path().join(DV_FILE))?;
-        let error = execute_official_plan(dv_plan)
+        let error = execute_kernel_plan(dv_plan)
             .await
             .expect_err("missing DV must fail");
         assert_eq!(error.as_str(), "deletion_vector_read");
         assert_failed_metrics(&dv_metrics.snapshot(), 1);
 
-        let transform_root = TestDir::new("official-transform-failure")?;
+        let transform_root = TestDir::new("kernel-transform-failure")?;
         write_partitioned_non_dv_table(&transform_root, &parquet_bytes)?;
         let mut transform_plan = pipeline_plan_for_backend(
             &transform_root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?;
         Arc::get_mut(&mut transform_plan)
@@ -3877,27 +3867,27 @@ mod tests {
             Expression::Column(ColumnName::new(["sensitive_missing_column"])),
         );
         let transform_metrics = transform_plan.metrics.clone();
-        let error = execute_official_plan(transform_plan)
+        let error = execute_kernel_plan(transform_plan)
             .await
             .expect_err("invalid transform must fail");
         assert_eq!(error.as_str(), "physical_to_logical_transform");
         assert_failed_metrics(&transform_metrics.snapshot(), 0);
         assert!(!error.to_string().contains("sensitive_missing_column"));
 
-        let schema_root = TestDir::new("official-schema-failure")?;
+        let schema_root = TestDir::new("kernel-schema-failure")?;
         write_partitioned_non_dv_table(&schema_root, &parquet_bytes)?;
         let mut schema_plan = pipeline_plan_for_backend(
             &schema_root,
             None,
             Some(64 * 1024),
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DeltaKernel,
             false,
         )?;
         Arc::get_mut(&mut schema_plan)
             .ok_or("expected unique schema plan")?
             .logical_schema = Arc::new(Schema::empty());
         let schema_metrics = schema_plan.metrics.clone();
-        let error = execute_official_plan(schema_plan)
+        let error = execute_kernel_plan(schema_plan)
             .await
             .expect_err("wrong logical schema must fail");
         assert_eq!(
@@ -3911,7 +3901,7 @@ mod tests {
     #[tokio::test]
     async fn scheduler_reads_full_and_projected_non_dv_logical_files()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-non-dv-logical-read")?;
+        let root = TestDir::new("direct-non-dv-logical-read")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes =
             parquet_bytes_for(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])?;
@@ -3979,7 +3969,7 @@ mod tests {
             ("metadata", None, GateRequest::Range(1)),
             ("full-get", Some(usize::MAX), GateRequest::FullGet),
         ] {
-            let root = TestDir::new(&format!("native-cancel-{name}"))?;
+            let root = TestDir::new(&format!("direct-cancel-{name}"))?;
             let parquet_bytes = parquet_bytes()?;
             write_partitioned_dv_table(&root, &parquet_bytes)?;
             let plan = pipeline_plan(&root, threshold)?;
@@ -4025,7 +4015,7 @@ mod tests {
     #[tokio::test]
     async fn cancellation_drops_batch_range_read_and_releases_permit()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-cancel-batch")?;
+        let root = TestDir::new("direct-cancel-batch")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -4076,7 +4066,7 @@ mod tests {
     #[tokio::test]
     async fn reports_redacted_setup_full_get_and_batch_read_errors()
     -> Result<(), Box<dyn std::error::Error>> {
-        let corrupt_root = TestDir::new("native-corrupt-setup")?;
+        let corrupt_root = TestDir::new("direct-corrupt-setup")?;
         fs::write(corrupt_root.path().join("secret.parquet"), b"not parquet")?;
         let corrupt_metrics = metrics();
         let corrupt_reader = reader(
@@ -4111,7 +4101,7 @@ mod tests {
             Some(1)
         );
 
-        let missing_root = TestDir::new("native-missing-full-get")?;
+        let missing_root = TestDir::new("direct-missing-full-get")?;
         let missing_metrics = metrics();
         let missing_reader = reader(
             &missing_root,
@@ -4137,7 +4127,7 @@ mod tests {
             Some(1)
         );
 
-        let range_root = TestDir::new("native-batch-range-error")?;
+        let range_root = TestDir::new("direct-batch-range-error")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -4209,7 +4199,7 @@ mod tests {
     #[tokio::test]
     async fn logical_pipeline_reports_dv_transform_and_schema_errors()
     -> Result<(), Box<dyn std::error::Error>> {
-        let dv_root = TestDir::new("native-dv-error")?;
+        let dv_root = TestDir::new("direct-dv-error")?;
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let parquet_bytes = parquet_bytes_with_properties(
             schema,
@@ -4234,7 +4224,7 @@ mod tests {
             Some(u64::try_from(parquet_bytes.len())?)
         );
 
-        let transform_root = TestDir::new("native-transform-errors")?;
+        let transform_root = TestDir::new("direct-transform-errors")?;
         write_partitioned_dv_table(&transform_root, &parquet_bytes)?;
         let plan = pipeline_plan(&transform_root, None)?;
         let (reader, _gated, task) =
@@ -4278,19 +4268,19 @@ mod tests {
     }
 
     #[test]
-    fn native_async_leaf_cast_plan_matches_timestamp_compatibility()
+    fn direct_parquet_leaf_cast_plan_matches_timestamp_compatibility()
     -> Result<(), Box<dyn std::error::Error>> {
         let target = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
 
         assert_eq!(
-            super::native_async_leaf_cast_plan(
+            super::direct_parquet_leaf_cast_plan(
                 &target,
                 &DataType::Timestamp(TimeUnit::Nanosecond, None)
             ),
             Ok(Some(target.clone()))
         );
         assert_eq!(
-            super::native_async_leaf_cast_plan(
+            super::direct_parquet_leaf_cast_plan(
                 &target,
                 &DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))
             ),
@@ -4301,10 +4291,10 @@ mod tests {
     }
 
     #[test]
-    fn native_async_leaf_cast_plan_rejects_incompatible_primitive_types()
+    fn direct_parquet_leaf_cast_plan_rejects_incompatible_primitive_types()
     -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(
-            super::native_async_leaf_cast_plan(&DataType::Int32, &DataType::Utf8),
+            super::direct_parquet_leaf_cast_plan(&DataType::Int32, &DataType::Utf8),
             Err(())
         );
 
@@ -4312,7 +4302,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_casts_top_level_timestamp_leaf()
+    fn direct_parquet_schema_match_casts_top_level_timestamp_leaf()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_schema = Arc::new(Schema::new(vec![timestamp_us_utc_field("event_ts", true)]));
         let file_schema = Arc::new(Schema::new(vec![Field::new(
@@ -4343,7 +4333,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_reshape_casts_top_level_timestamp_leaf()
+    fn direct_parquet_reshape_casts_top_level_timestamp_leaf()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_field = timestamp_us_utc_field("event_ts", true);
         let array = Arc::new(TimestampNanosecondArray::from(vec![
@@ -4354,7 +4344,7 @@ mod tests {
         let reshaped = super::reshape_array_to_provider_field(
             array,
             &provider_field,
-            &super::NativeAsyncFieldPlan::Cast {
+            &super::DirectParquetFieldPlan::Cast {
                 target_type: provider_field.data_type().clone(),
             },
         )?;
@@ -4371,7 +4361,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_reshape_casts_nested_struct_timestamp_leaf()
+    fn direct_parquet_reshape_casts_nested_struct_timestamp_leaf()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_child = timestamp_us_utc_field("event_ts", true);
         let provider_field = struct_field("payload", vec![provider_child.clone()], true);
@@ -4391,10 +4381,10 @@ mod tests {
         let reshaped = super::reshape_array_to_provider_field(
             array,
             &provider_field,
-            &super::NativeAsyncFieldPlan::Struct {
-                children: vec![super::NativeAsyncStructChild::ProjectedChild {
+            &super::DirectParquetFieldPlan::Struct {
+                children: vec![super::DirectParquetStructChild::ProjectedChild {
                     child_index: 0,
-                    field_plan: super::NativeAsyncFieldPlan::Cast {
+                    field_plan: super::DirectParquetFieldPlan::Cast {
                         target_type: provider_child.data_type().clone(),
                     },
                 }],
@@ -4419,7 +4409,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_casts_list_struct_leaf() -> Result<(), Box<dyn std::error::Error>>
+    fn direct_parquet_schema_match_casts_list_struct_leaf() -> Result<(), Box<dyn std::error::Error>>
     {
         let provider_element = Field::new(
             "element",
@@ -4514,7 +4504,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_rejects_list_primitive_leaf_cast()
+    fn direct_parquet_schema_match_rejects_list_primitive_leaf_cast()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_schema = Arc::new(Schema::new(vec![
             Field::new(
@@ -4559,7 +4549,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_casts_map_key_leaf() -> Result<(), Box<dyn std::error::Error>> {
+    fn direct_parquet_schema_match_casts_map_key_leaf() -> Result<(), Box<dyn std::error::Error>> {
         let provider_schema = Arc::new(Schema::new(vec![map_field(
             "attributes",
             Field::new("key", DataType::Int64, false),
@@ -4627,7 +4617,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_recurses_by_nested_field_id_before_names()
+    fn direct_parquet_schema_match_recurses_by_nested_field_id_before_names()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_profile_fields = vec![
             Field::new("first_name", DataType::Utf8, true).with_metadata(field_id_metadata(11)),
@@ -4689,7 +4679,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_reshapes_list_struct_elements_by_field_id()
+    fn direct_parquet_schema_match_reshapes_list_struct_elements_by_field_id()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_address_fields = vec![
             Field::new("city", DataType::Utf8, true).with_metadata(field_id_metadata(11)),
@@ -4779,7 +4769,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_recurses_by_local_nested_name_fallback()
+    fn direct_parquet_schema_match_recurses_by_local_nested_name_fallback()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_profile_fields = vec![
             Field::new("age", DataType::Int32, true),
@@ -4839,7 +4829,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_null_fills_missing_nullable_nested_child()
+    fn direct_parquet_schema_match_null_fills_missing_nullable_nested_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_profile_fields = vec![
             Field::new("age", DataType::Int32, true),
@@ -4886,7 +4876,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_null_fills_missing_nullable_list_struct_child()
+    fn direct_parquet_schema_match_null_fills_missing_nullable_list_struct_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_address_fields = vec![
             Field::new("zip", DataType::Int32, true),
@@ -4956,7 +4946,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_rejects_missing_non_nullable_list_struct_child()
+    fn direct_parquet_schema_match_rejects_missing_non_nullable_list_struct_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_address_fields = vec![
             Field::new("zip", DataType::Int32, true),
@@ -5012,7 +5002,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_reshapes_map_key_struct_by_field_id()
+    fn direct_parquet_schema_match_reshapes_map_key_struct_by_field_id()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_key_fields = vec![
             Field::new("city", DataType::Utf8, true).with_metadata(field_id_metadata(11)),
@@ -5124,7 +5114,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_null_fills_missing_nullable_map_key_struct_child()
+    fn direct_parquet_schema_match_null_fills_missing_nullable_map_key_struct_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_key_fields = vec![
             Field::new("zip", DataType::Int32, true),
@@ -5202,7 +5192,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_rejects_missing_non_nullable_map_key_struct_child()
+    fn direct_parquet_schema_match_rejects_missing_non_nullable_map_key_struct_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_key_fields = vec![
             Field::new("zip", DataType::Int32, true),
@@ -5262,7 +5252,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_reshapes_map_list_key_struct_by_field_id()
+    fn direct_parquet_schema_match_reshapes_map_list_key_struct_by_field_id()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_element_fields = vec![
             Field::new("city", DataType::Utf8, true).with_metadata(field_id_metadata(11)),
@@ -5394,7 +5384,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_reshapes_nested_map_key_struct_by_field_id()
+    fn direct_parquet_schema_match_reshapes_nested_map_key_struct_by_field_id()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_inner_key_fields = vec![
             Field::new("city", DataType::Utf8, true).with_metadata(field_id_metadata(11)),
@@ -5530,7 +5520,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_reshapes_map_key_and_value_structs_by_field_id()
+    fn direct_parquet_schema_match_reshapes_map_key_and_value_structs_by_field_id()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_key_fields = vec![
             Field::new("city", DataType::Utf8, true).with_metadata(field_id_metadata(11)),
@@ -5688,7 +5678,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_reshapes_map_value_struct_by_field_id()
+    fn direct_parquet_schema_match_reshapes_map_value_struct_by_field_id()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_value_fields = vec![
             Field::new("city", DataType::Utf8, true).with_metadata(field_id_metadata(11)),
@@ -5803,7 +5793,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_null_fills_missing_nullable_map_value_struct_child()
+    fn direct_parquet_schema_match_null_fills_missing_nullable_map_value_struct_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_value_fields = vec![
             Field::new("zip", DataType::Int32, true),
@@ -5885,7 +5875,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_rejects_missing_non_nullable_map_value_struct_child()
+    fn direct_parquet_schema_match_rejects_missing_non_nullable_map_value_struct_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_value_fields = vec![
             Field::new("zip", DataType::Int32, true),
@@ -5952,7 +5942,7 @@ mod tests {
     }
 
     #[test]
-    fn native_async_schema_match_rejects_missing_non_nullable_nested_child()
+    fn direct_parquet_schema_match_rejects_missing_non_nullable_nested_child()
     -> Result<(), Box<dyn std::error::Error>> {
         let provider_profile_fields = vec![
             Field::new("age", DataType::Int32, true),
@@ -5997,7 +5987,7 @@ mod tests {
     #[tokio::test]
     async fn matches_top_level_fields_by_id_reorders_casts_and_null_fills()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-top-level-schema-match")?;
+        let root = TestDir::new("direct-top-level-schema-match")?;
         let file_schema = Arc::new(Schema::new(vec![
             field_with_id("stale_name", DataType::Utf8, true, 2),
             field_with_id("stale_id", DataType::Int32, false, 1),
@@ -6048,7 +6038,7 @@ mod tests {
     #[tokio::test]
     async fn casts_top_level_timestamp_and_rejects_incompatible_or_missing_required_fields()
     -> Result<(), Box<dyn std::error::Error>> {
-        let root = TestDir::new("native-top-level-casts")?;
+        let root = TestDir::new("direct-top-level-casts")?;
         let file_schema = Arc::new(Schema::new(vec![Field::new(
             "event_ts",
             DataType::Timestamp(TimeUnit::Nanosecond, None),

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -1,4 +1,4 @@
-//! Object-store metering for NativeAsync Parquet data-file reads.
+//! Object-store metering for direct Parquet data-file reads.
 
 use std::{fmt, sync::Arc};
 
@@ -182,12 +182,12 @@ mod tests {
     };
 
     use super::MeteredParquetObjectStore;
-    use crate::{DeltaReadMetrics, DeltaReaderBackend, reader::metrics::DeltaReadMetricsConfig};
+    use crate::{DeltaReadMetrics, ParquetReaderBackend, reader::metrics::DeltaReadMetricsConfig};
 
-    fn native_metrics() -> DeltaReadMetrics {
+    fn direct_metrics() -> DeltaReadMetrics {
         DeltaReadMetrics::new(DeltaReadMetricsConfig {
             snapshot_version: 1,
-            reader_backend: DeltaReaderBackend::NativeAsync,
+            reader_backend: ParquetReaderBackend::DirectParquet,
             scan_metadata_exhausted: Some(true),
             scan_partitions_planned: 1,
             files_planned: 1,
@@ -210,7 +210,7 @@ mod tests {
 
     #[tokio::test]
     async fn bounded_and_unbounded_gets_record_exact_operations_and_bytes() -> Result<()> {
-        let range_metrics = native_metrics();
+        let range_metrics = direct_metrics();
         let range_store = memory_store(range_metrics.clone()).await?;
         let bytes = range_store
             .get_range(&Path::from("data.parquet"), 2..7)
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(snapshot.parquet_data_file_full_get_operations, Some(0));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(5));
 
-        let full_metrics = native_metrics();
+        let full_metrics = direct_metrics();
         let full_store = memory_store(full_metrics.clone()).await?;
         let bytes = full_store
             .get(&Path::from("data.parquet"))
@@ -238,7 +238,7 @@ mod tests {
 
     #[tokio::test]
     async fn head_failure_and_coalescing_match_frozen_attempt_semantics() -> Result<()> {
-        let head_metrics = native_metrics();
+        let head_metrics = direct_metrics();
         let head_store = memory_store(head_metrics.clone()).await?;
         let options = GetOptions::new().with_range(Some(1_u64..4)).with_head(true);
         let _result = head_store
@@ -249,7 +249,7 @@ mod tests {
         assert_eq!(snapshot.parquet_data_file_full_get_operations, Some(0));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(0));
 
-        let failure_metrics = native_metrics();
+        let failure_metrics = direct_metrics();
         let failure_store =
             MeteredParquetObjectStore::new(Arc::new(InMemory::new()), failure_metrics.clone());
         let result = failure_store
@@ -264,7 +264,7 @@ mod tests {
         assert_eq!(snapshot.parquet_data_file_full_get_operations, Some(0));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(0));
 
-        let coalesced_metrics = native_metrics();
+        let coalesced_metrics = direct_metrics();
         let coalesced_store = memory_store(coalesced_metrics.clone()).await?;
         let bytes = coalesced_store
             .get_ranges(&Path::from("data.parquet"), &[0..4, 8..12])
@@ -287,7 +287,7 @@ mod tests {
             .into_iter()
             .next()
             .ok_or_else(missing_chunk)?;
-        let success_metrics = native_metrics();
+        let success_metrics = direct_metrics();
         let success_store = scripted_store(
             test_get_result(
                 GetResultPayload::Stream(stream::iter(vec![Ok(first), Ok(second)]).boxed()),
@@ -305,7 +305,7 @@ mod tests {
             Some(8)
         );
 
-        let dropped_metrics = native_metrics();
+        let dropped_metrics = direct_metrics();
         let chunks = PutPayload::from_static(b"abc")
             .into_iter()
             .chain(PutPayload::from_static(b"defgh").into_iter())
@@ -334,7 +334,7 @@ mod tests {
             Some(3)
         );
 
-        let error_metrics = native_metrics();
+        let error_metrics = direct_metrics();
         let error = Error::Generic {
             store: "test",
             source: io::Error::other("payload failure").into(),
@@ -370,7 +370,7 @@ mod tests {
         let file = TemporaryTestFile::new(&vec![7_u8; 20_000])?;
         let range = 100_u64..16_500;
 
-        let dropped_metrics = native_metrics();
+        let dropped_metrics = direct_metrics();
         let dropped_store =
             scripted_store(file.get_result(range.clone())?, dropped_metrics.clone());
         let result = dropped_store
@@ -385,7 +385,7 @@ mod tests {
             Some(0)
         );
 
-        let delivered_metrics = native_metrics();
+        let delivered_metrics = direct_metrics();
         let delivered_store =
             scripted_store(file.get_result(range.clone())?, delivered_metrics.clone());
         let mut payload = delivered_store
@@ -413,7 +413,7 @@ mod tests {
 
     #[tokio::test]
     async fn delegated_operations_and_diagnostics_do_not_leak_or_meter() -> Result<()> {
-        let metrics = native_metrics();
+        let metrics = direct_metrics();
         let store = MeteredParquetObjectStore::new(Arc::new(InMemory::new()), metrics.clone());
         let first = Path::from("first.parquet");
         let second = Path::from("second.parquet");
@@ -432,7 +432,7 @@ mod tests {
         assert_eq!(snapshot.parquet_data_file_opened_bytes, Some(0));
         assert_eq!(format!("{store:?}"), "MeteredParquetObjectStore");
 
-        let redacted_metrics = native_metrics();
+        let redacted_metrics = direct_metrics();
         let redacted_store = scripted_store(
             test_get_result(GetResultPayload::Stream(stream::empty().boxed()), 0..0),
             redacted_metrics.clone(),

--- a/src/reader/backend/direct_parquet/row_group_pruning.rs
+++ b/src/reader/backend/direct_parquet/row_group_pruning.rs
@@ -42,7 +42,7 @@ use crate::delta::kernel::DeltaKernelPredicate;
 /// `Some(Vec::new())` means every row group was proven impossible and the
 /// parquet reader should return no rows.
 #[allow(dead_code)]
-pub(crate) fn native_async_pruned_row_groups(
+pub(crate) fn direct_parquet_pruned_row_groups(
     metadata: &ParquetMetaData,
     file_size: u64,
     byte_range: Option<&Range<u64>>,
@@ -83,7 +83,7 @@ pub(crate) fn native_async_pruned_row_groups(
             }
         };
         let may_match = predicate.is_none_or(|predicate| {
-            NativeAsyncRowGroupStats::new(row_group).may_contain_matching_rows(predicate.as_ref())
+            DirectParquetRowGroupStats::new(row_group).may_contain_matching_rows(predicate.as_ref())
         });
         if in_range && may_match {
             selected.push(ordinal);
@@ -92,12 +92,12 @@ pub(crate) fn native_async_pruned_row_groups(
     Ok(Some(selected))
 }
 
-struct NativeAsyncRowGroupStats<'a> {
+struct DirectParquetRowGroupStats<'a> {
     row_group: &'a RowGroupMetaData,
     field_indices: HashMap<ColumnName, usize>,
 }
 
-impl<'a> NativeAsyncRowGroupStats<'a> {
+impl<'a> DirectParquetRowGroupStats<'a> {
     fn new(row_group: &'a RowGroupMetaData) -> Self {
         Self {
             row_group,
@@ -134,7 +134,7 @@ impl<'a> NativeAsyncRowGroupStats<'a> {
     }
 }
 
-impl DataSkippingPredicateEvaluator for NativeAsyncRowGroupStats<'_> {
+impl DataSkippingPredicateEvaluator for DirectParquetRowGroupStats<'_> {
     type Output = bool;
     type ColumnStat = Scalar;
 
@@ -406,19 +406,19 @@ mod tests {
         ])?;
 
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, 80, Some(&(0..25)), None)?,
+            direct_parquet_pruned_row_groups(&metadata, 80, Some(&(0..25)), None)?,
             Some(vec![0])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, 80, Some(&(25..50)), None)?,
+            direct_parquet_pruned_row_groups(&metadata, 80, Some(&(25..50)), None)?,
             Some(vec![1])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, 80, Some(&(50..65)), None)?,
+            direct_parquet_pruned_row_groups(&metadata, 80, Some(&(50..65)), None)?,
             Some(vec![2])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, 80, Some(&(65..80)), None)?,
+            direct_parquet_pruned_row_groups(&metadata, 80, Some(&(65..80)), None)?,
             Some(vec![3])
         );
 
@@ -431,11 +431,11 @@ mod tests {
         let metadata = metadata_with_row_group_offsets(&[(30, Some(20)), (40, None)])?;
 
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, 41, Some(&(20..40)), None)?,
+            direct_parquet_pruned_row_groups(&metadata, 41, Some(&(20..40)), None)?,
             Some(vec![0])
         );
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, 41, Some(&(40..41)), None)?,
+            direct_parquet_pruned_row_groups(&metadata, 41, Some(&(40..41)), None)?,
             Some(vec![1])
         );
 
@@ -446,7 +446,7 @@ mod tests {
     fn regression_byte_range_rejects_malformed_row_group_coordinates()
     -> Result<(), Box<dyn std::error::Error>> {
         assert!(
-            native_async_pruned_row_groups(
+            direct_parquet_pruned_row_groups(
                 &metadata_without_columns()?,
                 100,
                 Some(&(0..100)),
@@ -460,17 +460,19 @@ mod tests {
             metadata_with_row_group_offsets(&[(100, None)])?,
             metadata_with_row_group_offsets(&[(101, None)])?,
         ] {
-            assert!(native_async_pruned_row_groups(&metadata, 100, Some(&(0..100)), None).is_err());
+            assert!(
+                direct_parquet_pruned_row_groups(&metadata, 100, Some(&(0..100)), None).is_err()
+            );
         }
 
         let metadata = metadata_with_row_group_offsets(&[(0, None), (99, None)])?;
         assert_eq!(
-            native_async_pruned_row_groups(&metadata, 100, Some(&(0..100)), None)?,
+            direct_parquet_pruned_row_groups(&metadata, 100, Some(&(0..100)), None)?,
             Some(vec![0, 1])
         );
         for (start, end) in [(0, 0), (0, 101), (100, 99)] {
             let range = start..end;
-            assert!(native_async_pruned_row_groups(&metadata, 100, Some(&range), None).is_err());
+            assert!(direct_parquet_pruned_row_groups(&metadata, 100, Some(&range), None).is_err());
         }
 
         Ok(())

--- a/src/reader/backend/kernel_reader.rs
+++ b/src/reader/backend/kernel_reader.rs
@@ -1,4 +1,4 @@
-//! Official Delta Kernel compatibility data-file reader.
+//! Delta Kernel data-file reader.
 
 use std::sync::Arc;
 
@@ -19,12 +19,12 @@ use crate::{
     },
 };
 
-struct OfficialKernelFileStreamState {
+struct DeltaKernelFileStreamState {
     receiver: mpsc::Receiver<RecordBatch>,
     task: Option<JoinHandle<Result<(), DeltaReaderError>>>,
 }
 
-impl Drop for OfficialKernelFileStreamState {
+impl Drop for DeltaKernelFileStreamState {
     fn drop(&mut self) {
         self.receiver.close();
         if let Some(task) = self.task.as_ref() {
@@ -33,7 +33,7 @@ impl Drop for OfficialKernelFileStreamState {
     }
 }
 
-pub(crate) fn official_kernel_file_executor(
+pub(crate) fn delta_kernel_file_executor(
     plan: &Arc<DeltaScanPlan>,
 ) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
     let plan = Arc::clone(plan);
@@ -96,14 +96,14 @@ fn read_file(
     let size = file_size.ok_or_else(|| {
         data_file_error(
             "data_file_size_missing",
-            delta_kernel::Error::generic("file size is required for OfficialKernel reads"),
+            delta_kernel::Error::generic("file size is required for Delta Kernel reads"),
         )
     })?;
     let modification_time_ms = modification_time_ms.ok_or_else(|| {
         data_file_error(
             "data_file_modification_time_missing",
             delta_kernel::Error::generic(
-                "file modification time is required for OfficialKernel reads",
+                "file modification time is required for Delta Kernel reads",
             ),
         )
     })?;
@@ -151,7 +151,7 @@ fn read_file(
         let batch = align_batch_to_logical_schema(
             batch,
             &plan.logical_schema,
-            "OfficialKernel output does not match the planned logical schema",
+            "Delta Kernel output does not match the planned logical schema",
         )?;
         let batch = match deletion_vector.as_mut() {
             Some(deletion_vector) => deletion_vector.mask_ordered_batch(batch)?,
@@ -181,7 +181,7 @@ fn spawn_blocking_file_stream(
         let _permit = permit;
         producer(output, cancellation)
     });
-    let state = OfficialKernelFileStreamState {
+    let state = DeltaKernelFileStreamState {
         receiver,
         task: Some(task),
     };
@@ -195,7 +195,7 @@ fn spawn_blocking_file_stream(
         let error = match result {
             Ok(Ok(())) => return None,
             Ok(Err(error)) => error,
-            Err(source) => data_file_error("official_kernel_task_failed", source),
+            Err(source) => data_file_error("delta_kernel_task_failed", source),
         };
         Some((Err(error), state))
     }))
@@ -229,16 +229,16 @@ mod tests {
 
     use super::spawn_blocking_file_stream;
     use crate::{
-        DeltaReaderBackend, DeltaReaderExecutionOptions,
+        DeltaReaderExecutionOptions, ParquetReaderBackend,
         reader::scheduling::{ScanCancellation, ScanReadLimiter},
     };
 
     fn options() -> Result<DeltaReaderExecutionOptions, crate::DeltaReaderError> {
         DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?
-            .with_reader_backend(DeltaReaderBackend::OfficialKernel)
+            .with_reader_backend(ParquetReaderBackend::DeltaKernel)
     }
 
     fn batch(id: i32) -> Result<RecordBatch, arrow::error::ArrowError> {
@@ -407,9 +407,9 @@ mod tests {
     }
 
     #[test]
-    fn official_kernel_boundary_adds_no_runtime_or_backend_infrastructure()
+    fn delta_kernel_boundary_adds_no_runtime_or_backend_infrastructure()
     -> Result<(), Box<dyn std::error::Error>> {
-        let source = include_str!("official_kernel.rs");
+        let source = include_str!("kernel_reader.rs");
         let manifest = include_str!("../../../Cargo.toml");
         for forbidden in [
             concat!("Runtime", "::new"),

--- a/src/reader/datafusion.rs
+++ b/src/reader/datafusion.rs
@@ -29,11 +29,9 @@ use self::{
 };
 
 use crate::{
-    DeltaReaderBackend, DeltaReaderError, DeltaReaderExecutionOptions, DeltaTable,
+    DeltaReaderError, DeltaReaderExecutionOptions, DeltaTable, ParquetReaderBackend,
     delta::kernel::delta_predicate_to_kernel_pruning,
-    reader::planning::{
-        DeltaScanPartitionTargetOptions, plan_row_predicate, plan_scan, validate_backend_available,
-    },
+    reader::planning::{DeltaScanPartitionTargetOptions, plan_row_predicate, plan_scan},
     reader::transform::schema_with_view_types,
 };
 
@@ -46,7 +44,7 @@ pub struct DeltaDataFusionScanOptions {
     pub execution_options: DeltaReaderExecutionOptions,
     /// Optional explicit scan partition target.
     pub target_partitions: Option<usize>,
-    /// Controls when DataFusion may split NativeAsync Parquet files into ranged scan tasks.
+    /// Controls when DataFusion may split direct Parquet reads into ranged scan tasks.
     pub intra_file_repartitioning: DeltaFileRepartitioning,
     /// Decode string and binary data-file columns into Arrow view arrays.
     pub use_view_types: bool,
@@ -107,7 +105,6 @@ impl DeltaTableProvider {
         source_name: Option<String>,
     ) -> Result<Self, DeltaReaderError> {
         options.execution_options.validate()?;
-        validate_backend_available(options.execution_options)?;
         if options.target_partitions == Some(0) {
             return Err(DeltaReaderError::InvalidConfiguration {
                 reason: "scan_partition_target_must_be_positive",
@@ -149,7 +146,7 @@ impl DeltaTableProvider {
             &filter_refs,
             DataFusionFilterCapabilities {
                 exact_predicate_evaluation: self.options.execution_options.reader_backend()
-                    == DeltaReaderBackend::NativeAsync,
+                    == ParquetReaderBackend::DirectParquet,
             },
         )?;
         if planning
@@ -352,7 +349,7 @@ impl TableProvider for DeltaTableProvider {
             filters,
             DataFusionFilterCapabilities {
                 exact_predicate_evaluation: self.options.execution_options.reader_backend()
-                    == DeltaReaderBackend::NativeAsync,
+                    == ParquetReaderBackend::DirectParquet,
             },
         );
         Ok(planning
@@ -547,7 +544,7 @@ fn is_reserved_sql_keyword(name: &str) -> bool {
 fn trace_failure(
     event: &'static str,
     snapshot_version: u64,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     error: &DeltaReaderError,
 ) {
     tracing::debug!(

--- a/src/reader/datafusion/execution.rs
+++ b/src/reader/datafusion/execution.rs
@@ -11,9 +11,9 @@
 //! `repartition_file_min_size` setting is the minimum total input size needed
 //! to attempt this operation, not the size of each generated range.
 //!
-//! Each returned range is stored on its `DeltaScanFileTask`. During
-//! NativeAsync execution, the range containing a Parquet row group's first
-//! column chunk's page offset owns that complete row group. Range ownership and
+//! Each returned range is stored on its `DeltaScanFileTask`. During direct
+//! Parquet execution, the range containing a row group's first column chunk
+//! page offset owns that complete row group. Range ownership and
 //! footer-statistics pruning are intersected before the selected row groups
 //! are passed to the Parquet reader, so a byte boundary never splits a row
 //! group.
@@ -59,25 +59,22 @@ use super::{
     planning::DataFusionScanPlanning,
 };
 
-#[cfg(feature = "native-async")]
-use crate::reader::backend::native_async::{
-    NativeAsyncParquetMetadataCache, native_async_file_executor,
-    native_async_file_executor_with_metadata_cache,
+use crate::reader::backend::direct_parquet::{
+    DirectParquetMetadataCache, direct_parquet_file_executor,
+    direct_parquet_file_executor_with_metadata_cache,
 };
-#[cfg(not(feature = "native-async"))]
-use crate::reader::native_async_executor;
 use crate::{
-    DeltaReadMetrics, DeltaReadMetricsSnapshot, DeltaReaderBackend, DeltaReaderError,
+    DeltaReadMetrics, DeltaReadMetricsSnapshot, DeltaReaderError, ParquetReaderBackend,
     delta::kernel::DeltaKernelPredicate,
     reader::{
+        delta_kernel_executor,
         metrics::saturating_fetch_add,
-        official_kernel_executor,
         planning::{DeltaScanFileTask, DeltaScanFileTaskPartition, DeltaScanPlan, build_partition},
         scheduling::{DeltaScanExecution, FileAdmission, FileAdmissionFn, ScanReadLimiter},
     },
 };
 
-/// Controls when DataFusion may split NativeAsync Parquet files into ranged scan tasks.
+/// Controls when DataFusion may split direct Parquet reads into ranged scan tasks.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DeltaFileRepartitioning {
@@ -333,8 +330,7 @@ struct DeltaDataFusionExec {
     dynamic_filters: Arc<[DeltaRetainedDynamicFilter]>,
     intra_file_repartitioning: DeltaFileRepartitioning,
     intra_file_repartitioning_applied: bool,
-    #[cfg(feature = "native-async")]
-    parquet_metadata_cache: Option<Arc<NativeAsyncParquetMetadataCache>>,
+    parquet_metadata_cache: Option<Arc<DirectParquetMetadataCache>>,
 }
 
 impl DeltaDataFusionExec {
@@ -369,7 +365,6 @@ impl DeltaDataFusionExec {
             dynamic_filters: Arc::from([]),
             intra_file_repartitioning,
             intra_file_repartitioning_applied: false,
-            #[cfg(feature = "native-async")]
             parquet_metadata_cache: None,
         }
     }
@@ -400,8 +395,7 @@ impl DeltaDataFusionExec {
             properties: scan_properties(&self.schema, partition_count),
             limiter,
             intra_file_repartitioning_applied: true,
-            #[cfg(feature = "native-async")]
-            parquet_metadata_cache: Some(Arc::new(NativeAsyncParquetMetadataCache::default())),
+            parquet_metadata_cache: Some(Arc::new(DirectParquetMetadataCache::default())),
             ..self.clone()
         })
     }
@@ -600,7 +594,7 @@ impl ExecutionPlan for DeltaDataFusionExec {
         config: &ConfigOptions,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
         if self.intra_file_repartitioning_applied
-            || self.plan.execution_options.reader_backend() != DeltaReaderBackend::NativeAsync
+            || self.plan.execution_options.reader_backend() != ParquetReaderBackend::DirectParquet
         {
             return Ok(None);
         }
@@ -631,35 +625,21 @@ impl ExecutionPlan for DeltaDataFusionExec {
         self.metrics.record_output_batch_size(output_batch_size);
         let admission = dynamic_admission(self.metrics.clone(), Arc::clone(&self.dynamic_filters));
         let executor = match self.plan.execution_options.reader_backend() {
-            DeltaReaderBackend::NativeAsync => {
-                #[cfg(feature = "native-async")]
-                {
-                    match &self.parquet_metadata_cache {
-                        Some(cache) => native_async_file_executor_with_metadata_cache(
-                            &self.plan,
-                            Some(output_batch_size),
-                            self.row_predicate.clone(),
-                            Arc::clone(cache),
-                        ),
-                        None => native_async_file_executor(
-                            &self.plan,
-                            Some(output_batch_size),
-                            self.row_predicate.clone(),
-                        ),
-                    }
-                }
-                #[cfg(not(feature = "native-async"))]
-                {
-                    native_async_executor(
-                        &self.plan,
-                        Some(output_batch_size),
-                        self.row_predicate.clone(),
-                    )
-                    .map_err(datafusion_error)?
-                }
-            }
-            DeltaReaderBackend::OfficialKernel => {
-                official_kernel_executor(&self.plan).map_err(datafusion_error)?
+            ParquetReaderBackend::DirectParquet => match &self.parquet_metadata_cache {
+                Some(cache) => direct_parquet_file_executor_with_metadata_cache(
+                    &self.plan,
+                    Some(output_batch_size),
+                    self.row_predicate.clone(),
+                    Arc::clone(cache),
+                ),
+                None => direct_parquet_file_executor(
+                    &self.plan,
+                    Some(output_batch_size),
+                    self.row_predicate.clone(),
+                ),
+            },
+            ParquetReaderBackend::DeltaKernel => {
+                delta_kernel_executor(&self.plan).map_err(datafusion_error)?
             }
         };
         let stream = DeltaScanExecution::with_shared_limiter(
@@ -823,7 +803,7 @@ fn adapter_error(reason: &'static str) -> DataFusionError {
     })
 }
 
-#[cfg(all(test, feature = "native-async"))]
+#[cfg(test)]
 mod tests {
     use std::{
         collections::HashSet,
@@ -834,14 +814,12 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    #[cfg(feature = "official-kernel")]
     use arrow::array::StringArray;
     use arrow::{
         array::Int32Array,
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
-    #[cfg(feature = "official-kernel")]
     use datafusion::physical_plan::filter::FilterExec;
     use datafusion::{
         common::config::ConfigOptions,
@@ -1050,7 +1028,7 @@ mod tests {
             &filter_refs,
             DataFusionFilterCapabilities {
                 exact_predicate_evaluation: execution_options.reader_backend()
-                    == DeltaReaderBackend::NativeAsync,
+                    == ParquetReaderBackend::DirectParquet,
             },
         )?;
         let physical_projection = planning.projection.physical_projection.clone();
@@ -1367,7 +1345,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn native_repartitioning_reads_each_row_once_and_preserves_byte_accounting() -> TestResult
+    async fn direct_repartitioning_reads_each_row_once_and_preserves_byte_accounting() -> TestResult
     {
         let fixture = TestTable::partitioned("file-repartitioning")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -1388,7 +1366,7 @@ mod tests {
         config.optimizer.repartition_file_min_size = 1;
         let repartitioned = plan
             .repartitioned(4, &config)?
-            .ok_or("native scan was not repartitioned")?;
+            .ok_or("direct scan was not repartitioned")?;
         assert!(repartitioned.repartitioned(4, &config)?.is_none());
 
         assert_eq!(
@@ -1422,19 +1400,18 @@ mod tests {
         )?;
         assert!(explicit_one.repartitioned(4, &config)?.is_none());
 
-        #[cfg(feature = "official-kernel")]
         {
-            let official = build_plan_with_repartitioning(
+            let kernel = build_plan_with_repartitioning(
                 &table,
                 None,
                 &[],
                 4,
                 DeltaReaderExecutionOptions::new()
-                    .with_reader_backend(DeltaReaderBackend::OfficialKernel)?,
+                    .with_reader_backend(ParquetReaderBackend::DeltaKernel)?,
                 None,
                 DeltaFileRepartitioning::Rebalance,
             )?;
-            assert!(official.repartitioned(4, &config)?.is_none());
+            assert!(kernel.repartitioned(4, &config)?.is_none());
         }
 
         Ok(())
@@ -1463,7 +1440,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn properties_projection_partitions_metrics_and_reexecution_match_provider_behavior()
     -> TestResult {
         let fixture = TestTable::partitioned("properties")?;
@@ -1621,7 +1597,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn dynamic_filter_hook_prunes_before_file_start_and_counts_once() -> TestResult {
         let fixture = TestTable::partitioned("dynamic")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -1680,7 +1655,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn physical_pushdown_preserves_dynamic_filters_across_plan_rebuild() -> TestResult {
         let fixture = TestTable::partitioned("dynamic-plan-rebuild")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -1722,12 +1696,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn late_dynamic_filter_keeps_admitted_file_and_prunes_the_next() -> TestResult {
         let fixture = TestTable::late_dynamic("late-dynamic")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let options = DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?
             .with_output_buffer_capacity_per_partition(1)?;
@@ -1765,7 +1738,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn hook_is_post_only_empty_safe_and_collector_is_ordered_and_distinct() -> TestResult {
         let fixture = TestTable::partitioned("collector")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -1856,7 +1828,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn dynamic_admission_reason_counts_are_once_per_file_and_saturating() -> TestResult {
         use crate::{
             delta::kernel::KernelPhysicalToLogicalTransform,
@@ -1955,7 +1926,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn dynamic_metrics_updates_are_thread_safe() -> TestResult {
         const THREADS: usize = 4;
         const ITERATIONS: usize = 100;
@@ -2011,7 +1981,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "native-async")]
     async fn execution_error_and_stream_drop_preserve_partial_metrics() -> TestResult {
         let missing_fixture = TestTable::missing("error")?;
         let missing_table = DeltaTableBuilder::new(missing_fixture.uri())
@@ -2041,7 +2010,7 @@ mod tests {
         let fixture = TestTable::partitioned("drop")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let options = DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?
             .with_output_buffer_capacity_per_partition(1)?;
@@ -2067,14 +2036,13 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(all(feature = "native-async", feature = "official-kernel"))]
     async fn reader_backends_produce_the_same_logical_rows() -> TestResult {
         let fixture = TestTable::partitioned("backends")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let mut outputs = Vec::new();
         for backend in [
-            DeltaReaderBackend::NativeAsync,
-            DeltaReaderBackend::OfficialKernel,
+            ParquetReaderBackend::DirectParquet,
+            ParquetReaderBackend::DeltaKernel,
         ] {
             let options = DeltaReaderExecutionOptions::new().with_reader_backend(backend)?;
             let plan = build_plan(&table, Some(&[1, 0]), &[], 2, options, None)?;
@@ -2111,14 +2079,14 @@ mod tests {
         }
         assert_eq!(outputs[0], outputs[1]);
 
-        let official_options = DeltaReaderExecutionOptions::new()
-            .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
+        let kernel_options = DeltaReaderExecutionOptions::new()
+            .with_reader_backend(ParquetReaderBackend::DeltaKernel)?;
         let inexact = build_plan(
             &table,
             None,
             &[col("id").gt(lit(1_i32))],
             1,
-            official_options,
+            kernel_options,
             None,
         )?;
         let unfiltered = datafusion::physical_plan::collect(

--- a/src/reader/deletion_vector.rs
+++ b/src/reader/deletion_vector.rs
@@ -478,8 +478,8 @@ mod tests {
         load_deletion_vector_selection,
     };
     use crate::{
-        DeltaReadMetrics, DeltaReaderBackend, DeltaReaderError, DeltaReaderPhase,
-        DeltaSnapshotSelection, DeltaStorageOptions,
+        DeltaReadMetrics, DeltaReaderError, DeltaReaderPhase, DeltaSnapshotSelection,
+        DeltaStorageOptions, ParquetReaderBackend,
         delta::{
             kernel::{is_kernel_error, preserve_deletion_vector},
             snapshot::{LoadedDeltaTableSnapshot, load_delta_table_snapshot_blocking},
@@ -776,7 +776,7 @@ mod tests {
     fn metrics() -> DeltaReadMetrics {
         DeltaReadMetrics::new(DeltaReadMetricsConfig {
             snapshot_version: 7,
-            reader_backend: DeltaReaderBackend::NativeAsync,
+            reader_backend: ParquetReaderBackend::DirectParquet,
             scan_metadata_exhausted: Some(true),
             scan_partitions_planned: 1,
             files_planned: 1,

--- a/src/reader/metrics.rs
+++ b/src/reader/metrics.rs
@@ -5,15 +5,15 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use super::options::DeltaReaderBackend;
+use super::options::ParquetReaderBackend;
 
 /// Immutable point-in-time metrics for one Delta scan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeltaReadMetricsSnapshot {
     /// Delta snapshot version selected for the scan.
     pub snapshot_version: u64,
-    /// Data-file reader backend selected for the scan.
-    pub reader_backend: DeltaReaderBackend,
+    /// Parquet reader backend selected for the scan.
+    pub reader_backend: ParquetReaderBackend,
     /// Whether planning exhausted the Delta scan metadata iterator.
     pub scan_metadata_exhausted: Option<bool>,
     /// Final execution partitions planned for the scan, including source repartitioning.
@@ -48,13 +48,13 @@ pub struct DeltaReadMetricsSnapshot {
     pub deletion_vector_failures: u64,
     /// Deletion-vector reads rejected by safety checks.
     pub deletion_vector_rejections: u64,
-    /// NativeAsync Parquet ranged GET operations, or `None` for another backend.
+    /// Direct Parquet ranged GET operations, or `None` for another backend.
     pub parquet_data_file_range_get_operations: Option<u64>,
-    /// NativeAsync Parquet full GET operations, or `None` for another backend.
+    /// Direct Parquet full GET operations, or `None` for another backend.
     pub parquet_data_file_full_get_operations: Option<u64>,
-    /// NativeAsync Parquet payload bytes received, or `None` for another backend.
+    /// Direct Parquet payload bytes received, or `None` for another backend.
     pub parquet_data_file_bytes_received: Option<u64>,
-    /// NativeAsync Parquet file bytes opened, or `None` for another backend.
+    /// Direct Parquet file bytes opened, or `None` for another backend.
     pub parquet_data_file_opened_bytes: Option<u64>,
 }
 
@@ -66,7 +66,7 @@ pub struct DeltaReadMetrics {
 
 struct DeltaReadMetricsInner {
     snapshot_version: u64,
-    reader_backend: DeltaReaderBackend,
+    reader_backend: ParquetReaderBackend,
     scan_metadata_exhausted: Option<bool>,
     scan_partitions_planned: AtomicU64,
     files_planned: u64,
@@ -93,7 +93,7 @@ struct DeltaReadMetricsInner {
 #[allow(dead_code)]
 pub(crate) struct DeltaReadMetricsConfig {
     pub(crate) snapshot_version: u64,
-    pub(crate) reader_backend: DeltaReaderBackend,
+    pub(crate) reader_backend: ParquetReaderBackend,
     pub(crate) scan_metadata_exhausted: Option<bool>,
     pub(crate) scan_partitions_planned: usize,
     pub(crate) files_planned: usize,
@@ -172,8 +172,8 @@ impl DeltaReadMetrics {
 
     fn parquet_metric(&self, counter: &AtomicU64) -> Option<u64> {
         match self.inner.reader_backend {
-            DeltaReaderBackend::NativeAsync => Some(load(counter)),
-            DeltaReaderBackend::OfficialKernel => None,
+            ParquetReaderBackend::DirectParquet => Some(load(counter)),
+            ParquetReaderBackend::DeltaKernel => None,
         }
     }
 
@@ -238,17 +238,14 @@ impl DeltaReadMetrics {
         saturating_fetch_add(&self.inner.deletion_vector_rejections, 1);
     }
 
-    #[cfg(feature = "native-async")]
     pub(crate) fn record_parquet_data_file_range_get_operation(&self) {
         saturating_fetch_add(&self.inner.parquet_data_file_range_get_operations, 1);
     }
 
-    #[cfg(feature = "native-async")]
     pub(crate) fn record_parquet_data_file_full_get_operation(&self) {
         saturating_fetch_add(&self.inner.parquet_data_file_full_get_operations, 1);
     }
 
-    #[cfg(feature = "native-async")]
     pub(crate) fn record_parquet_data_file_bytes_received(&self, bytes: usize) {
         saturating_fetch_add(
             &self.inner.parquet_data_file_bytes_received,
@@ -256,7 +253,6 @@ impl DeltaReadMetrics {
         );
     }
 
-    #[cfg(feature = "native-async")]
     pub(crate) fn record_parquet_data_file_opened_bytes(&self, bytes: u64) {
         saturating_fetch_add(&self.inner.parquet_data_file_opened_bytes, bytes);
     }
@@ -282,9 +278,9 @@ mod tests {
     use std::{sync::atomic::Ordering, thread};
 
     use super::{DeltaReadMetrics, DeltaReadMetricsConfig, saturating_fetch_add};
-    use crate::DeltaReaderBackend;
+    use crate::ParquetReaderBackend;
 
-    fn metrics(reader_backend: DeltaReaderBackend) -> DeltaReadMetrics {
+    fn metrics(reader_backend: ParquetReaderBackend) -> DeltaReadMetrics {
         DeltaReadMetrics::new(DeltaReadMetricsConfig {
             snapshot_version: 7,
             reader_backend,
@@ -299,41 +295,41 @@ mod tests {
 
     #[test]
     fn snapshot_has_context_zeroes_and_backend_availability() {
-        let native = metrics(DeltaReaderBackend::NativeAsync).snapshot();
-        assert_eq!(native.snapshot_version, 7);
-        assert_eq!(native.reader_backend, DeltaReaderBackend::NativeAsync);
-        assert_eq!(native.scan_metadata_exhausted, Some(true));
-        assert_eq!(native.scan_partitions_planned, 3);
-        assert_eq!(native.files_planned, 5);
-        assert_eq!(native.files_filtered_during_planning, Some(2));
-        assert_eq!(native.estimated_rows, Some(99));
-        assert_eq!(native.estimated_bytes, Some(42));
-        assert_eq!(native.scan_partitions_started, 0);
-        assert_eq!(native.scan_partitions_completed, 0);
-        assert_eq!(native.files_started, 0);
-        assert_eq!(native.files_completed, 0);
-        assert_eq!(native.batches_produced, 0);
-        assert_eq!(native.rows_produced, 0);
-        assert_eq!(native.deletion_vector_payloads_loaded, 0);
-        assert_eq!(native.deletion_vectors_applied, 0);
-        assert_eq!(native.deletion_vector_rows_deleted, 0);
-        assert_eq!(native.deletion_vector_failures, 0);
-        assert_eq!(native.deletion_vector_rejections, 0);
-        assert_eq!(native.parquet_data_file_range_get_operations, Some(0));
-        assert_eq!(native.parquet_data_file_full_get_operations, Some(0));
-        assert_eq!(native.parquet_data_file_bytes_received, Some(0));
-        assert_eq!(native.parquet_data_file_opened_bytes, Some(0));
+        let direct = metrics(ParquetReaderBackend::DirectParquet).snapshot();
+        assert_eq!(direct.snapshot_version, 7);
+        assert_eq!(direct.reader_backend, ParquetReaderBackend::DirectParquet);
+        assert_eq!(direct.scan_metadata_exhausted, Some(true));
+        assert_eq!(direct.scan_partitions_planned, 3);
+        assert_eq!(direct.files_planned, 5);
+        assert_eq!(direct.files_filtered_during_planning, Some(2));
+        assert_eq!(direct.estimated_rows, Some(99));
+        assert_eq!(direct.estimated_bytes, Some(42));
+        assert_eq!(direct.scan_partitions_started, 0);
+        assert_eq!(direct.scan_partitions_completed, 0);
+        assert_eq!(direct.files_started, 0);
+        assert_eq!(direct.files_completed, 0);
+        assert_eq!(direct.batches_produced, 0);
+        assert_eq!(direct.rows_produced, 0);
+        assert_eq!(direct.deletion_vector_payloads_loaded, 0);
+        assert_eq!(direct.deletion_vectors_applied, 0);
+        assert_eq!(direct.deletion_vector_rows_deleted, 0);
+        assert_eq!(direct.deletion_vector_failures, 0);
+        assert_eq!(direct.deletion_vector_rejections, 0);
+        assert_eq!(direct.parquet_data_file_range_get_operations, Some(0));
+        assert_eq!(direct.parquet_data_file_full_get_operations, Some(0));
+        assert_eq!(direct.parquet_data_file_bytes_received, Some(0));
+        assert_eq!(direct.parquet_data_file_opened_bytes, Some(0));
 
-        let official = metrics(DeltaReaderBackend::OfficialKernel).snapshot();
-        assert_eq!(official.parquet_data_file_range_get_operations, None);
-        assert_eq!(official.parquet_data_file_full_get_operations, None);
-        assert_eq!(official.parquet_data_file_bytes_received, None);
-        assert_eq!(official.parquet_data_file_opened_bytes, None);
+        let kernel = metrics(ParquetReaderBackend::DeltaKernel).snapshot();
+        assert_eq!(kernel.parquet_data_file_range_get_operations, None);
+        assert_eq!(kernel.parquet_data_file_full_get_operations, None);
+        assert_eq!(kernel.parquet_data_file_bytes_received, None);
+        assert_eq!(kernel.parquet_data_file_opened_bytes, None);
     }
 
     #[test]
     fn snapshot_maps_live_counters() {
-        let metrics = metrics(DeltaReaderBackend::NativeAsync);
+        let metrics = metrics(ParquetReaderBackend::DirectParquet);
         metrics.record_scan_partitions_planned(16);
         let counters = [
             &metrics.inner.scan_partitions_started,
@@ -377,7 +373,7 @@ mod tests {
 
     #[test]
     fn cloned_handles_saturate_under_concurrent_updates() -> Result<(), &'static str> {
-        let metrics = metrics(DeltaReaderBackend::NativeAsync);
+        let metrics = metrics(ParquetReaderBackend::DirectParquet);
         metrics
             .inner
             .files_started

--- a/src/reader/options.rs
+++ b/src/reader/options.rs
@@ -6,7 +6,7 @@ use crate::{DeltaReaderError, error::InvalidConfigurationSnafu};
 
 const DEFAULT_MAX_CONCURRENT_FILE_READS_PER_PARTITION: usize = 3;
 const DEFAULT_OUTPUT_BUFFER_CAPACITY_PER_PARTITION: usize = 1;
-const DEFAULT_NATIVE_ASYNC_PREFETCH_FILE_COUNT_PER_PARTITION: usize = 2;
+const DEFAULT_PREFETCH_FILE_COUNT_PER_PARTITION: usize = 2;
 const DEFAULT_PARQUET_METADATA_SIZE_HINT: usize = 64 * 1024;
 
 /// Storage options forwarded to Delta object-store construction.
@@ -22,24 +22,24 @@ pub enum DeltaSnapshotSelection {
     Version(u64),
 }
 
-/// Backend used to read Delta data files.
+/// Backend used to read Parquet data files.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum DeltaReaderBackend {
-    /// Use the official Delta Kernel data-file reader.
-    OfficialKernel,
-    /// Use the native asynchronous Parquet reader.
+pub enum ParquetReaderBackend {
+    /// Delegate data-file reads to Delta Kernel's Parquet handler.
+    DeltaKernel,
+    /// Read data files directly through the asynchronous Parquet API.
     #[default]
-    NativeAsync,
+    DirectParquet,
 }
 
 /// Bounded execution settings for one Delta scan.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeltaReaderExecutionOptions {
-    reader_backend: DeltaReaderBackend,
+    reader_backend: ParquetReaderBackend,
     max_concurrent_file_reads_per_scan: Option<usize>,
     max_concurrent_file_reads_per_partition: usize,
     output_buffer_capacity_per_partition: usize,
-    native_async_prefetch_file_count_per_partition: usize,
+    prefetch_file_count_per_partition: usize,
     parquet_metadata_size_hint: Option<usize>,
     parquet_full_file_read_threshold: Option<usize>,
 }
@@ -48,20 +48,19 @@ impl DeltaReaderExecutionOptions {
     /// Returns the baseline execution settings.
     pub const fn new() -> Self {
         Self {
-            reader_backend: DeltaReaderBackend::NativeAsync,
+            reader_backend: ParquetReaderBackend::DirectParquet,
             max_concurrent_file_reads_per_scan: None,
             max_concurrent_file_reads_per_partition:
                 DEFAULT_MAX_CONCURRENT_FILE_READS_PER_PARTITION,
             output_buffer_capacity_per_partition: DEFAULT_OUTPUT_BUFFER_CAPACITY_PER_PARTITION,
-            native_async_prefetch_file_count_per_partition:
-                DEFAULT_NATIVE_ASYNC_PREFETCH_FILE_COUNT_PER_PARTITION,
+            prefetch_file_count_per_partition: DEFAULT_PREFETCH_FILE_COUNT_PER_PARTITION,
             parquet_metadata_size_hint: Some(DEFAULT_PARQUET_METADATA_SIZE_HINT),
             parquet_full_file_read_threshold: None,
         }
     }
 
-    /// Returns the selected data-file reader backend.
-    pub const fn reader_backend(&self) -> DeltaReaderBackend {
+    /// Returns the selected Parquet reader backend.
+    pub const fn reader_backend(&self) -> ParquetReaderBackend {
         self.reader_backend
     }
 
@@ -80,25 +79,25 @@ impl DeltaReaderExecutionOptions {
         self.output_buffer_capacity_per_partition
     }
 
-    /// Returns the NativeAsync per-partition file prefetch depth.
-    pub const fn native_async_prefetch_file_count_per_partition(&self) -> usize {
-        self.native_async_prefetch_file_count_per_partition
+    /// Returns the direct Parquet reader's per-partition file prefetch depth.
+    pub const fn prefetch_file_count_per_partition(&self) -> usize {
+        self.prefetch_file_count_per_partition
     }
 
-    /// Returns the NativeAsync Parquet metadata size hint.
+    /// Returns the direct Parquet reader's metadata size hint.
     pub const fn parquet_metadata_size_hint(&self) -> Option<usize> {
         self.parquet_metadata_size_hint
     }
 
-    /// Returns the NativeAsync full-file read threshold.
+    /// Returns the direct Parquet reader's full-file read threshold.
     pub const fn parquet_full_file_read_threshold(&self) -> Option<usize> {
         self.parquet_full_file_read_threshold
     }
 
-    /// Selects a data-file reader backend.
+    /// Selects a Parquet reader backend.
     pub fn with_reader_backend(
         mut self,
-        value: DeltaReaderBackend,
+        value: ParquetReaderBackend,
     ) -> Result<Self, DeltaReaderError> {
         self.reader_backend = value;
         self.validate()?;
@@ -135,17 +134,17 @@ impl DeltaReaderExecutionOptions {
         Ok(self)
     }
 
-    /// Sets the NativeAsync per-partition file prefetch depth.
-    pub fn with_native_async_prefetch_file_count_per_partition(
+    /// Sets the direct Parquet reader's per-partition file prefetch depth.
+    pub fn with_prefetch_file_count_per_partition(
         mut self,
         value: usize,
     ) -> Result<Self, DeltaReaderError> {
-        self.native_async_prefetch_file_count_per_partition = value;
+        self.prefetch_file_count_per_partition = value;
         self.validate()?;
         Ok(self)
     }
 
-    /// Sets or clears the NativeAsync Parquet metadata size hint.
+    /// Sets or clears the direct Parquet reader's metadata size hint.
     pub fn with_parquet_metadata_size_hint(
         mut self,
         value: Option<usize>,
@@ -155,7 +154,7 @@ impl DeltaReaderExecutionOptions {
         Ok(self)
     }
 
-    /// Sets or clears the NativeAsync full-file read threshold.
+    /// Sets or clears the direct Parquet reader's full-file read threshold.
     pub fn with_parquet_full_file_read_threshold(
         mut self,
         value: Option<usize>,
@@ -231,8 +230,8 @@ mod tests {
     use crate::DeltaReaderPhase;
 
     use super::{
-        DeltaReaderBackend, DeltaReaderExecutionOptions, DeltaSnapshotSelection,
-        DeltaStorageOptions,
+        DeltaReaderExecutionOptions, DeltaSnapshotSelection, DeltaStorageOptions,
+        ParquetReaderBackend,
     };
 
     #[test]
@@ -244,15 +243,18 @@ mod tests {
             DeltaSnapshotSelection::Latest
         );
         assert_eq!(
-            DeltaReaderBackend::default(),
-            DeltaReaderBackend::NativeAsync
+            ParquetReaderBackend::default(),
+            ParquetReaderBackend::DirectParquet
         );
         assert_eq!(DeltaReaderExecutionOptions::default(), options);
-        assert_eq!(options.reader_backend(), DeltaReaderBackend::NativeAsync);
+        assert_eq!(
+            options.reader_backend(),
+            ParquetReaderBackend::DirectParquet
+        );
         assert_eq!(options.max_concurrent_file_reads_per_scan(), None);
         assert_eq!(options.max_concurrent_file_reads_per_partition(), 3);
         assert_eq!(options.output_buffer_capacity_per_partition(), 1);
-        assert_eq!(options.native_async_prefetch_file_count_per_partition(), 2);
+        assert_eq!(options.prefetch_file_count_per_partition(), 2);
         assert_eq!(options.parquet_metadata_size_hint(), Some(65_536));
         assert_eq!(options.parquet_full_file_read_threshold(), None);
         assert_eq!(DeltaStorageOptions::default(), DeltaStorageOptions::new());
@@ -265,19 +267,19 @@ mod tests {
     #[test]
     fn builders_set_every_public_option() -> Result<(), Box<dyn std::error::Error>> {
         let options = DeltaReaderExecutionOptions::new()
-            .with_reader_backend(DeltaReaderBackend::OfficialKernel)?
+            .with_reader_backend(ParquetReaderBackend::DeltaKernel)?
             .with_max_concurrent_file_reads_per_scan(Some(8))?
             .with_max_concurrent_file_reads_per_partition(4)?
             .with_output_buffer_capacity_per_partition(2)?
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_parquet_metadata_size_hint(None)?
             .with_parquet_full_file_read_threshold(Some(1024))?;
 
-        assert_eq!(options.reader_backend(), DeltaReaderBackend::OfficialKernel);
+        assert_eq!(options.reader_backend(), ParquetReaderBackend::DeltaKernel);
         assert_eq!(options.max_concurrent_file_reads_per_scan(), Some(8));
         assert_eq!(options.max_concurrent_file_reads_per_partition(), 4);
         assert_eq!(options.output_buffer_capacity_per_partition(), 2);
-        assert_eq!(options.native_async_prefetch_file_count_per_partition(), 0);
+        assert_eq!(options.prefetch_file_count_per_partition(), 0);
         assert_eq!(options.parquet_metadata_size_hint(), None);
         assert_eq!(options.parquet_full_file_read_threshold(), Some(1024));
         Ok(())
@@ -305,11 +307,11 @@ mod tests {
     -> Result<(), Box<dyn std::error::Error>> {
         let options = DeltaReaderExecutionOptions::new()
             .with_max_concurrent_file_reads_per_scan(Some(2))?
-            .with_native_async_prefetch_file_count_per_partition(4)?;
+            .with_prefetch_file_count_per_partition(4)?;
 
         assert_eq!(options.max_concurrent_file_reads_per_scan(), Some(2));
         assert_eq!(options.max_concurrent_file_reads_per_partition(), 3);
-        assert_eq!(options.native_async_prefetch_file_count_per_partition(), 4);
+        assert_eq!(options.prefetch_file_count_per_partition(), 4);
         Ok(())
     }
 

--- a/src/reader/planning.rs
+++ b/src/reader/planning.rs
@@ -168,27 +168,6 @@ pub(crate) fn plan_unpartitioned_scan(
     )
 }
 
-pub(crate) fn validate_backend_available(
-    execution_options: DeltaReaderExecutionOptions,
-) -> Result<(), DeltaReaderError> {
-    #[cfg(not(feature = "native-async"))]
-    if execution_options.reader_backend() == crate::DeltaReaderBackend::NativeAsync {
-        return crate::error::UnsupportedBackendSnafu {
-            reason: "native_async_feature_disabled",
-        }
-        .fail();
-    }
-    #[cfg(not(feature = "official-kernel"))]
-    if execution_options.reader_backend() == crate::DeltaReaderBackend::OfficialKernel {
-        return crate::error::UnsupportedBackendSnafu {
-            reason: "official_kernel_feature_disabled",
-        }
-        .fail();
-    }
-    let _ = execution_options;
-    Ok(())
-}
-
 fn build_unpartitioned_scan_plan(
     snapshot: &LoadedDeltaTableSnapshot,
     projection: Option<&[String]>,
@@ -4712,19 +4691,16 @@ mod tests {
     -> Result<(), Box<dyn std::error::Error>> {
         let (_empty_table, empty_snapshot) = loaded_snapshot("empty-files")?;
         let execution_options = crate::DeltaReaderExecutionOptions::default();
-        #[cfg(feature = "official-kernel")]
-        let execution_options =
-            execution_options.with_reader_backend(crate::DeltaReaderBackend::OfficialKernel)?;
-        let expected_backend = execution_options.reader_backend();
-        let expected_parquet_metric =
-            (expected_backend == crate::DeltaReaderBackend::NativeAsync).then_some(0);
         let empty = plan_scan(&empty_snapshot, None, &[], None, true, execution_options)?;
         assert!(empty.partitions.is_empty());
         assert_eq!(empty.estimated_bytes, Some(0));
         assert_eq!(empty.estimated_rows, Some(0));
         let empty_metrics = empty.metrics.snapshot();
         assert_eq!(empty_metrics.snapshot_version, empty.snapshot_version);
-        assert_eq!(empty_metrics.reader_backend, expected_backend);
+        assert_eq!(
+            empty_metrics.reader_backend,
+            crate::ParquetReaderBackend::DirectParquet
+        );
         assert_eq!(empty_metrics.scan_metadata_exhausted, Some(true));
         assert_eq!(empty_metrics.scan_partitions_planned, 0);
         assert_eq!(empty_metrics.files_planned, 0);
@@ -4747,20 +4723,11 @@ mod tests {
         assert_eq!(empty_metrics.deletion_vector_rejections, 0);
         assert_eq!(
             empty_metrics.parquet_data_file_range_get_operations,
-            expected_parquet_metric
+            Some(0)
         );
-        assert_eq!(
-            empty_metrics.parquet_data_file_full_get_operations,
-            expected_parquet_metric
-        );
-        assert_eq!(
-            empty_metrics.parquet_data_file_bytes_received,
-            expected_parquet_metric
-        );
-        assert_eq!(
-            empty_metrics.parquet_data_file_opened_bytes,
-            expected_parquet_metric
-        );
+        assert_eq!(empty_metrics.parquet_data_file_full_get_operations, Some(0));
+        assert_eq!(empty_metrics.parquet_data_file_bytes_received, Some(0));
+        assert_eq!(empty_metrics.parquet_data_file_opened_bytes, Some(0));
 
         let single_add = [add("single.parquet", 0, None)];
         let (_single_table, single_snapshot) =
@@ -5505,7 +5472,7 @@ mod tests {
         assert_eq!(metrics.snapshot_version, snapshot.version());
         assert_eq!(
             metrics.reader_backend,
-            crate::DeltaReaderBackend::NativeAsync
+            crate::ParquetReaderBackend::DirectParquet
         );
         assert_eq!(metrics.scan_metadata_exhausted, Some(true));
         assert_eq!(metrics.scan_partitions_planned, 2);
@@ -5543,7 +5510,7 @@ mod tests {
         ];
         let (_table, snapshot) = loaded_snapshot_with_adds("scan-execution", &adds)?;
         let execution_options = crate::DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?
             .with_output_buffer_capacity_per_partition(2)?;
@@ -5631,7 +5598,7 @@ mod tests {
         let adds = [add("part.parquet", 10, Some(1))];
         let (_table, snapshot) = loaded_snapshot_with_adds("concurrent-executions", &adds)?;
         let execution_options = crate::DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?;
         let plan = Arc::new(super::plan_scan(

--- a/src/reader/scheduling.rs
+++ b/src/reader/scheduling.rs
@@ -21,7 +21,7 @@ use tracing::Instrument;
 
 use super::planning::{DeltaScanFileTask, DeltaScanPlan};
 use crate::{
-    DeltaReadMetrics, DeltaReaderBackend, DeltaReaderError, DeltaReaderExecutionOptions,
+    DeltaReadMetrics, DeltaReaderError, DeltaReaderExecutionOptions, ParquetReaderBackend,
     error::{CancelledSnafu, InvalidConfigurationSnafu},
 };
 
@@ -376,10 +376,8 @@ impl PartitionStream {
     {
         let output_capacity = options.output_buffer_capacity_per_partition();
         let prefetch_file_count = match options.reader_backend() {
-            DeltaReaderBackend::NativeAsync => {
-                options.native_async_prefetch_file_count_per_partition()
-            }
-            DeltaReaderBackend::OfficialKernel => 0,
+            ParquetReaderBackend::DirectParquet => options.prefetch_file_count_per_partition(),
+            ParquetReaderBackend::DeltaKernel => 0,
         };
         let measured_metrics = metrics.clone();
         let measured_executor = Arc::new(move |task, permit, cancellation| {
@@ -732,7 +730,7 @@ mod tests {
     };
 
     use crate::{
-        DeltaReadMetrics, DeltaReaderBackend, DeltaReaderExecutionOptions, DeltaReaderPhase,
+        DeltaReadMetrics, DeltaReaderExecutionOptions, DeltaReaderPhase, ParquetReaderBackend,
         error::InvalidConfigurationSnafu, reader::metrics::DeltaReadMetricsConfig,
     };
 
@@ -746,7 +744,7 @@ mod tests {
         partition_capacity: usize,
     ) -> Result<DeltaReaderExecutionOptions, crate::DeltaReaderError> {
         DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(partition_capacity)?
             .with_max_concurrent_file_reads_per_scan(Some(scan_capacity))
     }
@@ -754,7 +752,7 @@ mod tests {
     fn metrics() -> DeltaReadMetrics {
         DeltaReadMetrics::new(DeltaReadMetricsConfig {
             snapshot_version: 1,
-            reader_backend: DeltaReaderBackend::NativeAsync,
+            reader_backend: ParquetReaderBackend::DirectParquet,
             scan_metadata_exhausted: Some(true),
             scan_partitions_planned: 1,
             files_planned: 3,
@@ -769,7 +767,7 @@ mod tests {
         prefetch_file_count: usize,
     ) -> Result<DeltaReaderExecutionOptions, crate::DeltaReaderError> {
         DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(prefetch_file_count)?
+            .with_prefetch_file_count_per_partition(prefetch_file_count)?
             .with_output_buffer_capacity_per_partition(output_capacity)
     }
 
@@ -1755,8 +1753,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn official_kernel_disables_speculative_prefetch()
-    -> Result<(), Box<dyn std::error::Error>> {
+    async fn delta_kernel_disables_speculative_prefetch() -> Result<(), Box<dyn std::error::Error>>
+    {
         let limiter = ScanReadLimiter::new(options(2, 2)?, 1, 1);
         let calls = Arc::new(AtomicUsize::new(0));
         let cancellation = ScanCancellation::new();
@@ -1767,12 +1765,12 @@ mod tests {
                 async move { Ok(pending_file_stream(permit)) }.boxed()
             })
         };
-        let official_options =
-            stream_options(1, 1)?.with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
+        let kernel_options =
+            stream_options(1, 1)?.with_reader_backend(ParquetReaderBackend::DeltaKernel)?;
         let mut stream = PartitionStream::new(
             vec![1, 2],
             limiter.partition(0)?,
-            official_options,
+            kernel_options,
             Arc::new(|_| Ok(FileAdmission::Admit)),
             executor,
             metrics(),
@@ -1806,7 +1804,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn official_kernel_cancellation_waits_for_the_sync_safe_boundary()
+    async fn delta_kernel_cancellation_waits_for_the_sync_safe_boundary()
     -> Result<(), Box<dyn std::error::Error>> {
         let limiter = ScanReadLimiter::new(options(1, 1)?, 1, 1);
         let calls = Arc::new(AtomicUsize::new(0));
@@ -1836,12 +1834,12 @@ mod tests {
                 .boxed()
             })
         };
-        let official_options =
-            stream_options(1, 0)?.with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
+        let kernel_options =
+            stream_options(1, 0)?.with_reader_backend(ParquetReaderBackend::DeltaKernel)?;
         let mut stream = PartitionStream::new(
             vec![1, 2],
             limiter.partition(0)?,
-            official_options,
+            kernel_options,
             Arc::new(|_| Ok(FileAdmission::Admit)),
             executor,
             metrics(),

--- a/tests/benchmark_harness.rs
+++ b/tests/benchmark_harness.rs
@@ -1,10 +1,6 @@
 //! Test target for the frozen reader benchmark harness.
 
-#![cfg(all(
-    feature = "datafusion",
-    feature = "native-async",
-    feature = "official-kernel"
-))]
+#![cfg(feature = "datafusion")]
 
 #[allow(dead_code)]
 #[path = "../benches/reader.rs"]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -5,12 +5,12 @@ use std::{error::Error as _, future::Future};
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use delta_arrow_reader::{
     DeltaBatchStream, DeltaComparison, DeltaPredicate, DeltaProtocolInfo, DeltaReadMetrics,
-    DeltaReadMetricsSnapshot, DeltaReaderBackend, DeltaReaderError, DeltaReaderExecutionOptions,
-    DeltaReaderPhase, DeltaScalar, DeltaScan, DeltaScanBuilder,
-    DeltaScanPartitionTargetDiagnosticInput, DeltaScanPartitionTargetDiagnosticOutput,
-    DeltaScanPartitionTargetDiagnosticSource, DeltaScanPartitionTargetLocalEnvironmentDiagnostic,
+    DeltaReadMetricsSnapshot, DeltaReaderError, DeltaReaderExecutionOptions, DeltaReaderPhase,
+    DeltaScalar, DeltaScan, DeltaScanBuilder, DeltaScanPartitionTargetDiagnosticInput,
+    DeltaScanPartitionTargetDiagnosticOutput, DeltaScanPartitionTargetDiagnosticSource,
+    DeltaScanPartitionTargetLocalEnvironmentDiagnostic,
     DeltaScanPartitionTargetLocalUnixFileDescriptorLimitStatus, DeltaSnapshotSelection,
-    DeltaStorageOptions, DeltaTable, DeltaTableBuilder, DeltaTableSnapshot,
+    DeltaStorageOptions, DeltaTable, DeltaTableBuilder, DeltaTableSnapshot, ParquetReaderBackend,
     delta_scan_partition_target_local_environment_diagnostic,
     derive_delta_scan_partition_target_diagnostic,
 };
@@ -48,15 +48,15 @@ fn configuration_and_error_contract_is_public() -> Result<(), DeltaReaderError> 
     );
 
     let options = DeltaReaderExecutionOptions::new()
-        .with_reader_backend(DeltaReaderBackend::OfficialKernel)?
+        .with_reader_backend(ParquetReaderBackend::DeltaKernel)?
         .with_max_concurrent_file_reads_per_scan(Some(6))?
         .with_max_concurrent_file_reads_per_partition(3)?
         .with_output_buffer_capacity_per_partition(1)?
-        .with_native_async_prefetch_file_count_per_partition(2)?
+        .with_prefetch_file_count_per_partition(2)?
         .with_parquet_metadata_size_hint(Some(65_536))?
         .with_parquet_full_file_read_threshold(None)?;
 
-    assert_eq!(options.reader_backend(), DeltaReaderBackend::OfficialKernel);
+    assert_eq!(options.reader_backend(), ParquetReaderBackend::DeltaKernel);
     options.validate()?;
 
     let error = DeltaReaderExecutionOptions::new()
@@ -340,30 +340,4 @@ fn datafusion_provider_contract_is_public() {
         register_delta_table(context, name, table, options)
     }
     let _ = (construct, register);
-}
-
-#[cfg(not(feature = "native-async"))]
-#[tokio::test]
-async fn disabled_native_backend_fails_before_uri_access() {
-    let error = DeltaTableBuilder::new("this URI must never be inspected")
-        .load_table()
-        .await
-        .expect_err("disabled default backend must fail");
-    assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
-    assert_eq!(error.as_str(), "unsupported_backend");
-}
-
-#[cfg(not(feature = "official-kernel"))]
-#[tokio::test]
-async fn disabled_official_backend_fails_before_uri_access() -> Result<(), DeltaReaderError> {
-    let options = DeltaReaderExecutionOptions::new()
-        .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
-    let error = DeltaTableBuilder::new("this URI must never be inspected")
-        .with_execution_options(options)
-        .load_table()
-        .await
-        .expect_err("disabled official backend must fail");
-    assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
-    assert_eq!(error.as_str(), "unsupported_backend");
-    Ok(())
 }

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -1,9 +1,8 @@
 //! Public reader integration tests.
 
-#[cfg(all(feature = "datafusion", feature = "native-async"))]
+#[cfg(feature = "datafusion")]
 #[path = "reader/datafusion_adapter.rs"]
 mod datafusion_adapter;
-#[cfg(any(feature = "native-async", feature = "official-kernel"))]
 #[path = "reader/direct_reader.rs"]
 mod direct_reader;
 #[path = "reader/portable_fixtures.rs"]

--- a/tests/reader/datafusion_adapter.rs
+++ b/tests/reader/datafusion_adapter.rs
@@ -26,7 +26,7 @@ use datafusion::{
     physical_plan::{ExecutionPlan, displayable},
     prelude::{SessionConfig, SessionContext},
 };
-use delta_arrow_reader::DeltaReaderBackend;
+use delta_arrow_reader::ParquetReaderBackend;
 use delta_arrow_reader::{
     DeltaDataFusionScanOptions, DeltaFileRepartitioning, DeltaReaderError,
     DeltaReaderExecutionOptions, DeltaReaderPhase, DeltaTableBuilder, DeltaTableProvider,
@@ -699,7 +699,6 @@ fn external_reader_error(error: &DataFusionError) -> TestResult<&DeltaReaderErro
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract() -> TestResult {
     let fixture = TestTable::partitioned("provider-contract")?;
     let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -835,22 +834,6 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
     .expect_err("zero target must fail");
     assert_eq!(zero_target.phase(), DeltaReaderPhase::Configuration);
 
-    #[cfg(not(feature = "official-kernel"))]
-    {
-        let execution_options = DeltaReaderExecutionOptions::new()
-            .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
-        let unavailable = DeltaTableProvider::try_new(
-            table,
-            DeltaDataFusionScanOptions {
-                execution_options,
-                target_partitions: None,
-                ..Default::default()
-            },
-        )
-        .expect_err("disabled backend must fail");
-        assert_eq!(unavailable.phase(), DeltaReaderPhase::Configuration);
-    }
-
     let unsupported_fixture = TestTable::unsupported("unsupported-provider")?;
     let unsupported = DeltaTableBuilder::new(unsupported_fixture.uri())
         .load_table()
@@ -862,7 +845,6 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn registration_sql_metrics_duplicates_and_repeated_scans_are_exact() -> TestResult {
     let fixture = TestTable::partitioned("registration")?;
     let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -976,7 +958,6 @@ async fn registration_sql_metrics_duplicates_and_repeated_scans_are_exact() -> T
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[cfg(feature = "native-async")]
 async fn caller_runtime_owns_concurrent_dataframe_execution() -> TestResult {
     let fixture = TestTable::partitioned("caller-runtime")?;
     let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -997,15 +978,14 @@ async fn caller_runtime_owns_concurrent_dataframe_execution() -> TestResult {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
-async fn native_exact_and_official_residual_execution_return_the_same_rows() -> TestResult {
+async fn direct_exact_and_kernel_residual_execution_return_the_same_rows() -> TestResult {
     let fixture = TestTable::partitioned("backend-parity")?;
     let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
     let mut outputs = Vec::new();
 
     for (name, backend) in [
-        ("native_orders", DeltaReaderBackend::NativeAsync),
-        ("official_orders", DeltaReaderBackend::OfficialKernel),
+        ("direct_orders", ParquetReaderBackend::DirectParquet),
+        ("kernel_orders", ParquetReaderBackend::DeltaKernel),
     ] {
         let context = SessionContext::new();
         let execution_options = DeltaReaderExecutionOptions::new().with_reader_backend(backend)?;
@@ -1022,8 +1002,8 @@ async fn native_exact_and_official_residual_execution_return_the_same_rows() -> 
         assert_eq!(
             provider.supports_filters_pushdown(&[&data_filter])?,
             [match backend {
-                DeltaReaderBackend::NativeAsync => TableProviderFilterPushDown::Exact,
-                DeltaReaderBackend::OfficialKernel => TableProviderFilterPushDown::Inexact,
+                ParquetReaderBackend::DirectParquet => TableProviderFilterPushDown::Exact,
+                ParquetReaderBackend::DeltaKernel => TableProviderFilterPushDown::Inexact,
             }]
         );
         context.register_table(name, Arc::new(provider))?;
@@ -1049,7 +1029,6 @@ async fn native_exact_and_official_residual_execution_return_the_same_rows() -> 
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn sql_join_dynamic_filter_prunes_before_file_admission() -> TestResult {
     let context = SessionContext::new_with_config(
         SessionConfig::new()
@@ -1110,7 +1089,6 @@ async fn sql_join_dynamic_filter_prunes_before_file_admission() -> TestResult {
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn dynamic_join_kept_file_still_applies_deletion_vector() -> TestResult {
     let context = SessionContext::new_with_config(
         SessionConfig::new()
@@ -1167,8 +1145,7 @@ async fn dynamic_join_kept_file_still_applies_deletion_vector() -> TestResult {
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
-async fn native_exact_filter_applies_before_deletion_vector_masking() -> TestResult {
+async fn direct_exact_filter_applies_before_deletion_vector_masking() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_two_row_groups_and_deletion_vector(
         "provider-dv-predicate-pruning",
         3,
@@ -1203,7 +1180,6 @@ async fn native_exact_filter_applies_before_deletion_vector_masking() -> TestRes
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn execution_records_batch_size_and_rejects_invalid_partition() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-execution-options")?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
@@ -1249,7 +1225,6 @@ async fn execution_records_batch_size_and_rejects_invalid_partition() -> TestRes
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn empty_scan_has_no_partitions_rows_or_execution_metrics() -> TestResult {
     let fixture = TestTable::empty("provider-empty-scan")?;
     let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
@@ -1287,7 +1262,6 @@ async fn empty_scan_has_no_partitions_rows_or_execution_metrics() -> TestResult 
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn execution_error_preserves_reader_source_and_partial_metrics() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-missing-file")?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
@@ -1325,14 +1299,13 @@ async fn execution_error_preserves_reader_source_and_partial_metrics() -> TestRe
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn execution_stream_drop_preserves_bounded_partial_metrics() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_two_large_files("provider-stream-drop", 20_000)?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
         .load_table()
         .await?;
     let execution_options = DeltaReaderExecutionOptions::new()
-        .with_native_async_prefetch_file_count_per_partition(0)?
+        .with_prefetch_file_count_per_partition(0)?
         .with_max_concurrent_file_reads_per_partition(1)?
         .with_max_concurrent_file_reads_per_scan(Some(1))?
         .with_output_buffer_capacity_per_partition(1)?;
@@ -1373,8 +1346,7 @@ async fn execution_stream_drop_preserves_bounded_partial_metrics() -> TestResult
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
-async fn native_metadata_hint_preserves_rows_and_request_fallback() -> TestResult {
+async fn direct_metadata_hint_preserves_rows_and_request_fallback() -> TestResult {
     let fixture =
         RealParquetDeltaTable::new_with_two_large_files("provider-parquet-metadata-hint", 20_000)?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
@@ -1426,7 +1398,7 @@ async fn native_metadata_hint_preserves_rows_and_request_fallback() -> TestResul
         requests.push(
             snapshot
                 .parquet_data_file_range_get_operations
-                .ok_or("missing NativeAsync range GET metric")?,
+                .ok_or("missing direct Parquet range GET metric")?,
         );
     }
 
@@ -1439,7 +1411,6 @@ async fn native_metadata_hint_preserves_rows_and_request_fallback() -> TestResul
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn dynamic_join_pruning_preserves_the_sql_residual() -> TestResult {
     let context = SessionContext::new_with_config(
         SessionConfig::new()
@@ -1499,14 +1470,13 @@ async fn dynamic_join_pruning_preserves_the_sql_residual() -> TestResult {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
-async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
+async fn optimizer_keeps_limit_above_delta_kernel_residual() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-residual-limit")?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
         .load_table()
         .await?;
     let execution_options = DeltaReaderExecutionOptions::new()
-        .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
+        .with_reader_backend(ParquetReaderBackend::DeltaKernel)?;
     let context = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     register_delta_table(
         &context,
@@ -1545,7 +1515,7 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
         .column(0)
         .as_any()
         .downcast_ref::<StringViewArray>()
-        .ok_or("official kernel did not preserve the DataFusion view schema")?;
+        .ok_or("Delta Kernel did not preserve the DataFusion view schema")?;
     assert_eq!(names.iter().collect::<Vec<_>>(), [Some("bob")]);
     assert_eq!(metrics[0].snapshot().reader.rows_produced, 3);
 
@@ -1572,14 +1542,13 @@ async fn optimizer_keeps_limit_above_official_kernel_residual() -> TestResult {
         .column(0)
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or("official kernel did not preserve the standard Utf8 schema")?;
+        .ok_or("Delta Kernel did not preserve the standard Utf8 schema")?;
     assert_eq!(names.iter().collect::<Vec<_>>(), [Some("bob")]);
     Ok(())
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
-async fn native_scan_decodes_both_string_representations_with_exact_values() -> TestResult {
+async fn direct_scan_decodes_both_string_representations_with_exact_values() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_supported_types("provider-view-values")?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())
         .load_table()
@@ -1701,8 +1670,7 @@ async fn native_scan_decodes_both_string_representations_with_exact_values() -> 
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
-async fn native_scan_preserves_views_through_nested_map_reordering() -> TestResult {
+async fn direct_scan_preserves_views_through_nested_map_reordering() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_reordered_map_value_struct_fields(
         "provider-reordered-map-views",
     )?;
@@ -1766,7 +1734,6 @@ async fn native_scan_preserves_views_through_nested_map_reordering() -> TestResu
 }
 
 #[tokio::test]
-#[cfg(feature = "native-async")]
 async fn joined_delta_scans_keep_distinct_metrics_and_limit_above_join() -> TestResult {
     let fixture = RealParquetDeltaTable::new_default("provider-joined-scans")?;
     let table = DeltaTableBuilder::new(fixture.path().to_string_lossy().into_owned())

--- a/tests/reader/direct_reader.rs
+++ b/tests/reader/direct_reader.rs
@@ -15,9 +15,7 @@ use arrow::{
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
-#[cfg(feature = "official-kernel")]
-use delta_arrow_reader::DeltaReaderBackend;
-#[cfg(feature = "native-async")]
+use delta_arrow_reader::ParquetReaderBackend;
 use delta_arrow_reader::{
     DeltaComparison, DeltaPredicate, DeltaReaderPhase, DeltaScalar, DeltaSnapshotSelection,
     DeltaStorageOptions,
@@ -25,7 +23,6 @@ use delta_arrow_reader::{
 use delta_arrow_reader::{
     DeltaReadMetrics, DeltaReaderExecutionOptions, DeltaScan, DeltaTableBuilder,
 };
-#[cfg(feature = "native-async")]
 use futures_util::StreamExt;
 use futures_util::TryStreamExt;
 use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
@@ -58,14 +55,12 @@ impl TestTable {
         Ok(table)
     }
 
-    #[cfg(feature = "native-async")]
     fn unsupported(name: &str) -> TestResult<Self> {
         let table = Self::empty(name)?;
         table.write_log(0, &[protocol(4), metadata()])?;
         Ok(table)
     }
 
-    #[cfg(feature = "native-async")]
     fn missing_data_file(name: &str) -> TestResult<Self> {
         let table = Self::empty(name)?;
         table.write_log(
@@ -88,7 +83,6 @@ impl TestTable {
         self.0.to_string_lossy().into_owned()
     }
 
-    #[cfg(feature = "native-async")]
     fn normalized_uri(&self) -> TestResult<String> {
         url::Url::from_directory_path(fs::canonicalize(&self.0)?)
             .map(|url| url.into())
@@ -226,14 +220,12 @@ fn ids(batches: &[RecordBatch]) -> Vec<i32> {
         .collect()
 }
 
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 fn sorted_ids(batches: &[RecordBatch]) -> Vec<i32> {
     let mut values = ids(batches);
     values.sort_unstable();
     values
 }
 
-#[cfg(feature = "native-async")]
 fn labels(batches: &[RecordBatch]) -> Vec<Option<String>> {
     batches
         .iter()
@@ -251,7 +243,6 @@ fn labels(batches: &[RecordBatch]) -> Vec<Option<String>> {
 }
 
 #[test]
-#[cfg(feature = "native-async")]
 fn table_loads_versions_and_public_state_is_redacted() -> TestResult {
     let fixture = TestTable::two_versions("load")?;
     let secret_uri = fixture.uri();
@@ -295,7 +286,6 @@ fn table_loads_versions_and_public_state_is_redacted() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "native-async")]
 fn local_end_to_end_example_reads_without_sql() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("local-example")?;
@@ -318,7 +308,6 @@ fn local_end_to_end_example_reads_without_sql() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "native-async")]
 fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
     let fixture = TestTable::unsupported("unsupported")?;
     let runtime = runtime()?;
@@ -344,7 +333,6 @@ fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "native-async")]
 fn projection_predicate_limit_partition_and_metrics_contracts_hold() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("scan")?;
@@ -489,7 +477,7 @@ fn projection_predicate_limit_partition_and_metrics_contracts_hold() -> TestResu
         assert_eq!(zero_snapshot.batches_produced, 0);
 
         let early_options = DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(0)?
+            .with_prefetch_file_count_per_partition(0)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?
             .with_output_buffer_capacity_per_partition(1)?;
@@ -527,12 +515,11 @@ fn projection_predicate_limit_partition_and_metrics_contracts_hold() -> TestResu
 }
 
 #[test]
-#[cfg(feature = "native-async")]
 fn stream_is_pull_driven_reports_one_error_and_retains_drop_metrics() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("drop")?;
         let options = DeltaReaderExecutionOptions::new()
-            .with_native_async_prefetch_file_count_per_partition(1)?
+            .with_prefetch_file_count_per_partition(1)?
             .with_max_concurrent_file_reads_per_partition(1)?
             .with_max_concurrent_file_reads_per_scan(Some(1))?
             .with_output_buffer_capacity_per_partition(1)?;
@@ -577,54 +564,53 @@ fn stream_is_pull_driven_reports_one_error_and_retains_drop_metrics() -> TestRes
     })
 }
 
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 #[test]
-fn official_kernel_matches_native_direct_results() -> TestResult {
+fn delta_kernel_matches_direct_results() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("backend-parity")?;
-        let native = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
-        let official = DeltaTableBuilder::new(fixture.uri())
+        let direct = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
+        let kernel = DeltaTableBuilder::new(fixture.uri())
             .with_execution_options(
                 DeltaReaderExecutionOptions::new()
-                    .with_reader_backend(DeltaReaderBackend::OfficialKernel)?,
+                    .with_reader_backend(ParquetReaderBackend::DeltaKernel)?,
             )
             .load_table()
             .await?;
-        let official_options = DeltaReaderExecutionOptions::new()
-            .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
+        let kernel_options = DeltaReaderExecutionOptions::new()
+            .with_reader_backend(ParquetReaderBackend::DeltaKernel)?;
         let predicate = DeltaPredicate::Compare {
             column: "id".into(),
             op: DeltaComparison::GtEq,
             value: DeltaScalar::Int32(5),
         };
-        let native_scan = native
+        let direct_scan = direct
             .scan()
             .with_projection(vec!["id".into()])
             .with_predicate(predicate.clone())
             .with_target_partitions(2)?
             .build()
             .await?;
-        let official_scan = official
+        let kernel_scan = kernel
             .scan()
             .with_projection(vec!["id".into()])
             .with_predicate(predicate)
             .with_target_partitions(2)?
             .build()
             .await?;
-        let (native_batches, native_metrics) = collect_scan(native_scan).await?;
-        let (official_batches, official_metrics) = collect_scan(official_scan).await?;
+        let (direct_batches, direct_metrics) = collect_scan(direct_scan).await?;
+        let (kernel_batches, kernel_metrics) = collect_scan(kernel_scan).await?;
 
-        assert_eq!(sorted_ids(&native_batches), [5, 6, 7, 8]);
-        assert_eq!(sorted_ids(&official_batches), sorted_ids(&native_batches));
-        assert_eq!(native_metrics.snapshot().files_planned, 1);
-        assert_eq!(official_metrics.snapshot().files_planned, 1);
+        assert_eq!(sorted_ids(&direct_batches), [5, 6, 7, 8]);
+        assert_eq!(sorted_ids(&kernel_batches), sorted_ids(&direct_batches));
+        assert_eq!(direct_metrics.snapshot().files_planned, 1);
+        assert_eq!(kernel_metrics.snapshot().files_planned, 1);
         assert_eq!(
-            native_metrics.snapshot().reader_backend,
-            DeltaReaderBackend::NativeAsync
+            direct_metrics.snapshot().reader_backend,
+            ParquetReaderBackend::DirectParquet
         );
         assert_eq!(
-            official_metrics.snapshot().reader_backend,
-            DeltaReaderBackend::OfficialKernel
+            kernel_metrics.snapshot().reader_backend,
+            ParquetReaderBackend::DeltaKernel
         );
 
         let residual = DeltaPredicate::Compare {
@@ -632,49 +618,47 @@ fn official_kernel_matches_native_direct_results() -> TestResult {
             op: DeltaComparison::Eq,
             value: DeltaScalar::Float64(-0.0),
         };
-        let native_residual = native
+        let direct_residual = direct
             .scan()
             .with_projection(vec!["id".into()])
             .with_predicate(residual.clone())
             .build()
             .await?;
-        let official_residual = official
+        let kernel_residual = kernel
             .scan()
             .with_projection(vec!["id".into()])
             .with_predicate(residual)
             .build()
             .await?;
-        let (native_residual, native_residual_metrics) = collect_scan(native_residual).await?;
-        let (official_residual, official_residual_metrics) =
-            collect_scan(official_residual).await?;
-        assert_eq!(sorted_ids(&native_residual), [1]);
-        assert_eq!(sorted_ids(&official_residual), sorted_ids(&native_residual));
-        assert_eq!(native_residual_metrics.snapshot().rows_produced, 8);
-        assert_eq!(official_residual_metrics.snapshot().rows_produced, 8);
+        let (direct_residual, direct_residual_metrics) = collect_scan(direct_residual).await?;
+        let (kernel_residual, kernel_residual_metrics) = collect_scan(kernel_residual).await?;
+        assert_eq!(sorted_ids(&direct_residual), [1]);
+        assert_eq!(sorted_ids(&kernel_residual), sorted_ids(&direct_residual));
+        assert_eq!(direct_residual_metrics.snapshot().rows_produced, 8);
+        assert_eq!(kernel_residual_metrics.snapshot().rows_produced, 8);
 
-        let per_scan_override = native
+        let per_scan_override = direct
             .scan()
             .with_projection(vec!["id".into()])
-            .with_execution_options(official_options)?
+            .with_execution_options(kernel_options)?
             .build()
             .await?;
         let (override_batches, override_metrics) = collect_scan(per_scan_override).await?;
         assert_eq!(sorted_ids(&override_batches), [1, 2, 3, 4, 5, 6, 7, 8]);
         assert_eq!(
             override_metrics.snapshot().reader_backend,
-            DeltaReaderBackend::OfficialKernel
+            ParquetReaderBackend::DeltaKernel
         );
         Ok::<_, Box<dyn Error>>(())
     })
 }
 
-#[cfg(feature = "official-kernel")]
 #[test]
-fn official_kernel_reads_through_the_direct_surface() -> TestResult {
+fn delta_kernel_reads_through_the_direct_surface() -> TestResult {
     runtime()?.block_on(async {
-        let fixture = TestTable::two_versions("official-direct")?;
+        let fixture = TestTable::two_versions("kernel-direct")?;
         let options = DeltaReaderExecutionOptions::new()
-            .with_reader_backend(DeltaReaderBackend::OfficialKernel)?;
+            .with_reader_backend(ParquetReaderBackend::DeltaKernel)?;
         let table = DeltaTableBuilder::new(fixture.uri())
             .with_execution_options(options)
             .load_table()
@@ -690,7 +674,7 @@ fn official_kernel_reads_through_the_direct_surface() -> TestResult {
         assert_eq!(ids(&batches).len(), 8);
         assert_eq!(
             metrics.snapshot().reader_backend,
-            DeltaReaderBackend::OfficialKernel
+            ParquetReaderBackend::DeltaKernel
         );
         Ok::<_, Box<dyn Error>>(())
     })

--- a/tests/reader/portable_fixtures.rs
+++ b/tests/reader/portable_fixtures.rs
@@ -2,30 +2,24 @@
 
 use std::{error::Error, path::Path};
 
-#[cfg(feature = "native-async")]
 use std::{fs, fs::File, sync::Arc};
 
-#[cfg(feature = "native-async")]
 use arrow::{
     array::Int32Array, compute::concat_batches, datatypes::SchemaRef, record_batch::RecordBatch,
     util::display::array_value_to_string,
 };
-#[cfg(feature = "native-async")]
 use delta_arrow_reader::{
     DeltaBatchStream, DeltaComparison, DeltaPredicate, DeltaReadMetrics, DeltaReadMetricsSnapshot,
-    DeltaReaderBackend, DeltaReaderError, DeltaReaderExecutionOptions, DeltaReaderPhase,
-    DeltaScalar, DeltaTableBuilder,
+    DeltaReaderError, DeltaReaderExecutionOptions, DeltaReaderPhase, DeltaScalar,
+    DeltaTableBuilder, ParquetReaderBackend,
 };
-#[cfg(feature = "native-async")]
 use futures_util::{StreamExt, TryStreamExt};
-#[cfg(feature = "native-async")]
 use parquet::file::{reader::FileReader, serialized_reader::SerializedFileReader};
 
 use super::support::RealParquetDeltaTable;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error>>;
 
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 struct BackendParityCase {
     name: &'static str,
     fixture: RealParquetDeltaTable,
@@ -34,17 +28,13 @@ struct BackendParityCase {
     expected_deleted_rows: Option<u64>,
 }
 
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const COLUMN_MAPPING_ROWS: &[&str] = &["alice\t1", "bob\t2", "\t3"];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const PARTITION_ROWS: &[&str] = &["us-west\t1", "us-west\t2", "us-west\t3"];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const SUPPORTED_TYPE_ROWS: &[&str] = &[
     "1\talice\ttrue\t616c706861\t2024-01-01\t2024-01-01T00:00:00Z\t123.45\t1.25\t10.5\t{level: 1, label: low}\t[10, 20]",
     "2\tbob\tfalse\t62657461\t2024-01-02\t2024-01-02T00:00:00Z\t-67.89\t-2.5\t-20.25\t{level: 2, label: high}\t[30]",
     "3\t\t\t\t\t\t\t\t\t{level: , label: }\t",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const TIMESTAMP_ROWS: &[&str] = &[
     "1\talice\t2024-01-01T00:00:00Z",
     "2\tbob\t2024-01-02T00:00:00Z",
@@ -53,7 +43,6 @@ const TIMESTAMP_ROWS: &[&str] = &[
     "5\tdylan\t2024-01-04T00:00:00Z",
     "6\t\t",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const NESTED_TIMESTAMP_ROWS: &[&str] = &[
     "1\t{event_ts: 2024-01-01T00:00:00Z}",
     "2\t{event_ts: 2024-01-02T00:00:00Z}",
@@ -62,94 +51,76 @@ const NESTED_TIMESTAMP_ROWS: &[&str] = &[
     "5\t{event_ts: 2024-01-04T00:00:00Z}",
     "6\t{event_ts: }",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const NESTED_ROWS: &[&str] = &[
     "{age: 34, first_name: alice}\t1",
     "{age: 41, first_name: bob}\t2",
     "{age: , first_name: }\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const NESTED_MAPPING_ROWS: &[&str] = &[
     "{first_name: alice, age: 34}\talice\t1",
     "{first_name: bob, age: 41}\tbob\t2",
     "{first_name: , age: }\t\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const PROJECTED_NESTED_MAPPING_ROWS: &[&str] = &[
     "{first_name: alice, age: 34}",
     "{first_name: bob, age: 41}",
     "{first_name: , age: }",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const ARRAY_ROWS: &[&str] = &[
     "[{zip: 94110, city: san francisco}, {zip: 10001, city: new york}]\t1",
     "\t2",
     "[{zip: , city: phoenix}]\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MISSING_ARRAY_ROWS: &[&str] = &[
     "[{zip: 94110, city: san francisco, country: }, {zip: 10001, city: new york, country: }]\t1",
     "\t2",
     "[{zip: , city: phoenix, country: }]\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const ARRAY_MAPPING_ROWS: &[&str] = &[
     "[{city: san francisco, zip: 94110}, {city: new york, zip: 10001}]\talice\t1",
     "\tbob\t2",
     "[{city: phoenix, zip: }]\t\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MAP_ROWS: &[&str] = &[
     "{home: {zip: 94110, city: san francisco}, work: {zip: 10001, city: new york}}\t1",
     "{}\t2",
     "{mailing: {zip: , city: phoenix}}\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MISSING_MAP_ROWS: &[&str] = &[
     "{home: {zip: 94110, city: san francisco, country: }, work: {zip: 10001, city: new york, country: }}\t1",
     "{}\t2",
     "{mailing: {zip: , city: phoenix, country: }}\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MAP_KEY_CAST_ROWS: &[&str] = &["{10: home, 20: work}\t1", "{}\t2", "{30: mailing}\t3"];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MAP_MAPPING_ROWS: &[&str] = &[
     "{home: {city: san francisco, zip: 94110}, work: {city: new york, zip: 10001}}\talice\t1",
     "{}\tbob\t2",
     "{mailing: {city: phoenix, zip: }}\t\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MAP_KEY_VALUE_MAPPING_ROWS: &[&str] = &[
     "{{city: san francisco, zip: 94110}: {label: home, score: 7}, {city: new york, zip: 10001}: {label: work, score: 8}}\talice\t1",
     "{}\tbob\t2",
     "{{city: phoenix, zip: }: {label: mailing, score: 9}}\t\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MAP_LIST_KEY_ROWS: &[&str] = &[
     "{[{zip: 94110, city: san francisco}, {zip: 10001, city: new york}]: home, []: work}\t1",
     "{}\t2",
     "{[{zip: , city: phoenix}]: mailing}\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const NESTED_MAP_KEY_ROWS: &[&str] = &[
     "{{{zip: 94110, city: san francisco}: 7, {zip: 10001, city: new york}: 8}: home, {}: work}\t1",
     "{}\t2",
     "{{{zip: , city: phoenix}: 9}: mailing}\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MISSING_NESTED_ROWS: &[&str] = &[
     "{age: 34, first_name: alice, loyalty_tier: }\t1",
     "{age: 41, first_name: bob, loyalty_tier: }\t2",
     "{age: , first_name: , loyalty_tier: }\t3",
 ];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const MISSING_COLUMN_ROWS: &[&str] = &["1\talice\t", "2\tbob\t", "3\t\t"];
-#[cfg(feature = "native-async")]
 const DEFAULT_ROWS: &[&str] = &["1\talice", "2\tbob", "3\t"];
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 const DELETION_VECTOR_ROWS: &[&str] = &["1\talice", "3\t"];
 
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 fn backend_parity_cases() -> TestResult<Vec<BackendParityCase>> {
     let case =
         |name, fixture, projection, expected_rows, expected_deleted_rows| BackendParityCase {
@@ -500,7 +471,6 @@ fn every_frozen_real_parquet_fixture_is_portable() -> TestResult {
     Ok(())
 }
 
-#[cfg(feature = "native-async")]
 enum ScanAttempt {
     Success {
         batch: RecordBatch,
@@ -514,24 +484,21 @@ enum ScanAttempt {
     },
 }
 
-#[cfg(feature = "native-async")]
 fn runtime() -> TestResult<tokio::runtime::Runtime> {
     Ok(tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?)
 }
 
-#[cfg(feature = "native-async")]
-fn native_options(capacity: usize, prefetch: usize) -> TestResult<DeltaReaderExecutionOptions> {
+fn direct_options(capacity: usize, prefetch: usize) -> TestResult<DeltaReaderExecutionOptions> {
     Ok(DeltaReaderExecutionOptions::new()
-        .with_native_async_prefetch_file_count_per_partition(0)?
+        .with_prefetch_file_count_per_partition(0)?
         .with_max_concurrent_file_reads_per_partition(capacity)?
         .with_max_concurrent_file_reads_per_scan(Some(capacity))?
         .with_output_buffer_capacity_per_partition(1)?
-        .with_native_async_prefetch_file_count_per_partition(prefetch)?)
+        .with_prefetch_file_count_per_partition(prefetch)?)
 }
 
-#[cfg(feature = "native-async")]
 async fn wait_for_delivered_batch_metrics(metrics: &DeltaReadMetrics) {
     for _ in 0..1000 {
         if metrics.snapshot().batches_produced > 0 {
@@ -541,7 +508,6 @@ async fn wait_for_delivered_batch_metrics(metrics: &DeltaReadMetrics) {
     }
 }
 
-#[cfg(feature = "native-async")]
 fn missing_data_file_fixture(
     name: &str,
     advertised_size: u64,
@@ -560,13 +526,11 @@ fn missing_data_file_fixture(
     Ok(fixture)
 }
 
-#[cfg(feature = "native-async")]
 fn projection(names: &[&str]) -> Option<Vec<String>> {
     Some(names.iter().map(|name| (*name).to_owned()).collect())
 }
 
-#[cfg(feature = "native-async")]
-async fn native_stream(
+async fn direct_stream(
     fixture: &RealParquetDeltaTable,
     options: DeltaReaderExecutionOptions,
 ) -> TestResult<DeltaBatchStream> {
@@ -584,10 +548,9 @@ async fn native_stream(
     Ok(scan.execute().await?)
 }
 
-#[cfg(feature = "native-async")]
 async fn scan_fixture(
     fixture: &RealParquetDeltaTable,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     projection: Option<Vec<String>>,
     predicate: Option<DeltaPredicate>,
 ) -> TestResult<ScanAttempt> {
@@ -633,7 +596,6 @@ async fn scan_fixture(
     }
 }
 
-#[cfg(feature = "native-async")]
 fn batch_ids(batch: &RecordBatch) -> TestResult<Vec<i32>> {
     let index = batch.schema().index_of("id")?;
     let ids = batch
@@ -644,7 +606,6 @@ fn batch_ids(batch: &RecordBatch) -> TestResult<Vec<i32>> {
     Ok(ids.values().to_vec())
 }
 
-#[cfg(feature = "native-async")]
 fn batch_rows_ordered_by_id(batch: &RecordBatch) -> TestResult<Vec<String>> {
     let mut rows = (0..batch.num_rows()).collect::<Vec<_>>();
     if let Ok(id_index) = batch.schema().index_of("id") {
@@ -669,10 +630,9 @@ fn batch_rows_ordered_by_id(batch: &RecordBatch) -> TestResult<Vec<String>> {
         .collect()
 }
 
-#[cfg(feature = "native-async")]
 fn assert_success(
     case_name: &str,
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     attempt: ScanAttempt,
     expected_ids: &[i32],
 ) -> TestResult<(RecordBatch, DeltaReadMetricsSnapshot, usize)> {
@@ -709,7 +669,6 @@ fn assert_success(
     Ok((batch, metrics, batch_count))
 }
 
-#[cfg(feature = "native-async")]
 fn assert_missing_required(
     case_name: &str,
     expected_path: &str,
@@ -746,7 +705,7 @@ fn assert_missing_required(
         source_display.contains("is missing from the Parquet file"),
         "{case_name}: {source_display}"
     );
-    assert_eq!(metrics.reader_backend, DeltaReaderBackend::NativeAsync);
+    assert_eq!(metrics.reader_backend, ParquetReaderBackend::DirectParquet);
     assert_eq!(metrics.files_started, 1, "{case_name}");
     assert_eq!(metrics.files_completed, 0, "{case_name}");
     assert_eq!(metrics.batches_produced, 0, "{case_name}");
@@ -754,9 +713,8 @@ fn assert_missing_required(
     Ok(())
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
+fn direct_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
     struct Case {
         name: &'static str,
         fixture: RealParquetDeltaTable,
@@ -769,7 +727,7 @@ fn native_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
             Case {
                 name: "missing required array struct field",
                 fixture: RealParquetDeltaTable::new_with_missing_non_nullable_array_struct_field(
-                    "direct-native-missing-required-array",
+                    "direct-missing-required-array",
                 )?,
                 path: "addresses.element.required_country",
                 projection: &["addresses", "id"],
@@ -778,7 +736,7 @@ fn native_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
                 name: "missing required map value struct field",
                 fixture:
                     RealParquetDeltaTable::new_with_missing_non_nullable_map_value_struct_field(
-                        "direct-native-missing-required-map-value",
+                        "direct-missing-required-map-value",
                     )?,
                 path: "attributes.value.required_country",
                 projection: &["attributes", "id"],
@@ -786,7 +744,7 @@ fn native_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
             Case {
                 name: "missing required nested struct field",
                 fixture: RealParquetDeltaTable::new_with_missing_non_nullable_nested_struct_field(
-                    "direct-native-missing-required-nested",
+                    "direct-missing-required-nested",
                 )?,
                 path: "profile.required_code",
                 projection: &["profile", "id"],
@@ -794,7 +752,7 @@ fn native_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
             Case {
                 name: "missing required column",
                 fixture: RealParquetDeltaTable::new_with_missing_non_nullable_column(
-                    "direct-native-missing-required-column",
+                    "direct-missing-required-column",
                 )?,
                 path: "required_code",
                 projection: &["id", "customer_name", "required_code"],
@@ -804,7 +762,7 @@ fn native_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
         for case in cases {
             let attempt = scan_fixture(
                 &case.fixture,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 projection(case.projection),
                 None,
             )
@@ -815,12 +773,10 @@ fn native_missing_required_fields_preserve_errors_and_metrics() -> TestResult {
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_exact_predicates_preserve_deletion_vector_row_indexes() -> TestResult {
+fn direct_exact_predicates_preserve_deletion_vector_row_indexes() -> TestResult {
     runtime()?.block_on(async {
-        let fixture =
-            RealParquetDeltaTable::new_with_deletion_vector("direct-native-dv-predicate", &[1])?;
+        let fixture = RealParquetDeltaTable::new_with_deletion_vector("direct-dv-predicate", &[1])?;
 
         for (name, value, expected, rows_produced, rows_deleted) in [
             ("only deleted row", 2, Vec::new(), 0, 1),
@@ -833,10 +789,10 @@ fn native_exact_predicates_preserve_deletion_vector_row_indexes() -> TestResult 
             };
             let (_, metrics, _) = assert_success(
                 name,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 scan_fixture(
                     &fixture,
-                    DeltaReaderBackend::NativeAsync,
+                    ParquetReaderBackend::DirectParquet,
                     Some(vec!["id".to_owned()]),
                     Some(predicate),
                 )
@@ -853,7 +809,7 @@ fn native_exact_predicates_preserve_deletion_vector_row_indexes() -> TestResult 
 
         let no_rows = scan_fixture(
             &fixture,
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             Some(vec!["id".to_owned()]),
             Some(DeltaPredicate::Compare {
                 column: "id".into(),
@@ -873,13 +829,11 @@ fn native_exact_predicates_preserve_deletion_vector_row_indexes() -> TestResult 
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_partial_pruning_predicate_remains_residual_only() -> TestResult {
+fn direct_partial_pruning_predicate_remains_residual_only() -> TestResult {
     runtime()?.block_on(async {
-        let fixture = RealParquetDeltaTable::new_with_supported_types(
-            "direct-native-partial-pruning-predicate",
-        )?;
+        let fixture =
+            RealParquetDeltaTable::new_with_supported_types("direct-partial-pruning-predicate")?;
         let predicate = DeltaPredicate::And(vec![
             DeltaPredicate::Compare {
                 column: "id".into(),
@@ -894,10 +848,10 @@ fn native_partial_pruning_predicate_remains_residual_only() -> TestResult {
         ]);
         let (_, metrics, _) = assert_success(
             "partial pruning predicate",
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             scan_fixture(
                 &fixture,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 Some(vec!["id".to_owned()]),
                 Some(predicate),
             )
@@ -910,9 +864,8 @@ fn native_partial_pruning_predicate_remains_residual_only() -> TestResult {
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestResult {
+fn direct_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestResult {
     struct Case {
         name: &'static str,
         fixture: RealParquetDeltaTable,
@@ -930,7 +883,7 @@ fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestR
             Case {
                 name: "multiple batches",
                 fixture: RealParquetDeltaTable::new_with_rows_and_deletion_vector(
-                    "direct-native-dv-multiple-batches",
+                    "direct-dv-multiple-batches",
                     9_000,
                     &[8_191, 8_192, 8_999],
                 )?,
@@ -945,7 +898,7 @@ fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestR
             Case {
                 name: "multiple row groups",
                 fixture: RealParquetDeltaTable::new_with_two_row_groups_and_deletion_vector(
-                    "direct-native-dv-row-groups",
+                    "direct-dv-row-groups",
                     3_000,
                     &[2_999, 3_000, 5_999],
                 )?,
@@ -960,7 +913,7 @@ fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestR
             Case {
                 name: "sparse indexes",
                 fixture: RealParquetDeltaTable::new_with_rows_and_deletion_vector(
-                    "direct-native-dv-sparse",
+                    "direct-dv-sparse",
                     40_000,
                     &[0, 19_999, 39_999],
                 )?,
@@ -975,7 +928,7 @@ fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestR
             Case {
                 name: "all rows live",
                 fixture: RealParquetDeltaTable::new_with_deletion_vector(
-                    "direct-native-dv-all-live",
+                    "direct-dv-all-live",
                     &[],
                 )?,
                 rows: 3,
@@ -989,7 +942,7 @@ fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestR
             Case {
                 name: "all rows deleted",
                 fixture: RealParquetDeltaTable::new_with_deletion_vector(
-                    "direct-native-dv-all-deleted",
+                    "direct-dv-all-deleted",
                     &[0, 1, 2],
                 )?,
                 rows: 3,
@@ -1015,10 +968,10 @@ fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestR
                 .collect::<Vec<_>>();
             let (batch, metrics, batch_count) = assert_success(
                 case.name,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 scan_fixture(
                     &case.fixture,
-                    DeltaReaderBackend::NativeAsync,
+                    ParquetReaderBackend::DirectParquet,
                     projection(case.projection),
                     None,
                 )
@@ -1066,44 +1019,37 @@ fn native_deletion_vector_boundaries_preserve_rows_schema_and_metrics() -> TestR
                 assert_eq!(metrics.batches_produced, u64::try_from(batch_count)?);
             }
 
-            #[cfg(feature = "official-kernel")]
             if case.compare_official {
-                let (official, _, _) = assert_success(
+                let (kernel, _, _) = assert_success(
                     case.name,
-                    DeltaReaderBackend::OfficialKernel,
+                    ParquetReaderBackend::DeltaKernel,
                     scan_fixture(
                         &case.fixture,
-                        DeltaReaderBackend::OfficialKernel,
+                        ParquetReaderBackend::DeltaKernel,
                         projection(case.projection),
                         None,
                     )
                     .await?,
                     &expected,
                 )?;
-                assert_eq!(official, batch, "{}", case.name);
+                assert_eq!(kernel, batch, "{}", case.name);
             }
-
-            #[cfg(not(feature = "official-kernel"))]
-            let _ = case.compare_official;
         }
         Ok::<_, Box<dyn Error>>(())
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_deletion_vector_payload_error_is_redacted_and_metered() -> TestResult {
+fn direct_deletion_vector_payload_error_is_redacted_and_metered() -> TestResult {
     const RELATIVE_DV_FILE: &str = "deletion_vector_61d16c75-6994-46b7-a15b-8b538852e50e.bin";
 
     runtime()?.block_on(async {
-        let fixture = RealParquetDeltaTable::new_with_deletion_vector(
-            "direct-native-dv-payload-error",
-            &[1],
-        )?;
+        let fixture =
+            RealParquetDeltaTable::new_with_deletion_vector("direct-dv-payload-error", &[1])?;
         fs::remove_file(fixture.path().join(RELATIVE_DV_FILE))?;
         let ScanAttempt::Failure { error, metrics } = scan_fixture(
             &fixture,
-            DeltaReaderBackend::NativeAsync,
+            ParquetReaderBackend::DirectParquet,
             projection(&["id"]),
             None,
         )
@@ -1120,7 +1066,7 @@ fn native_deletion_vector_payload_error_is_redacted_and_metered() -> TestResult 
             "{display}"
         );
         assert!(!display.contains(RELATIVE_DV_FILE));
-        assert_eq!(metrics.reader_backend, DeltaReaderBackend::NativeAsync);
+        assert_eq!(metrics.reader_backend, ParquetReaderBackend::DirectParquet);
         assert_eq!(metrics.files_started, 1);
         assert_eq!(metrics.files_completed, 0);
         assert_eq!(metrics.batches_produced, 0);
@@ -1134,21 +1080,20 @@ fn native_deletion_vector_payload_error_is_redacted_and_metered() -> TestResult 
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_preserves_frozen_file_and_batch_order() -> TestResult {
+fn direct_preserves_frozen_file_and_batch_order() -> TestResult {
     runtime()?.block_on(async {
         let cases = [
             (
                 "two files",
-                RealParquetDeltaTable::new_with_two_files("direct-native-file-order")?,
+                RealParquetDeltaTable::new_with_two_files("direct-file-order")?,
                 (1..=4).collect::<Vec<_>>(),
                 2,
                 false,
             ),
             (
                 "multiple batches",
-                RealParquetDeltaTable::new_with_rows("direct-native-multiple-batch-order", 9_000)?,
+                RealParquetDeltaTable::new_with_rows("direct-multiple-batch-order", 9_000)?,
                 (1..=9_000).collect::<Vec<_>>(),
                 1,
                 true,
@@ -1158,10 +1103,10 @@ fn native_preserves_frozen_file_and_batch_order() -> TestResult {
         for (name, fixture, expected, expected_files, require_multiple_batches) in cases {
             let (batch, metrics, batch_count) = assert_success(
                 name,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 scan_fixture(
                     &fixture,
-                    DeltaReaderBackend::NativeAsync,
+                    ParquetReaderBackend::DirectParquet,
                     projection(&["id"]),
                     None,
                 )
@@ -1186,14 +1131,13 @@ fn native_preserves_frozen_file_and_batch_order() -> TestResult {
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_missing_file_preserves_read_error_and_metrics() -> TestResult {
+fn direct_missing_file_preserves_read_error_and_metrics() -> TestResult {
     runtime()?.block_on(async {
-        let fixture = missing_data_file_fixture("direct-native-missing-file", 123)?;
+        let fixture = missing_data_file_fixture("direct-missing-file", 123)?;
         let relative_path = fixture.data_file_path().to_owned();
 
-        let mut stream = native_stream(&fixture, native_options(1, 0)?).await?;
+        let mut stream = direct_stream(&fixture, direct_options(1, 0)?).await?;
         let metrics = stream.metrics();
         let error = stream
             .next()
@@ -1214,7 +1158,7 @@ fn native_missing_file_preserves_read_error_and_metrics() -> TestResult {
         let metrics = metrics.snapshot();
         assert_eq!(metrics.files_started, 1);
         assert_eq!(metrics.files_completed, 0);
-        assert_eq!(metrics.reader_backend, DeltaReaderBackend::NativeAsync);
+        assert_eq!(metrics.reader_backend, ParquetReaderBackend::DirectParquet);
         assert_eq!(metrics.parquet_data_file_opened_bytes, Some(123));
         assert!(
             metrics
@@ -1229,15 +1173,12 @@ fn native_missing_file_preserves_read_error_and_metrics() -> TestResult {
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_stream_drop_stops_future_file_scheduling() -> TestResult {
+fn direct_stream_drop_stops_future_file_scheduling() -> TestResult {
     runtime()?.block_on(async {
-        let fixture = RealParquetDeltaTable::new_with_two_large_files(
-            "direct-native-drop-scheduling",
-            20_000,
-        )?;
-        let mut stream = native_stream(&fixture, native_options(1, 0)?).await?;
+        let fixture =
+            RealParquetDeltaTable::new_with_two_large_files("direct-drop-scheduling", 20_000)?;
+        let mut stream = direct_stream(&fixture, direct_options(1, 0)?).await?;
         let metrics = stream.metrics();
         let first = stream.next().await.ok_or("expected first batch")??;
 
@@ -1246,7 +1187,7 @@ fn native_stream_drop_stops_future_file_scheduling() -> TestResult {
         wait_for_delivered_batch_metrics(&metrics).await;
 
         let metrics = metrics.snapshot();
-        assert_eq!(metrics.reader_backend, DeltaReaderBackend::NativeAsync);
+        assert_eq!(metrics.reader_backend, ParquetReaderBackend::DirectParquet);
         assert_eq!(metrics.scan_partitions_started, 1);
         assert_eq!(metrics.scan_partitions_completed, 0);
         assert_eq!(metrics.files_started, 1);
@@ -1257,16 +1198,15 @@ fn native_stream_drop_stops_future_file_scheduling() -> TestResult {
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_deletion_vector_stream_drop_preserves_partial_metrics() -> TestResult {
+fn direct_deletion_vector_stream_drop_preserves_partial_metrics() -> TestResult {
     runtime()?.block_on(async {
         let fixture = RealParquetDeltaTable::new_with_rows_and_deletion_vector(
-            "direct-native-dv-drop-partial-progress",
+            "direct-dv-drop-partial-progress",
             20_000,
             &[0, 8_191, 8_192, 19_999],
         )?;
-        let mut stream = native_stream(&fixture, native_options(1, 0)?).await?;
+        let mut stream = direct_stream(&fixture, direct_options(1, 0)?).await?;
         let metrics = stream.metrics();
         let first = stream.next().await.ok_or("expected first batch")??;
         let first_ids = batch_ids(&first)?;
@@ -1278,7 +1218,7 @@ fn native_deletion_vector_stream_drop_preserves_partial_metrics() -> TestResult 
         wait_for_delivered_batch_metrics(&metrics).await;
 
         let metrics = metrics.snapshot();
-        assert_eq!(metrics.reader_backend, DeltaReaderBackend::NativeAsync);
+        assert_eq!(metrics.reader_backend, ParquetReaderBackend::DirectParquet);
         assert_eq!(metrics.scan_partitions_started, 1);
         assert_eq!(metrics.scan_partitions_completed, 0);
         assert_eq!(metrics.files_started, 1);
@@ -1294,15 +1234,14 @@ fn native_deletion_vector_stream_drop_preserves_partial_metrics() -> TestResult 
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_backpressure_bounds_future_file_scheduling() -> TestResult {
+fn direct_backpressure_bounds_future_file_scheduling() -> TestResult {
     runtime()?.block_on(async {
         let fixture = RealParquetDeltaTable::new_with_two_large_files(
-            "direct-native-backpressure-scheduling",
+            "direct-backpressure-scheduling",
             20_000,
         )?;
-        let mut stream = native_stream(&fixture, native_options(1, 0)?).await?;
+        let mut stream = direct_stream(&fixture, direct_options(1, 0)?).await?;
         let metrics = stream.metrics();
         let first = stream.next().await.ok_or("expected first batch")??;
         let mut ids = batch_ids(&first)?;
@@ -1318,7 +1257,7 @@ fn native_backpressure_bounds_future_file_scheduling() -> TestResult {
         }
         assert_eq!(ids, (1..=40_000).collect::<Vec<_>>());
         let complete = metrics.snapshot();
-        assert_eq!(complete.reader_backend, DeltaReaderBackend::NativeAsync);
+        assert_eq!(complete.reader_backend, ParquetReaderBackend::DirectParquet);
         assert_eq!(complete.scan_partitions_completed, 1);
         assert_eq!(complete.files_started, 2);
         assert_eq!(complete.files_completed, 2);
@@ -1327,15 +1266,14 @@ fn native_backpressure_bounds_future_file_scheduling() -> TestResult {
     })
 }
 
-#[cfg(feature = "native-async")]
 #[test]
-fn native_prefetch_preserves_file_order_and_completes() -> TestResult {
+fn direct_prefetch_preserves_file_order_and_completes() -> TestResult {
     runtime()?.block_on(async {
         let fixture =
-            RealParquetDeltaTable::new_with_two_large_files("direct-native-prefetch-order", 9_000)?;
-        let options = native_options(2, 1)?;
-        assert_eq!(options.native_async_prefetch_file_count_per_partition(), 1);
-        let stream = native_stream(&fixture, options).await?;
+            RealParquetDeltaTable::new_with_two_large_files("direct-prefetch-order", 9_000)?;
+        let options = direct_options(2, 1)?;
+        assert_eq!(options.prefetch_file_count_per_partition(), 1);
+        let stream = direct_stream(&fixture, options).await?;
         let metrics = stream.metrics();
         let batches = stream.try_collect::<Vec<_>>().await?;
         let mut ids = Vec::new();
@@ -1345,7 +1283,7 @@ fn native_prefetch_preserves_file_order_and_completes() -> TestResult {
 
         assert_eq!(ids, (1..=18_000).collect::<Vec<_>>());
         let metrics = metrics.snapshot();
-        assert_eq!(metrics.reader_backend, DeltaReaderBackend::NativeAsync);
+        assert_eq!(metrics.reader_backend, ParquetReaderBackend::DirectParquet);
         assert_eq!(metrics.scan_partitions_completed, 1);
         assert_eq!(metrics.files_started, 2);
         assert_eq!(metrics.files_completed, 2);
@@ -1358,12 +1296,11 @@ fn native_prefetch_preserves_file_order_and_completes() -> TestResult {
     })
 }
 
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 fn assert_parity_success(
     case_name: &str,
     projected_columns: &[&str],
     expected_rows: &[&str],
-    backend: DeltaReaderBackend,
+    backend: ParquetReaderBackend,
     attempt: ScanAttempt,
 ) -> TestResult<(RecordBatch, DeltaReadMetricsSnapshot)> {
     let ScanAttempt::Success {
@@ -1407,50 +1344,49 @@ fn assert_parity_success(
     Ok((batch, metrics))
 }
 
-#[cfg(all(feature = "native-async", feature = "official-kernel"))]
 #[test]
-fn official_kernel_matches_native_for_frozen_cases() -> TestResult {
+fn delta_kernel_matches_direct_for_frozen_cases() -> TestResult {
     runtime()?.block_on(async {
         let cases = backend_parity_cases()?;
         assert_eq!(cases.len(), 24);
 
         for case in cases {
-            let native = scan_fixture(
+            let direct = scan_fixture(
                 &case.fixture,
-                DeltaReaderBackend::NativeAsync,
+                ParquetReaderBackend::DirectParquet,
                 projection(case.projection),
                 None,
             )
             .await?;
-            let official = scan_fixture(
+            let kernel = scan_fixture(
                 &case.fixture,
-                DeltaReaderBackend::OfficialKernel,
+                ParquetReaderBackend::DeltaKernel,
                 projection(case.projection),
                 None,
             )
             .await?;
-            let (native, native_metrics) = assert_parity_success(
+            let (direct, direct_metrics) = assert_parity_success(
                 case.name,
                 case.projection,
                 case.expected_rows,
-                DeltaReaderBackend::NativeAsync,
-                native,
+                ParquetReaderBackend::DirectParquet,
+                direct,
             )?;
-            let (official, _) = assert_parity_success(
+            let (kernel, _) = assert_parity_success(
                 case.name,
                 case.projection,
                 case.expected_rows,
-                DeltaReaderBackend::OfficialKernel,
-                official,
+                ParquetReaderBackend::DeltaKernel,
+                kernel,
             )?;
 
-            assert_eq!(official, native, "{}", case.name);
+            assert_eq!(kernel, direct, "{}", case.name);
             if let Some(deleted_rows) = case.expected_deleted_rows {
-                assert_eq!(native_metrics.deletion_vector_payloads_loaded, 1);
-                assert_eq!(native_metrics.deletion_vectors_applied, 1);
-                assert_eq!(native_metrics.deletion_vector_rows_deleted, deleted_rows);
-                assert_eq!(native_metrics.deletion_vector_failures, 0);
-                assert_eq!(native_metrics.deletion_vector_rejections, 0);
+                assert_eq!(direct_metrics.deletion_vector_payloads_loaded, 1);
+                assert_eq!(direct_metrics.deletion_vectors_applied, 1);
+                assert_eq!(direct_metrics.deletion_vector_rows_deleted, deleted_rows);
+                assert_eq!(direct_metrics.deletion_vector_failures, 0);
+                assert_eq!(direct_metrics.deletion_vector_rejections, 0);
             }
         }
 

--- a/tests/reader/support/real_parquet_delta_table.rs
+++ b/tests/reader/support/real_parquet_delta_table.rs
@@ -401,7 +401,7 @@ impl RealParquetDeltaTable {
     }
 
     /// Creates a local Delta table covering the scalar and nested data types
-    /// the native async reader is expected to preserve without special Delta
+    /// the direct async reader is expected to preserve without special Delta
     /// metadata features.
     pub(crate) fn new_with_supported_types(name: &str) -> Result<Self, Box<dyn std::error::Error>> {
         Self::new_with_protocol_metadata_file_batches(


### PR DESCRIPTION
## Summary

- make both Parquet reader implementations available at runtime and remove the `native-async` and `official-kernel` Cargo features
- rename the public backend API to `ParquetReaderBackend::{DirectParquet, DeltaKernel}`
- rename direct-reader settings, internal modules, documentation, metrics labels, and benchmark output to match the runtime API
- keep `datafusion` as the only optional Cargo feature and reduce CI to the two real build configurations

## Breaking changes

- `DeltaReaderBackend` is replaced by `ParquetReaderBackend`
- `NativeAsync` and `OfficialKernel` are replaced by `DirectParquet` and `DeltaKernel`
- `native_async_prefetch_file_count_per_partition` is replaced by `prefetch_file_count_per_partition`
- the `native-async` and `official-kernel` Cargo features are removed

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked`
- `cargo test --locked --features datafusion`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps`
- `cargo package --locked --allow-dirty`
- `python -m zensical build --strict -f docs-site/mkdocs.yml`
