### PR TITLE
chore: organize release changelog sections

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,13 @@
+[changelog]
+commit_parsers = [
+    { message = "^feat", group = "added" },
+    { message = "^fix", group = "fixed" },
+    { message = "^perf", group = "performance" },
+    { message = "^refactor", group = "changed" },
+    { message = '^chore(?:\([^)]*\))?!', group = "changed" },
+    { message = "^docs", group = "documentation" },
+    { message = "^security", group = "security" },
+    { message = "^(build|chore|style)", group = "maintenance" },
+    { message = "^(ci|test)", skip = true },
+    { message = "^.*", group = "other" },
+]


### PR DESCRIPTION
## Summary

- group release notes into user-facing changelog sections
- keep CI and test-only commits out of published notes
- preserve an Other fallback for unmatched commits

## Validation

- previewed the pending v0.4.0 changelog with release-plz
- verified the current history is grouped into Added, Changed, and Documentation