### PR TITLE
docs: compare Delta reader performance and tradeoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,50 @@ is read when DataFusion executes the query.
 The [DataFusion quickstart](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
 walks through registration and a first SQL query.
 
+## Why not...
+
+Most alternatives solve a much bigger problem than reading a Delta table. Their
+Delta path pays for that extra weight.
+
+### Spark or Trino
+
+Spark is Delta Lake's home ground, and Trino is a proven distributed engine.
+Both make sense when you already need a cluster. As the foundation of a small,
+single-node read service, however, they are heavy: a JVM, a full query runtime,
+and far more operational machinery than the job requires. Running either one
+just to stream Arrow batches is bringing a distributed system to do a library's
+job.
+
+### The "read everything" engines
+
+DuckDB, Polars, and Daft promise one engine for many formats. Delta Lake becomes
+another compatibility box to check, and the jack-of-all-trades tradeoff showed
+clearly in our benchmarks. DuckDB took 5.8-14.6 times as long as Delta Arrow
+Reader, and Polars took 1.7-20 times as long. Of our four workloads, Daft could
+run only the text projection; it took 2.1 times as long and rejected the
+deletion-vector tables. All three also used more memory in every comparable
+run. Their Delta paths were simply not competitive. See the
+[benchmark setup and complete results](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/).
+
+### delta-rs
+
+delta-rs is the closest alternative, but it is a broader Delta library that
+supports writes as well as reads. Its reader is not as focused. Delta Arrow
+Reader stays read-only, so it can put its effort into asynchronous reads,
+bounded memory, Arrow streaming, and efficient deletion vectors. Across the two
+projection workloads, it ranged from roughly even with delta-rs to finishing
+24% sooner. On deletion-vector tables, the difference was much larger: delta-rs
+took three times as long to return one live row and seven times as long to scan
+the full table.
+
+That matters because deletion vectors are no longer an edge case. Databricks
+[recommends them for most tables and is rolling out automatic enablement for new tables](https://docs.databricks.com/aws/en/admin/workspace-settings/deletion-vectors),
+so a reader that handles them well is preparing for the normal case, not an
+unusual one.
+
+Delta Arrow Reader does less on purpose. For read-only Delta work, that is an
+advantage, not a limitation.
+
 ## Scope
 
 The reader can load the latest or a selected table snapshot. It supports column

--- a/README.md
+++ b/README.md
@@ -4,15 +4,8 @@
   <strong>Delta Lake in. Arrow batches out. No Spark required.</strong>
 </h3>
 
-<p align="center">
-  Stream Arrow batches directly.<br/>
-  Query with DataFusion when you want SQL.
-</p>
-
-Delta Arrow Reader is a read-only Rust library that reads Delta Lake tables as
-Apache Arrow record batches. Use the batch stream directly, or register a table
-with DataFusion and query it with SQL. Batches arrive as your application
-requests them, so a scan does not collect the whole result in memory.
+Delta Arrow Reader is a read-only Rust library that streams Delta Lake data as
+Arrow batches, with optional SQL through DataFusion.
 
 <p align="center">
   <a href="https://docs.rs/delta-arrow-reader"><img alt="Rust API" src="https://docs.rs/delta-arrow-reader/badge.svg"></a>
@@ -24,12 +17,55 @@ For guided examples and design details, see the
 
 ## When to use it
 
-Delta Arrow Reader is a good fit when:
+Delta Arrow Reader fits Rust services, command-line tools, and data pipelines
+that read Delta Lake tables. It is especially useful when:
 
-- You need to read Delta Lake tables from a Rust application.
-- You want to process Arrow batches without loading the full result first.
-- You want to query a Delta table through DataFusion.
-- You want your application to own its Tokio runtime and control read concurrency.
+- You need to read a large table without holding all of it in memory.
+- You want to process each batch as soon as it arrives.
+- Your application already works with Arrow data.
+- You want to run SQL through DataFusion.
+
+## Why not...
+
+Most alternatives solve a much bigger problem than reading a Delta table. Their
+Delta path pays for that extra weight.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-wall-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-wall-light.svg">
+  <img alt="Wall-time comparison across five Delta readers and four workloads" src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-wall-light.svg" width="1000">
+</picture>
+
+### Spark or Trino
+
+Spark is Delta Lake's home ground, and Trino is a proven distributed engine.
+They fit naturally when a cluster is already part of the system. A small,
+single-node read service would still carry their JVM, full query runtime, and
+operational machinery. Running either one just to stream Arrow batches is
+bringing a distributed system to do a library's job.
+
+### The "read everything" engines
+
+DuckDB, Polars, and Daft promise one engine for many formats. Delta Lake becomes
+another compatibility box to check, and the jack-of-all-trades tradeoff showed
+clearly in our benchmarks. DuckDB took 5.8-14.6 times as long as Delta Arrow
+Reader, and Polars took 1.7-20 times as long. Of our four workloads, Daft could
+run only the text projection; it took 2.1 times as long and rejected the
+deletion-vector tables. All three also used more memory in every comparable
+run. See the
+[benchmark setup and complete results](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/).
+
+### delta-rs
+
+delta-rs is the closest alternative and covers the full Delta lifecycle,
+including writes. Delta Arrow Reader concentrates on asynchronous reads,
+bounded memory, Arrow streaming, and efficient deletion vectors. Across the two
+projection workloads, it ranged from roughly even with delta-rs to finishing
+24% sooner. **On deletion-vector tables, delta-rs took three times as long to
+return one live row and seven times as long to scan the full table.**
+
+Databricks now
+[recommends deletion vectors for most tables and is rolling out automatic enablement for new tables](https://docs.databricks.com/aws/en/admin/workspace-settings/deletion-vectors).
 
 ## Install
 
@@ -77,50 +113,6 @@ is read when DataFusion executes the query.
 
 The [DataFusion quickstart](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
 walks through registration and a first SQL query.
-
-## Why not...
-
-Most alternatives solve a much bigger problem than reading a Delta table. Their
-Delta path pays for that extra weight.
-
-### Spark or Trino
-
-Spark is Delta Lake's home ground, and Trino is a proven distributed engine.
-Both make sense when you already need a cluster. As the foundation of a small,
-single-node read service, however, they are heavy: a JVM, a full query runtime,
-and far more operational machinery than the job requires. Running either one
-just to stream Arrow batches is bringing a distributed system to do a library's
-job.
-
-### The "read everything" engines
-
-DuckDB, Polars, and Daft promise one engine for many formats. Delta Lake becomes
-another compatibility box to check, and the jack-of-all-trades tradeoff showed
-clearly in our benchmarks. DuckDB took 5.8-14.6 times as long as Delta Arrow
-Reader, and Polars took 1.7-20 times as long. Of our four workloads, Daft could
-run only the text projection; it took 2.1 times as long and rejected the
-deletion-vector tables. All three also used more memory in every comparable
-run. Their Delta paths were simply not competitive. See the
-[benchmark setup and complete results](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/).
-
-### delta-rs
-
-delta-rs is the closest alternative, but it is a broader Delta library that
-supports writes as well as reads. Its reader is not as focused. Delta Arrow
-Reader stays read-only, so it can put its effort into asynchronous reads,
-bounded memory, Arrow streaming, and efficient deletion vectors. Across the two
-projection workloads, it ranged from roughly even with delta-rs to finishing
-24% sooner. On deletion-vector tables, the difference was much larger: delta-rs
-took three times as long to return one live row and seven times as long to scan
-the full table.
-
-That matters because deletion vectors are no longer an edge case. Databricks
-[recommends them for most tables and is rolling out automatic enablement for new tables](https://docs.databricks.com/aws/en/admin/workspace-settings/deletion-vectors),
-so a reader that handles them well is preparing for the normal case, not an
-unusual one.
-
-Delta Arrow Reader does less on purpose. For read-only Delta work, that is an
-advantage, not a limitation.
 
 ## Scope
 

--- a/benches/render_comparison_chart.py
+++ b/benches/render_comparison_chart.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Render README comparison charts from the published benchmark tables."""
+
+from html import escape
+from math import ceil
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RESULTS = ROOT / "docs/content/benchmarks.md"
+OUTPUT = ROOT / "docs/content/assets"
+READERS = ("Delta Arrow Reader", "delta-rs", "DuckDB", "Polars", "Daft")
+WORKLOADS = (
+    ("Mixed-column projection", "Mixed-column projection", "Mixed projection"),
+    ("3 GB text projection", "3 GB text projection", "3 GB text"),
+    (
+        "Read one row from a table with deletion vectors",
+        "Read one row with deletion vectors",
+        "DV first row",
+    ),
+    (
+        "Scan a full table with deletion vectors",
+        "Full deletion-vector scan",
+        "DV full scan",
+    ),
+)
+METRICS = {
+    "wall": ("Wall time", "Lower is faster", "Seconds", 5),
+    "cpu": ("CPU time", "Lower uses less compute", "CPU seconds", 10),
+    "memory": ("Peak memory", "Lower uses less RAM", "Peak RSS (MiB)", 1_000),
+}
+THEMES = {
+    "dark": {
+        "background": "#0b0d10",
+        "background_end": "#11151a",
+        "text": "#f0f2f5",
+        "muted": "#98a2b0",
+        "grid": "#29303a",
+        "series": ("#a5b4fc", "#c4b5fd", "#7dd3fc", "#6ee7b7"),
+    },
+    "light": {
+        "background": "#ffffff",
+        "background_end": "#f7f8fa",
+        "text": "#1f2328",
+        "muted": "#68707d",
+        "grid": "#d9dee6",
+        "series": ("#c7d2fe", "#ddd6fe", "#bae6fd", "#a7f3d0"),
+    },
+}
+
+
+def load_results() -> dict[str, list[tuple[str, list[float | None]]]]:
+    lines = RESULTS.read_text().splitlines()
+    header = "| Workload | " + " | ".join(READERS) + " |"
+    starts = [index + 2 for index, line in enumerate(lines) if line == header]
+    assert len(starts) == 2
+    parsed = {metric: [] for metric in METRICS}
+
+    for row, (expected_timing, expected_resource, display_name) in enumerate(WORKLOADS):
+        timing_cells = [
+            cell.strip()
+            for cell in lines[starts[0] + row].strip("|").split("|")
+        ]
+        resource_cells = [
+            cell.strip()
+            for cell in lines[starts[1] + row].strip("|").split("|")
+        ]
+        assert timing_cells[0] == expected_timing
+        assert resource_cells[0] == expected_resource
+
+        wall_values = []
+        cpu_values = []
+        memory_values = []
+        for timing, resource in zip(timing_cells[1:], resource_cells[1:], strict=True):
+            if timing == resource == "Unsupported":
+                wall_values.append(None)
+                cpu_values.append(None)
+                memory_values.append(None)
+                continue
+            cpu, memory = resource.split(" / ")
+            wall_values.append(float(timing.removesuffix(" s")))
+            cpu_values.append(float(cpu.removesuffix(" s")))
+            memory_values.append(
+                float(memory.removesuffix(" MiB").replace(",", ""))
+            )
+
+        for metric, values in (
+            ("wall", wall_values),
+            ("cpu", cpu_values),
+            ("memory", memory_values),
+        ):
+            assert len(values) == len(READERS)
+            parsed[metric].append((display_name, values))
+    return parsed
+
+
+def tick_label(metric: str, value: float) -> str:
+    return f"{value:,.0f}" if metric == "memory" else f"{value:g}"
+
+
+def render(
+    theme_name: str,
+    metric: str,
+    results: list[tuple[str, list[float | None]]],
+) -> str:
+    theme = THEMES[theme_name]
+    title, guidance, axis_label, step = METRICS[metric]
+    maximum = max(
+        value
+        for _, values in results
+        for value in values
+        if value is not None
+    )
+    axis_max = ceil(maximum / step) * step
+    plot_x = 92
+    plot_width = 1056
+    plot_top = 150
+    plot_bottom = 500
+    group_width = plot_width / len(READERS)
+    bar_width = 24
+    bar_gap = 7
+    cluster_width = len(WORKLOADS) * bar_width + (len(WORKLOADS) - 1) * bar_gap
+    parts = [
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" '
+        'viewBox="0 0 1200 610" role="img" aria-labelledby="title description">',
+        f'<title id="title">Delta reader {escape(title.lower())} comparison</title>',
+        f'<desc id="description">{escape(guidance)}. Delta Arrow Reader is '
+        'highlighted. Each color represents one workload.</desc>',
+        '<style>text{font-family:Inter,ui-sans-serif,-apple-system,'
+        'BlinkMacSystemFont,"Segoe UI",sans-serif}</style>',
+        '<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1">'
+        f'<stop offset="0" stop-color="{theme["background"]}"/>'
+        f'<stop offset="1" stop-color="{theme["background_end"]}"/>'
+        '</linearGradient></defs>',
+        '<rect width="1200" height="610" fill="url(#page)"/>',
+        f'<text x="44" y="32" fill="{theme["muted"]}" font-size="12" '
+        'font-weight="700" '
+        'letter-spacing="2">DELTA ARROW READER BENCHMARK</text>',
+        f'<text x="44" y="70" fill="{theme["text"]}" font-size="32" '
+        f'font-weight="700">{escape(title)}</text>',
+        f'<text x="44" y="99" fill="{theme["muted"]}" font-size="16">'
+        f'{escape(guidance)}</text>',
+    ]
+
+    legend_x = 44
+    for workload_index, (_, _, workload) in enumerate(WORKLOADS):
+        color = theme["series"][workload_index]
+        parts.extend(
+            [
+                f'<circle cx="{legend_x + 5}" cy="127" r="5" fill="{color}"/>',
+                f'<text x="{legend_x + 18}" y="132" fill="{theme["text"]}" '
+                f'font-size="14">{escape(workload)}</text>',
+            ]
+        )
+        legend_x += 215
+
+    for tick in range(6):
+        value = axis_max * tick / 5
+        y = plot_bottom - (plot_bottom - plot_top) * tick / 5
+        parts.extend(
+            [
+                f'<line x1="{plot_x}" y1="{y}" x2="{plot_x + plot_width}" y2="{y}" '
+                f'stroke="{theme["grid"]}" stroke-dasharray="3 6"/>',
+                f'<text x="76" y="{y + 5}" text-anchor="end" '
+                f'fill="{theme["muted"]}" font-size="13">'
+                f'{tick_label(metric, value)}</text>',
+            ]
+        )
+
+    for reader_index, reader in enumerate(READERS):
+        center_x = plot_x + group_width * (reader_index + 0.5)
+        if reader == "Delta Arrow Reader":
+            parts.append(
+                f'<rect x="{plot_x + 4}" y="{plot_top - 10}" '
+                f'width="{group_width - 8}" height="414" '
+                f'rx="12" fill="{theme["text"]}" fill-opacity="0.055"/>'
+            )
+        weight = "700" if reader == "Delta Arrow Reader" else "500"
+        parts.append(
+            f'<text x="{center_x}" y="530" text-anchor="middle" '
+            f'fill="{theme["text"]}" font-size="16" font-weight="{weight}">'
+            f'{escape(reader)}</text>'
+        )
+        unsupported = sum(values[reader_index] is None for _, values in results)
+        if unsupported:
+            parts.append(
+                f'<text x="{center_x}" y="549" text-anchor="middle" '
+                f'fill="{theme["muted"]}" font-size="12">'
+                f'{unsupported} workloads not supported</text>'
+            )
+
+        for workload_index, (_, values) in enumerate(results):
+            value = values[reader_index]
+            if value is None:
+                continue
+            height = max(3, round(value / axis_max * (plot_bottom - plot_top)))
+            bar_x = (
+                center_x
+                - cluster_width / 2
+                + workload_index * (bar_width + bar_gap)
+            )
+            color = theme["series"][workload_index]
+            parts.append(
+                f'<rect x="{bar_x}" y="{plot_bottom - height}" '
+                f'width="{bar_width}" height="{height}" rx="4" fill="{color}"/>'
+            )
+
+    parts.extend(
+        [
+            f'<line x1="{plot_x}" y1="{plot_bottom}" '
+            f'x2="{plot_x + plot_width}" '
+            f'y2="{plot_bottom}" stroke="{theme["grid"]}"/>',
+            f'<text x="{plot_x + plot_width}" y="144" text-anchor="end" '
+            f'fill="{theme["muted"]}" font-size="13">'
+            f'{escape(axis_label)}</text>',
+            f'<text x="44" y="586" fill="{theme["muted"]}" font-size="13">'
+            'Local MinIO | 16 logical CPUs | process startup excluded</text>',
+            "</svg>",
+        ]
+    )
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    results = load_results()
+    OUTPUT.mkdir(parents=True, exist_ok=True)
+    for metric in METRICS:
+        for theme in THEMES:
+            target = OUTPUT / f"reader-benchmark-{metric}-{theme}.svg"
+            target.write_text(render(theme, metric, results[metric]))
+            print(target.relative_to(ROOT))
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/run_order.py
+++ b/benches/run_order.py
@@ -1,26 +1,54 @@
-"""Counterbalanced order used for each three-reader workload."""
+"""Counterbalanced orders used for the reader comparison."""
 
-CANDIDATES = ("delta-arrow-reader", "delta-rs", "duckdb")
-RUN_ORDER = (
-    ("delta-arrow-reader", "delta-rs", "duckdb"),
-    ("delta-rs", "duckdb", "delta-arrow-reader"),
-    ("duckdb", "delta-arrow-reader", "delta-rs"),
-    ("duckdb", "delta-rs", "delta-arrow-reader"),
-    ("delta-rs", "delta-arrow-reader", "duckdb"),
-    ("delta-arrow-reader", "duckdb", "delta-rs"),
-)
+from collections import Counter
+
+
+WORKLOAD_CANDIDATES = {
+    "mixed-column": ("delta-arrow-reader", "delta-rs", "duckdb", "polars"),
+    "text": (
+        "delta-arrow-reader",
+        "delta-rs",
+        "duckdb",
+        "polars",
+        "daft",
+    ),
+    "dv-limit": ("delta-arrow-reader", "delta-rs", "duckdb", "polars"),
+    "dv-full": ("delta-arrow-reader", "delta-rs", "duckdb", "polars"),
+}
+
+
+def balanced_orders(candidates: tuple[str, ...]) -> list[tuple[str, ...]]:
+    """Represent every position and ordered adjacency twice."""
+    count = len(candidates)
+    first = [0]
+    for position in range(1, count):
+        first.append((position + 1) // 2 if position % 2 else count - position // 2)
+    rows = [
+        tuple(candidates[(index + shift) % count] for index in first)
+        for shift in range(count)
+    ]
+    return rows + [tuple(reversed(row)) for row in rows]
 
 
 def validate() -> None:
-    assert all(set(run) == set(CANDIDATES) for run in RUN_ORDER)
-    for position in range(len(CANDIDATES)):
-        assert all(
-            sum(run[position] == candidate for run in RUN_ORDER) == 2
-            for candidate in CANDIDATES
+    for candidates in WORKLOAD_CANDIDATES.values():
+        orders = balanced_orders(candidates)
+        positions = Counter(
+            (candidate, position)
+            for order in orders
+            for position, candidate in enumerate(order)
         )
+        adjacent_pairs = Counter(
+            pair for order in orders for pair in zip(order, order[1:])
+        )
+        assert set(positions.values()) == {2}
+        assert set(adjacent_pairs.values()) == {2}
+        assert len(adjacent_pairs) == len(candidates) * (len(candidates) - 1)
 
 
 if __name__ == "__main__":
     validate()
-    for run in RUN_ORDER:
-        print(" -> ".join(run))
+    for workload, candidates in WORKLOAD_CANDIDATES.items():
+        print(f"[{workload}]")
+        for order in balanced_orders(candidates):
+            print(" -> ".join(order))

--- a/docs/content/assets/reader-benchmark-cpu-dark.svg
+++ b/docs/content/assets/reader-benchmark-cpu-dark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Delta reader cpu time comparison</title>
+<desc id="description">Lower uses less compute. Delta Arrow Reader is highlighted. Each color represents one workload.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0d10"/><stop offset="1" stop-color="#11151a"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#98a2b0" font-size="12" font-weight="700" letter-spacing="2">DELTA ARROW READER BENCHMARK</text>
+<text x="44" y="70" fill="#f0f2f5" font-size="32" font-weight="700">CPU time</text>
+<text x="44" y="99" fill="#98a2b0" font-size="16">Lower uses less compute</text>
+<circle cx="49" cy="127" r="5" fill="#a5b4fc"/>
+<text x="62" y="132" fill="#f0f2f5" font-size="14">Mixed projection</text>
+<circle cx="264" cy="127" r="5" fill="#c4b5fd"/>
+<text x="277" y="132" fill="#f0f2f5" font-size="14">3 GB text</text>
+<circle cx="479" cy="127" r="5" fill="#7dd3fc"/>
+<text x="492" y="132" fill="#f0f2f5" font-size="14">DV first row</text>
+<circle cx="694" cy="127" r="5" fill="#6ee7b7"/>
+<text x="707" y="132" fill="#f0f2f5" font-size="14">DV full scan</text>
+<line x1="92" y1="500.0" x2="1148" y2="500.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="505.0" text-anchor="end" fill="#98a2b0" font-size="13">0</text>
+<line x1="92" y1="430.0" x2="1148" y2="430.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="435.0" text-anchor="end" fill="#98a2b0" font-size="13">10</text>
+<line x1="92" y1="360.0" x2="1148" y2="360.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="365.0" text-anchor="end" fill="#98a2b0" font-size="13">20</text>
+<line x1="92" y1="290.0" x2="1148" y2="290.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="295.0" text-anchor="end" fill="#98a2b0" font-size="13">30</text>
+<line x1="92" y1="220.0" x2="1148" y2="220.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="225.0" text-anchor="end" fill="#98a2b0" font-size="13">40</text>
+<line x1="92" y1="150.0" x2="1148" y2="150.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="155.0" text-anchor="end" fill="#98a2b0" font-size="13">50</text>
+<rect x="96" y="140" width="203.2" height="414" rx="12" fill="#f0f2f5" fill-opacity="0.055"/>
+<text x="197.6" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="700">Delta Arrow Reader</text>
+<rect x="139.1" y="454" width="24" height="46" rx="4" fill="#a5b4fc"/>
+<rect x="170.1" y="373" width="24" height="127" rx="4" fill="#c4b5fd"/>
+<rect x="201.1" y="497" width="24" height="3" rx="4" fill="#7dd3fc"/>
+<rect x="232.1" y="493" width="24" height="7" rx="4" fill="#6ee7b7"/>
+<text x="408.79999999999995" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">delta-rs</text>
+<rect x="350.29999999999995" y="457" width="24" height="43" rx="4" fill="#a5b4fc"/>
+<rect x="381.29999999999995" y="386" width="24" height="114" rx="4" fill="#c4b5fd"/>
+<rect x="412.29999999999995" y="497" width="24" height="3" rx="4" fill="#7dd3fc"/>
+<rect x="443.29999999999995" y="484" width="24" height="16" rx="4" fill="#6ee7b7"/>
+<text x="620.0" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">DuckDB</text>
+<rect x="561.5" y="428" width="24" height="72" rx="4" fill="#a5b4fc"/>
+<rect x="592.5" y="283" width="24" height="217" rx="4" fill="#c4b5fd"/>
+<rect x="623.5" y="494" width="24" height="6" rx="4" fill="#7dd3fc"/>
+<rect x="654.5" y="490" width="24" height="10" rx="4" fill="#6ee7b7"/>
+<text x="831.1999999999999" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">Polars</text>
+<rect x="772.6999999999999" y="404" width="24" height="96" rx="4" fill="#a5b4fc"/>
+<rect x="803.6999999999999" y="368" width="24" height="132" rx="4" fill="#c4b5fd"/>
+<rect x="834.6999999999999" y="493" width="24" height="7" rx="4" fill="#7dd3fc"/>
+<rect x="865.6999999999999" y="487" width="24" height="13" rx="4" fill="#6ee7b7"/>
+<text x="1042.4" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">Daft</text>
+<text x="1042.4" y="549" text-anchor="middle" fill="#98a2b0" font-size="12">3 workloads not supported</text>
+<rect x="1014.9000000000001" y="194" width="24" height="306" rx="4" fill="#c4b5fd"/>
+<line x1="92" y1="500" x2="1148" y2="500" stroke="#29303a"/>
+<text x="1148" y="144" text-anchor="end" fill="#98a2b0" font-size="13">CPU seconds</text>
+<text x="44" y="586" fill="#98a2b0" font-size="13">Local MinIO | 16 logical CPUs | process startup excluded</text>
+</svg>

--- a/docs/content/assets/reader-benchmark-cpu-light.svg
+++ b/docs/content/assets/reader-benchmark-cpu-light.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Delta reader cpu time comparison</title>
+<desc id="description">Lower uses less compute. Delta Arrow Reader is highlighted. Each color represents one workload.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f7f8fa"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#68707d" font-size="12" font-weight="700" letter-spacing="2">DELTA ARROW READER BENCHMARK</text>
+<text x="44" y="70" fill="#1f2328" font-size="32" font-weight="700">CPU time</text>
+<text x="44" y="99" fill="#68707d" font-size="16">Lower uses less compute</text>
+<circle cx="49" cy="127" r="5" fill="#c7d2fe"/>
+<text x="62" y="132" fill="#1f2328" font-size="14">Mixed projection</text>
+<circle cx="264" cy="127" r="5" fill="#ddd6fe"/>
+<text x="277" y="132" fill="#1f2328" font-size="14">3 GB text</text>
+<circle cx="479" cy="127" r="5" fill="#bae6fd"/>
+<text x="492" y="132" fill="#1f2328" font-size="14">DV first row</text>
+<circle cx="694" cy="127" r="5" fill="#a7f3d0"/>
+<text x="707" y="132" fill="#1f2328" font-size="14">DV full scan</text>
+<line x1="92" y1="500.0" x2="1148" y2="500.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="505.0" text-anchor="end" fill="#68707d" font-size="13">0</text>
+<line x1="92" y1="430.0" x2="1148" y2="430.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="435.0" text-anchor="end" fill="#68707d" font-size="13">10</text>
+<line x1="92" y1="360.0" x2="1148" y2="360.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="365.0" text-anchor="end" fill="#68707d" font-size="13">20</text>
+<line x1="92" y1="290.0" x2="1148" y2="290.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="295.0" text-anchor="end" fill="#68707d" font-size="13">30</text>
+<line x1="92" y1="220.0" x2="1148" y2="220.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="225.0" text-anchor="end" fill="#68707d" font-size="13">40</text>
+<line x1="92" y1="150.0" x2="1148" y2="150.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="155.0" text-anchor="end" fill="#68707d" font-size="13">50</text>
+<rect x="96" y="140" width="203.2" height="414" rx="12" fill="#1f2328" fill-opacity="0.055"/>
+<text x="197.6" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="700">Delta Arrow Reader</text>
+<rect x="139.1" y="454" width="24" height="46" rx="4" fill="#c7d2fe"/>
+<rect x="170.1" y="373" width="24" height="127" rx="4" fill="#ddd6fe"/>
+<rect x="201.1" y="497" width="24" height="3" rx="4" fill="#bae6fd"/>
+<rect x="232.1" y="493" width="24" height="7" rx="4" fill="#a7f3d0"/>
+<text x="408.79999999999995" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">delta-rs</text>
+<rect x="350.29999999999995" y="457" width="24" height="43" rx="4" fill="#c7d2fe"/>
+<rect x="381.29999999999995" y="386" width="24" height="114" rx="4" fill="#ddd6fe"/>
+<rect x="412.29999999999995" y="497" width="24" height="3" rx="4" fill="#bae6fd"/>
+<rect x="443.29999999999995" y="484" width="24" height="16" rx="4" fill="#a7f3d0"/>
+<text x="620.0" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">DuckDB</text>
+<rect x="561.5" y="428" width="24" height="72" rx="4" fill="#c7d2fe"/>
+<rect x="592.5" y="283" width="24" height="217" rx="4" fill="#ddd6fe"/>
+<rect x="623.5" y="494" width="24" height="6" rx="4" fill="#bae6fd"/>
+<rect x="654.5" y="490" width="24" height="10" rx="4" fill="#a7f3d0"/>
+<text x="831.1999999999999" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">Polars</text>
+<rect x="772.6999999999999" y="404" width="24" height="96" rx="4" fill="#c7d2fe"/>
+<rect x="803.6999999999999" y="368" width="24" height="132" rx="4" fill="#ddd6fe"/>
+<rect x="834.6999999999999" y="493" width="24" height="7" rx="4" fill="#bae6fd"/>
+<rect x="865.6999999999999" y="487" width="24" height="13" rx="4" fill="#a7f3d0"/>
+<text x="1042.4" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">Daft</text>
+<text x="1042.4" y="549" text-anchor="middle" fill="#68707d" font-size="12">3 workloads not supported</text>
+<rect x="1014.9000000000001" y="194" width="24" height="306" rx="4" fill="#ddd6fe"/>
+<line x1="92" y1="500" x2="1148" y2="500" stroke="#d9dee6"/>
+<text x="1148" y="144" text-anchor="end" fill="#68707d" font-size="13">CPU seconds</text>
+<text x="44" y="586" fill="#68707d" font-size="13">Local MinIO | 16 logical CPUs | process startup excluded</text>
+</svg>

--- a/docs/content/assets/reader-benchmark-memory-dark.svg
+++ b/docs/content/assets/reader-benchmark-memory-dark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Delta reader peak memory comparison</title>
+<desc id="description">Lower uses less RAM. Delta Arrow Reader is highlighted. Each color represents one workload.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0d10"/><stop offset="1" stop-color="#11151a"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#98a2b0" font-size="12" font-weight="700" letter-spacing="2">DELTA ARROW READER BENCHMARK</text>
+<text x="44" y="70" fill="#f0f2f5" font-size="32" font-weight="700">Peak memory</text>
+<text x="44" y="99" fill="#98a2b0" font-size="16">Lower uses less RAM</text>
+<circle cx="49" cy="127" r="5" fill="#a5b4fc"/>
+<text x="62" y="132" fill="#f0f2f5" font-size="14">Mixed projection</text>
+<circle cx="264" cy="127" r="5" fill="#c4b5fd"/>
+<text x="277" y="132" fill="#f0f2f5" font-size="14">3 GB text</text>
+<circle cx="479" cy="127" r="5" fill="#7dd3fc"/>
+<text x="492" y="132" fill="#f0f2f5" font-size="14">DV first row</text>
+<circle cx="694" cy="127" r="5" fill="#6ee7b7"/>
+<text x="707" y="132" fill="#f0f2f5" font-size="14">DV full scan</text>
+<line x1="92" y1="500.0" x2="1148" y2="500.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="505.0" text-anchor="end" fill="#98a2b0" font-size="13">0</text>
+<line x1="92" y1="430.0" x2="1148" y2="430.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="435.0" text-anchor="end" fill="#98a2b0" font-size="13">1,400</text>
+<line x1="92" y1="360.0" x2="1148" y2="360.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="365.0" text-anchor="end" fill="#98a2b0" font-size="13">2,800</text>
+<line x1="92" y1="290.0" x2="1148" y2="290.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="295.0" text-anchor="end" fill="#98a2b0" font-size="13">4,200</text>
+<line x1="92" y1="220.0" x2="1148" y2="220.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="225.0" text-anchor="end" fill="#98a2b0" font-size="13">5,600</text>
+<line x1="92" y1="150.0" x2="1148" y2="150.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="155.0" text-anchor="end" fill="#98a2b0" font-size="13">7,000</text>
+<rect x="96" y="140" width="203.2" height="414" rx="12" fill="#f0f2f5" fill-opacity="0.055"/>
+<text x="197.6" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="700">Delta Arrow Reader</text>
+<rect x="139.1" y="483" width="24" height="17" rx="4" fill="#a5b4fc"/>
+<rect x="170.1" y="412" width="24" height="88" rx="4" fill="#c4b5fd"/>
+<rect x="201.1" y="497" width="24" height="3" rx="4" fill="#7dd3fc"/>
+<rect x="232.1" y="497" width="24" height="3" rx="4" fill="#6ee7b7"/>
+<text x="408.79999999999995" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">delta-rs</text>
+<rect x="350.29999999999995" y="485" width="24" height="15" rx="4" fill="#a5b4fc"/>
+<rect x="381.29999999999995" y="416" width="24" height="84" rx="4" fill="#c4b5fd"/>
+<rect x="412.29999999999995" y="487" width="24" height="13" rx="4" fill="#7dd3fc"/>
+<rect x="443.29999999999995" y="487" width="24" height="13" rx="4" fill="#6ee7b7"/>
+<text x="620.0" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">DuckDB</text>
+<rect x="561.5" y="464" width="24" height="36" rx="4" fill="#a5b4fc"/>
+<rect x="592.5" y="241" width="24" height="259" rx="4" fill="#c4b5fd"/>
+<rect x="623.5" y="485" width="24" height="15" rx="4" fill="#7dd3fc"/>
+<rect x="654.5" y="484" width="24" height="16" rx="4" fill="#6ee7b7"/>
+<text x="831.1999999999999" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">Polars</text>
+<rect x="772.6999999999999" y="432" width="24" height="68" rx="4" fill="#a5b4fc"/>
+<rect x="803.6999999999999" y="340" width="24" height="160" rx="4" fill="#c4b5fd"/>
+<rect x="834.6999999999999" y="478" width="24" height="22" rx="4" fill="#7dd3fc"/>
+<rect x="865.6999999999999" y="471" width="24" height="29" rx="4" fill="#6ee7b7"/>
+<text x="1042.4" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">Daft</text>
+<text x="1042.4" y="549" text-anchor="middle" fill="#98a2b0" font-size="12">3 workloads not supported</text>
+<rect x="1014.9000000000001" y="187" width="24" height="313" rx="4" fill="#c4b5fd"/>
+<line x1="92" y1="500" x2="1148" y2="500" stroke="#29303a"/>
+<text x="1148" y="144" text-anchor="end" fill="#98a2b0" font-size="13">Peak RSS (MiB)</text>
+<text x="44" y="586" fill="#98a2b0" font-size="13">Local MinIO | 16 logical CPUs | process startup excluded</text>
+</svg>

--- a/docs/content/assets/reader-benchmark-memory-light.svg
+++ b/docs/content/assets/reader-benchmark-memory-light.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Delta reader peak memory comparison</title>
+<desc id="description">Lower uses less RAM. Delta Arrow Reader is highlighted. Each color represents one workload.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f7f8fa"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#68707d" font-size="12" font-weight="700" letter-spacing="2">DELTA ARROW READER BENCHMARK</text>
+<text x="44" y="70" fill="#1f2328" font-size="32" font-weight="700">Peak memory</text>
+<text x="44" y="99" fill="#68707d" font-size="16">Lower uses less RAM</text>
+<circle cx="49" cy="127" r="5" fill="#c7d2fe"/>
+<text x="62" y="132" fill="#1f2328" font-size="14">Mixed projection</text>
+<circle cx="264" cy="127" r="5" fill="#ddd6fe"/>
+<text x="277" y="132" fill="#1f2328" font-size="14">3 GB text</text>
+<circle cx="479" cy="127" r="5" fill="#bae6fd"/>
+<text x="492" y="132" fill="#1f2328" font-size="14">DV first row</text>
+<circle cx="694" cy="127" r="5" fill="#a7f3d0"/>
+<text x="707" y="132" fill="#1f2328" font-size="14">DV full scan</text>
+<line x1="92" y1="500.0" x2="1148" y2="500.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="505.0" text-anchor="end" fill="#68707d" font-size="13">0</text>
+<line x1="92" y1="430.0" x2="1148" y2="430.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="435.0" text-anchor="end" fill="#68707d" font-size="13">1,400</text>
+<line x1="92" y1="360.0" x2="1148" y2="360.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="365.0" text-anchor="end" fill="#68707d" font-size="13">2,800</text>
+<line x1="92" y1="290.0" x2="1148" y2="290.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="295.0" text-anchor="end" fill="#68707d" font-size="13">4,200</text>
+<line x1="92" y1="220.0" x2="1148" y2="220.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="225.0" text-anchor="end" fill="#68707d" font-size="13">5,600</text>
+<line x1="92" y1="150.0" x2="1148" y2="150.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="155.0" text-anchor="end" fill="#68707d" font-size="13">7,000</text>
+<rect x="96" y="140" width="203.2" height="414" rx="12" fill="#1f2328" fill-opacity="0.055"/>
+<text x="197.6" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="700">Delta Arrow Reader</text>
+<rect x="139.1" y="483" width="24" height="17" rx="4" fill="#c7d2fe"/>
+<rect x="170.1" y="412" width="24" height="88" rx="4" fill="#ddd6fe"/>
+<rect x="201.1" y="497" width="24" height="3" rx="4" fill="#bae6fd"/>
+<rect x="232.1" y="497" width="24" height="3" rx="4" fill="#a7f3d0"/>
+<text x="408.79999999999995" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">delta-rs</text>
+<rect x="350.29999999999995" y="485" width="24" height="15" rx="4" fill="#c7d2fe"/>
+<rect x="381.29999999999995" y="416" width="24" height="84" rx="4" fill="#ddd6fe"/>
+<rect x="412.29999999999995" y="487" width="24" height="13" rx="4" fill="#bae6fd"/>
+<rect x="443.29999999999995" y="487" width="24" height="13" rx="4" fill="#a7f3d0"/>
+<text x="620.0" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">DuckDB</text>
+<rect x="561.5" y="464" width="24" height="36" rx="4" fill="#c7d2fe"/>
+<rect x="592.5" y="241" width="24" height="259" rx="4" fill="#ddd6fe"/>
+<rect x="623.5" y="485" width="24" height="15" rx="4" fill="#bae6fd"/>
+<rect x="654.5" y="484" width="24" height="16" rx="4" fill="#a7f3d0"/>
+<text x="831.1999999999999" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">Polars</text>
+<rect x="772.6999999999999" y="432" width="24" height="68" rx="4" fill="#c7d2fe"/>
+<rect x="803.6999999999999" y="340" width="24" height="160" rx="4" fill="#ddd6fe"/>
+<rect x="834.6999999999999" y="478" width="24" height="22" rx="4" fill="#bae6fd"/>
+<rect x="865.6999999999999" y="471" width="24" height="29" rx="4" fill="#a7f3d0"/>
+<text x="1042.4" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">Daft</text>
+<text x="1042.4" y="549" text-anchor="middle" fill="#68707d" font-size="12">3 workloads not supported</text>
+<rect x="1014.9000000000001" y="187" width="24" height="313" rx="4" fill="#ddd6fe"/>
+<line x1="92" y1="500" x2="1148" y2="500" stroke="#d9dee6"/>
+<text x="1148" y="144" text-anchor="end" fill="#68707d" font-size="13">Peak RSS (MiB)</text>
+<text x="44" y="586" fill="#68707d" font-size="13">Local MinIO | 16 logical CPUs | process startup excluded</text>
+</svg>

--- a/docs/content/assets/reader-benchmark-wall-dark.svg
+++ b/docs/content/assets/reader-benchmark-wall-dark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Delta reader wall time comparison</title>
+<desc id="description">Lower is faster. Delta Arrow Reader is highlighted. Each color represents one workload.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0d10"/><stop offset="1" stop-color="#11151a"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#98a2b0" font-size="12" font-weight="700" letter-spacing="2">DELTA ARROW READER BENCHMARK</text>
+<text x="44" y="70" fill="#f0f2f5" font-size="32" font-weight="700">Wall time</text>
+<text x="44" y="99" fill="#98a2b0" font-size="16">Lower is faster</text>
+<circle cx="49" cy="127" r="5" fill="#a5b4fc"/>
+<text x="62" y="132" fill="#f0f2f5" font-size="14">Mixed projection</text>
+<circle cx="264" cy="127" r="5" fill="#c4b5fd"/>
+<text x="277" y="132" fill="#f0f2f5" font-size="14">3 GB text</text>
+<circle cx="479" cy="127" r="5" fill="#7dd3fc"/>
+<text x="492" y="132" fill="#f0f2f5" font-size="14">DV first row</text>
+<circle cx="694" cy="127" r="5" fill="#6ee7b7"/>
+<text x="707" y="132" fill="#f0f2f5" font-size="14">DV full scan</text>
+<line x1="92" y1="500.0" x2="1148" y2="500.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="505.0" text-anchor="end" fill="#98a2b0" font-size="13">0</text>
+<line x1="92" y1="430.0" x2="1148" y2="430.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="435.0" text-anchor="end" fill="#98a2b0" font-size="13">3</text>
+<line x1="92" y1="360.0" x2="1148" y2="360.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="365.0" text-anchor="end" fill="#98a2b0" font-size="13">6</text>
+<line x1="92" y1="290.0" x2="1148" y2="290.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="295.0" text-anchor="end" fill="#98a2b0" font-size="13">9</text>
+<line x1="92" y1="220.0" x2="1148" y2="220.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="225.0" text-anchor="end" fill="#98a2b0" font-size="13">12</text>
+<line x1="92" y1="150.0" x2="1148" y2="150.0" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="76" y="155.0" text-anchor="end" fill="#98a2b0" font-size="13">15</text>
+<rect x="96" y="140" width="203.2" height="414" rx="12" fill="#f0f2f5" fill-opacity="0.055"/>
+<text x="197.6" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="700">Delta Arrow Reader</text>
+<rect x="139.1" y="480" width="24" height="20" rx="4" fill="#a5b4fc"/>
+<rect x="170.1" y="447" width="24" height="53" rx="4" fill="#c4b5fd"/>
+<rect x="201.1" y="497" width="24" height="3" rx="4" fill="#7dd3fc"/>
+<rect x="232.1" y="496" width="24" height="4" rx="4" fill="#6ee7b7"/>
+<text x="408.79999999999995" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">delta-rs</text>
+<rect x="350.29999999999995" y="473" width="24" height="27" rx="4" fill="#a5b4fc"/>
+<rect x="381.29999999999995" y="440" width="24" height="60" rx="4" fill="#c4b5fd"/>
+<rect x="412.29999999999995" y="497" width="24" height="3" rx="4" fill="#7dd3fc"/>
+<rect x="443.29999999999995" y="475" width="24" height="25" rx="4" fill="#6ee7b7"/>
+<text x="620.0" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">DuckDB</text>
+<rect x="561.5" y="214" width="24" height="286" rx="4" fill="#a5b4fc"/>
+<rect x="592.5" y="195" width="24" height="305" rx="4" fill="#c4b5fd"/>
+<rect x="623.5" y="491" width="24" height="9" rx="4" fill="#7dd3fc"/>
+<rect x="654.5" y="475" width="24" height="25" rx="4" fill="#6ee7b7"/>
+<text x="831.1999999999999" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">Polars</text>
+<rect x="772.6999999999999" y="426" width="24" height="74" rx="4" fill="#a5b4fc"/>
+<rect x="803.6999999999999" y="410" width="24" height="90" rx="4" fill="#c4b5fd"/>
+<rect x="834.6999999999999" y="487" width="24" height="13" rx="4" fill="#7dd3fc"/>
+<rect x="865.6999999999999" y="479" width="24" height="21" rx="4" fill="#6ee7b7"/>
+<text x="1042.4" y="530" text-anchor="middle" fill="#f0f2f5" font-size="16" font-weight="500">Daft</text>
+<text x="1042.4" y="549" text-anchor="middle" fill="#98a2b0" font-size="12">3 workloads not supported</text>
+<rect x="1014.9000000000001" y="389" width="24" height="111" rx="4" fill="#c4b5fd"/>
+<line x1="92" y1="500" x2="1148" y2="500" stroke="#29303a"/>
+<text x="1148" y="144" text-anchor="end" fill="#98a2b0" font-size="13">Seconds</text>
+<text x="44" y="586" fill="#98a2b0" font-size="13">Local MinIO | 16 logical CPUs | process startup excluded</text>
+</svg>

--- a/docs/content/assets/reader-benchmark-wall-light.svg
+++ b/docs/content/assets/reader-benchmark-wall-light.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Delta reader wall time comparison</title>
+<desc id="description">Lower is faster. Delta Arrow Reader is highlighted. Each color represents one workload.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f7f8fa"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#68707d" font-size="12" font-weight="700" letter-spacing="2">DELTA ARROW READER BENCHMARK</text>
+<text x="44" y="70" fill="#1f2328" font-size="32" font-weight="700">Wall time</text>
+<text x="44" y="99" fill="#68707d" font-size="16">Lower is faster</text>
+<circle cx="49" cy="127" r="5" fill="#c7d2fe"/>
+<text x="62" y="132" fill="#1f2328" font-size="14">Mixed projection</text>
+<circle cx="264" cy="127" r="5" fill="#ddd6fe"/>
+<text x="277" y="132" fill="#1f2328" font-size="14">3 GB text</text>
+<circle cx="479" cy="127" r="5" fill="#bae6fd"/>
+<text x="492" y="132" fill="#1f2328" font-size="14">DV first row</text>
+<circle cx="694" cy="127" r="5" fill="#a7f3d0"/>
+<text x="707" y="132" fill="#1f2328" font-size="14">DV full scan</text>
+<line x1="92" y1="500.0" x2="1148" y2="500.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="505.0" text-anchor="end" fill="#68707d" font-size="13">0</text>
+<line x1="92" y1="430.0" x2="1148" y2="430.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="435.0" text-anchor="end" fill="#68707d" font-size="13">3</text>
+<line x1="92" y1="360.0" x2="1148" y2="360.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="365.0" text-anchor="end" fill="#68707d" font-size="13">6</text>
+<line x1="92" y1="290.0" x2="1148" y2="290.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="295.0" text-anchor="end" fill="#68707d" font-size="13">9</text>
+<line x1="92" y1="220.0" x2="1148" y2="220.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="225.0" text-anchor="end" fill="#68707d" font-size="13">12</text>
+<line x1="92" y1="150.0" x2="1148" y2="150.0" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="76" y="155.0" text-anchor="end" fill="#68707d" font-size="13">15</text>
+<rect x="96" y="140" width="203.2" height="414" rx="12" fill="#1f2328" fill-opacity="0.055"/>
+<text x="197.6" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="700">Delta Arrow Reader</text>
+<rect x="139.1" y="480" width="24" height="20" rx="4" fill="#c7d2fe"/>
+<rect x="170.1" y="447" width="24" height="53" rx="4" fill="#ddd6fe"/>
+<rect x="201.1" y="497" width="24" height="3" rx="4" fill="#bae6fd"/>
+<rect x="232.1" y="496" width="24" height="4" rx="4" fill="#a7f3d0"/>
+<text x="408.79999999999995" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">delta-rs</text>
+<rect x="350.29999999999995" y="473" width="24" height="27" rx="4" fill="#c7d2fe"/>
+<rect x="381.29999999999995" y="440" width="24" height="60" rx="4" fill="#ddd6fe"/>
+<rect x="412.29999999999995" y="497" width="24" height="3" rx="4" fill="#bae6fd"/>
+<rect x="443.29999999999995" y="475" width="24" height="25" rx="4" fill="#a7f3d0"/>
+<text x="620.0" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">DuckDB</text>
+<rect x="561.5" y="214" width="24" height="286" rx="4" fill="#c7d2fe"/>
+<rect x="592.5" y="195" width="24" height="305" rx="4" fill="#ddd6fe"/>
+<rect x="623.5" y="491" width="24" height="9" rx="4" fill="#bae6fd"/>
+<rect x="654.5" y="475" width="24" height="25" rx="4" fill="#a7f3d0"/>
+<text x="831.1999999999999" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">Polars</text>
+<rect x="772.6999999999999" y="426" width="24" height="74" rx="4" fill="#c7d2fe"/>
+<rect x="803.6999999999999" y="410" width="24" height="90" rx="4" fill="#ddd6fe"/>
+<rect x="834.6999999999999" y="487" width="24" height="13" rx="4" fill="#bae6fd"/>
+<rect x="865.6999999999999" y="479" width="24" height="21" rx="4" fill="#a7f3d0"/>
+<text x="1042.4" y="530" text-anchor="middle" fill="#1f2328" font-size="16" font-weight="500">Daft</text>
+<text x="1042.4" y="549" text-anchor="middle" fill="#68707d" font-size="12">3 workloads not supported</text>
+<rect x="1014.9000000000001" y="389" width="24" height="111" rx="4" fill="#ddd6fe"/>
+<line x1="92" y1="500" x2="1148" y2="500" stroke="#d9dee6"/>
+<text x="1148" y="144" text-anchor="end" fill="#68707d" font-size="13">Seconds</text>
+<text x="44" y="586" fill="#68707d" font-size="13">Local MinIO | 16 logical CPUs | process startup excluded</text>
+</svg>

--- a/docs/content/benchmarks.md
+++ b/docs/content/benchmarks.md
@@ -15,6 +15,12 @@ The table below shows how long each reader took to load the Delta snapshot and
 stream the full result. Process startup and Python import time are not included.
 Each value is the median after one warmup run.
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-wall-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-wall-light.svg">
+  <img alt="Wall-time comparison across five Delta readers and four workloads" src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-wall-light.svg">
+</picture>
+
 | Workload | Delta Arrow Reader | delta-rs | DuckDB | Polars | Daft |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Mixed-column projection | 0.873 s | 1.143 s | 12.246 s | 3.152 s | Unsupported |
@@ -33,8 +39,20 @@ took 2.239-4.902 seconds. Because those ranges overlap, we do not treat the
 difference between their medians as conclusive. The Delta Arrow Reader range
 did not overlap the Polars or Daft range on that workload.
 
-Speed is only part of the picture. The next table shows median CPU time and
-median peak memory use:
+Speed is only part of the picture. The charts and table below show median CPU
+time and median peak memory use:
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-cpu-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-cpu-light.svg">
+  <img alt="CPU-time comparison across five Delta readers and four workloads" src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-cpu-light.svg">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-memory-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-memory-light.svg">
+  <img alt="Peak-memory comparison across five Delta readers and four workloads" src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/reader-benchmark-memory-light.svg">
+</picture>
 
 | Workload | Delta Arrow Reader | delta-rs | DuckDB | Polars | Daft |
 | --- | ---: | ---: | ---: | ---: | ---: |

--- a/docs/content/benchmarks.md
+++ b/docs/content/benchmarks.md
@@ -1,9 +1,10 @@
 # Benchmarks
 
-We compared Delta Arrow Reader with delta-rs and DuckDB on four workloads.
-Delta Arrow Reader was faster on the mixed-column projection and both
-deletion-vector scans. It was effectively tied with delta-rs on the large text
-projection, while DuckDB was slower in all four tests.
+We compared Delta Arrow Reader with delta-rs, DuckDB, Polars, and Daft on four
+workloads. Delta Arrow Reader had the lowest median time on every workload an
+alternative could run. Polars completed all four workloads. Daft completed the
+text projection but rejected the other three because it does not support
+deletion vectors.
 
 These numbers describe the workloads and machine shown below. Different tables,
 queries, and hardware can produce different results.
@@ -11,35 +12,42 @@ queries, and hardware can produce different results.
 ## Results
 
 The table below shows how long each reader took to load the Delta snapshot and
-stream the full result. Process startup is not included. Each value is the
-median of six runs, after one warmup run.
+stream the full result. Process startup and Python import time are not included.
+Each value is the median after one warmup run.
 
-| Workload | Delta Arrow Reader | delta-rs | DuckDB |
-| --- | ---: | ---: | ---: |
-| Mixed-column projection | 0.801 s | 1.023 s | 10.467 s |
-| 3 GB text projection | 2.655 s | 2.620 s | 13.033 s |
-| Read one row from a table with deletion vectors | 0.0223 s | 0.0803 s | 0.2616 s |
-| Scan a full table with deletion vectors | 0.112 s | 0.811 s | 0.882 s |
+| Workload | Delta Arrow Reader | delta-rs | DuckDB | Polars | Daft |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Mixed-column projection | 0.873 s | 1.143 s | 12.246 s | 3.152 s | Unsupported |
+| 3 GB text projection | 2.254 s | 2.584 s | 13.063 s | 3.866 s | 4.750 s |
+| Read one row from a table with deletion vectors | 0.0269 s | 0.0820 s | 0.3920 s | 0.5371 s | Unsupported |
+| Scan a full table with deletion vectors | 0.1548 s | 1.0834 s | 1.0818 s | 0.8838 s | Unsupported |
 
-On the text projection, Delta Arrow Reader took 2.226-3.244 seconds and delta-rs
-took 2.264-2.839 seconds. Because those ranges overlap, we treat the 1.3%
-difference between their medians as a tie. On the other three workloads, even
-the slowest Delta Arrow Reader run was faster than the fastest run from either
-alternative.
+Compared with Delta Arrow Reader, Polars took 3.61 times as long on the
+mixed-column projection, 1.71 times as long on the text projection, 19.95 times
+as long on the one-row deletion-vector read, and 5.71 times as long on the full
+deletion-vector scan. Daft took 2.11 times as long on the one workload it could
+run.
+
+On the text projection, Delta Arrow Reader took 2.206-2.791 seconds and delta-rs
+took 2.239-4.902 seconds. Because those ranges overlap, we do not treat the
+difference between their medians as conclusive. The Delta Arrow Reader range
+did not overlap the Polars or Daft range on that workload.
 
 Speed is only part of the picture. The next table shows median CPU time and
-peak memory use:
+median peak memory use:
 
-| Workload | Delta Arrow Reader | delta-rs | DuckDB |
-| --- | ---: | ---: | ---: |
-| Mixed-column projection | 6.610 s / 325 MiB | 6.028 s / 297 MiB | 8.763 s / 713 MiB |
-| 3 GB text projection | 14.663 s / 1,472 MiB | 11.318 s / 1,392 MiB | 30.357 s / 5,208 MiB |
-| Read one row from a table with deletion vectors | 0.0431 s / 66 MiB | 0.2933 s / 278 MiB | 0.7368 s / 309 MiB |
-| Scan a full table with deletion vectors | 0.967 s / 74 MiB | 1.867 s / 276 MiB | 1.246 s / 320 MiB |
+| Workload | Delta Arrow Reader | delta-rs | DuckDB | Polars | Daft |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Mixed-column projection | 6.53 s / 334 MiB | 6.09 s / 293 MiB | 10.25 s / 721 MiB | 13.72 s / 1,359 MiB | Unsupported |
+| 3 GB text projection | 18.17 s / 1,760 MiB | 16.33 s / 1,677 MiB | 31.07 s / 5,186 MiB | 18.87 s / 3,209 MiB | 43.65 s / 6,263 MiB |
+| Read one row with deletion vectors | 0.051 s / 58 MiB | 0.275 s / 266 MiB | 0.816 s / 306 MiB | 0.942 s / 447 MiB | Unsupported |
+| Full deletion-vector scan | 1.04 s / 67 MiB | 2.27 s / 266 MiB | 1.39 s / 316 MiB | 1.81 s / 580 MiB | Unsupported |
 
-Each cell shows CPU time followed by peak memory. Delta Arrow Reader used more
-CPU and memory than delta-rs on the two projection workloads. On the
-deletion-vector workloads, it was faster and used less memory.
+Each cell shows CPU time followed by peak memory. Delta Arrow Reader used
+slightly more CPU and memory than delta-rs on the two projection workloads. It
+used less memory than DuckDB, Polars, and Daft on every comparable workload. On
+the deletion-vector workloads, it also used less CPU and memory than every
+alternative.
 
 ## Workloads
 
@@ -67,35 +75,44 @@ them across a full scan.
 
 ## Method
 
-All three readers used the same Delta snapshots stored in local MinIO. Each
-reader used 16-way parallelism and streamed Arrow batches of 8,192 rows without
-keeping the full result in memory.
+All readers used the same Delta snapshots stored in local MinIO. Each reader
+used the machine's 16 logical CPUs. Results were consumed as Arrow batches
+without retaining the full result, and output batches were limited to 8,192
+rows.
 
-For each workload, we ran every reader once to warm up the system and discarded
-those results. We then ran six measured rounds, changing the order each time so
-that every reader appeared first, second, and third twice. The exact
-[run order](https://github.com/mag1cfrog/delta-arrow-reader/blob/main/benches/run_order.py)
+For each workload, we ran every supported reader once to warm up the system and
+discarded those results. We then used balanced, process-isolated run orders:
+eight measured rounds for each four-reader workload and ten rounds for the
+five-reader text workload. Every reader appeared in every position twice, and
+every ordered pair of adjacent readers appeared twice. The exact
+[run-order generator](https://github.com/mag1cfrog/delta-arrow-reader/blob/main/benches/run_order.py)
 is checked in.
 
-Delta Arrow Reader and delta-rs ran in the same Rust program with DataFusion
-54.1.0 and Arrow/Parquet 58.4.0. DuckDB ran in a separate Python process because
-it uses its own query engine. Its time covers the full path from opening the
-Delta table to producing Arrow batches. Linux process accounting recorded wall
-time, CPU use, memory use, page faults, and context switches.
+Delta Arrow Reader and delta-rs used the same Rust harness with DataFusion
+54.1.0 and Arrow/Parquet 58.4.0. DuckDB, Polars, and Daft each ran in a separate
+Python process. Their measured time covers the path from opening the Delta
+table to producing Arrow batches, but not interpreter startup or imports. Linux
+process accounting recorded wall time, CPU use, memory use, page faults, and
+context switches.
 
-All 72 measured processes completed successfully: four workloads, six rounds,
-and three readers. The row counts matched. Both deletion vectors in the
+All 146 measured processes completed successfully. Their row counts and logical
+schemas matched the frozen workload expectations. Both deletion vectors in the
 reference table removed the same 43 rows, and the generated table removed the
 expected 200 rows.
 
-Each result also had the same logical columns and data types. The readers did
-not always represent those values in memory in exactly the same way. We allowed
-differences in string encoding, timestamp units, and where each reader split
-its Arrow batches because none of them changed the result.
+The readers did not always represent values in memory in exactly the same way.
+We allowed differences in string encoding, timestamp units, dictionary
+encoding, and where each reader split its Arrow batches because none of them
+changed the logical result.
+
+Daft was not timed on the mixed-column or deletion-vector workloads. A separate
+capability probe confirmed that Daft 0.7.24 rejects tables that advertise the
+Delta deletion-vector reader feature. We did not bypass that check or ask Daft
+to ignore deleted rows.
 
 ## Environment
 
-We ran the benchmark on August 26, 2026, using one machine with the following
+We ran the benchmark on August 27, 2026, using one machine with the following
 hardware and software:
 
 - AMD Ryzen 7 8845HS, with 8 cores and 16 threads
@@ -108,6 +125,8 @@ hardware and software:
 | Delta Arrow Reader | 0.3.0 (`aaf6699`) |
 | delta-rs | `fd7e96910243f9e67b4eae994d52ef246cfcea38` |
 | DuckDB | 1.5.5, Delta extension `45c4087` |
+| Polars | 1.44.1, with deltalake 1.6.3 |
+| Daft | 0.7.24, with deltalake 1.6.3 |
 
 We kept all benchmark data in local MinIO so that public-network delays would
 not affect the results. Hardware and system load still affect absolute times,


### PR DESCRIPTION
## Summary

- add Polars and Daft to the published four-workload reader comparison
- explain when Delta Arrow Reader is a better fit than distributed and general-purpose engines
- add wall-time, CPU-time, and peak-memory charts generated from the published benchmark tables
- simplify and reorganize the README for first-time users

## Validation

- cargo test --locked
- cargo test --locked --features datafusion
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
- cargo package --locked
- python -m zensical build --strict -f docs/mkdocs.yml
- deterministic chart regeneration and SVG parsing checks