### PR TITLE
feat: add eager Delta scan metadata caching

### DIFF
--- a/src/delta/kernel.rs
+++ b/src/delta/kernel.rs
@@ -4,7 +4,6 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use arrow::{
     array::{Array as _, BooleanArray},
-    compute::filter_record_batch,
     datatypes::SchemaRef,
     error::ArrowError,
     record_batch::RecordBatch,
@@ -191,9 +190,8 @@ impl KernelScan {
         let mut batches = Vec::new();
         for metadata in self.scan.scan_metadata(engine_context.engine.as_ref())? {
             let metadata = metadata?;
-            let (data, selection) = metadata.scan_files.into_parts();
+            let data = metadata.scan_files.apply_selection_vector()?;
             let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data)?.into();
-            let batch = apply_selection_vector(&batch, &selection)?;
             if batch.num_rows() > 0 {
                 batches.push(batch);
             }
@@ -224,18 +222,6 @@ fn collect_file_metadata(
         files,
         add_actions_excluded_during_planning: saw_batch.then_some(excluded_add_actions).flatten(),
     })
-}
-
-fn apply_selection_vector(
-    batch: &RecordBatch,
-    selection: &[bool],
-) -> Result<RecordBatch, ArrowError> {
-    let selection = BooleanArray::from(
-        (0..batch.num_rows())
-            .map(|index| selection.get(index).copied().unwrap_or(true))
-            .collect::<Vec<_>>(),
-    );
-    filter_record_batch(batch, &selection)
 }
 
 fn excluded_add_action_count(metadata: &ScanMetadata) -> Option<u64> {
@@ -666,7 +652,10 @@ mod tests {
             Arc::new(Int32Array::from(vec![1, 2, 3])) as Arc<dyn arrow::array::Array>,
         )])?;
 
-        let selected = apply_selection_vector(&batch, &[false])?;
+        let data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(batch));
+        let selected = delta_kernel::FilteredEngineData::try_new(data, vec![false])?
+            .apply_selection_vector()?;
+        let selected: RecordBatch = ArrowEngineData::try_from_engine_data(selected)?.into();
         let ids = selected
             .column(0)
             .as_any()

--- a/src/delta/kernel.rs
+++ b/src/delta/kernel.rs
@@ -172,14 +172,14 @@ impl KernelScan {
                     .cloned()
                     .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
                     .collect::<Vec<_>>();
-                collect_file_metadata(self.scan.scan_metadata_from(
+                collect_scan_files(self.scan.scan_metadata_from(
                     engine_context.engine.as_ref(),
                     snapshot_version,
                     data,
                     None,
                 )?)
             }
-            None => collect_file_metadata(self.scan.scan_metadata(engine_context.engine.as_ref())?),
+            None => collect_scan_files(self.scan.scan_metadata(engine_context.engine.as_ref())?),
         }
     }
 
@@ -200,7 +200,7 @@ impl KernelScan {
     }
 }
 
-fn collect_file_metadata(
+fn collect_scan_files(
     metadata: impl Iterator<Item = delta_kernel::DeltaResult<ScanMetadata>>,
 ) -> delta_kernel::DeltaResult<KernelScanFileCollection> {
     fn collect(files: &mut Vec<KernelScanFileMetadata>, file: ScanFile) {

--- a/src/delta/kernel.rs
+++ b/src/delta/kernel.rs
@@ -2,12 +2,15 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use arrow::array::BooleanArray;
 use arrow::{
-    array::Array as _, datatypes::SchemaRef, error::ArrowError, record_batch::RecordBatch,
+    array::{Array as _, BooleanArray},
+    compute::filter_record_batch,
+    datatypes::SchemaRef,
+    error::ArrowError,
+    record_batch::RecordBatch,
 };
 use delta_kernel::{
-    Engine, Snapshot, SnapshotRef,
+    Engine, EngineData, Snapshot, SnapshotRef,
     engine::{
         arrow_conversion::TryIntoArrow,
         arrow_data::{ArrowEngineData, EngineDataArrowExt},
@@ -160,29 +163,79 @@ impl KernelScan {
     pub(crate) fn collect_file_metadata(
         &self,
         engine_context: &DeltaKernelEngineContext,
+        snapshot_version: u64,
+        eager_scan_metadata: Option<&[RecordBatch]>,
     ) -> delta_kernel::DeltaResult<KernelScanFileCollection> {
-        fn collect(files: &mut Vec<KernelScanFileMetadata>, file: ScanFile) {
-            files.push(KernelScanFileMetadata::from_scan_file(file));
+        match eager_scan_metadata {
+            Some(batches) => {
+                let data = batches
+                    .iter()
+                    .cloned()
+                    .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
+                    .collect::<Vec<_>>();
+                collect_file_metadata(self.scan.scan_metadata_from(
+                    engine_context.engine.as_ref(),
+                    snapshot_version,
+                    data,
+                    None,
+                )?)
+            }
+            None => collect_file_metadata(self.scan.scan_metadata(engine_context.engine.as_ref())?),
         }
+    }
 
-        let mut files = Vec::new();
-        let mut excluded_add_actions = Some(0_u64);
-        let mut saw_batch = false;
+    pub(crate) fn materialize_scan_metadata(
+        &self,
+        engine_context: &DeltaKernelEngineContext,
+    ) -> delta_kernel::DeltaResult<Arc<[RecordBatch]>> {
+        let mut batches = Vec::new();
         for metadata in self.scan.scan_metadata(engine_context.engine.as_ref())? {
             let metadata = metadata?;
-            saw_batch = true;
-            excluded_add_actions = excluded_add_actions.and_then(|total| {
-                excluded_add_action_count(&metadata).and_then(|count| total.checked_add(count))
-            });
-            files = metadata.visit_scan_files(files, collect)?;
+            let (data, selection) = metadata.scan_files.into_parts();
+            let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data)?.into();
+            let batch = apply_selection_vector(&batch, &selection)?;
+            if batch.num_rows() > 0 {
+                batches.push(batch);
+            }
         }
-        Ok(KernelScanFileCollection {
-            files,
-            add_actions_excluded_during_planning: saw_batch
-                .then_some(excluded_add_actions)
-                .flatten(),
-        })
+        Ok(batches.into())
     }
+}
+
+fn collect_file_metadata(
+    metadata: impl Iterator<Item = delta_kernel::DeltaResult<ScanMetadata>>,
+) -> delta_kernel::DeltaResult<KernelScanFileCollection> {
+    fn collect(files: &mut Vec<KernelScanFileMetadata>, file: ScanFile) {
+        files.push(KernelScanFileMetadata::from_scan_file(file));
+    }
+
+    let mut files = Vec::new();
+    let mut excluded_add_actions = Some(0_u64);
+    let mut saw_batch = false;
+    for metadata in metadata {
+        let metadata = metadata?;
+        saw_batch = true;
+        excluded_add_actions = excluded_add_actions.and_then(|total| {
+            excluded_add_action_count(&metadata).and_then(|count| total.checked_add(count))
+        });
+        files = metadata.visit_scan_files(files, collect)?;
+    }
+    Ok(KernelScanFileCollection {
+        files,
+        add_actions_excluded_during_planning: saw_batch.then_some(excluded_add_actions).flatten(),
+    })
+}
+
+fn apply_selection_vector(
+    batch: &RecordBatch,
+    selection: &[bool],
+) -> Result<RecordBatch, ArrowError> {
+    let selection = BooleanArray::from(
+        (0..batch.num_rows())
+            .map(|index| selection.get(index).copied().unwrap_or(true))
+            .collect::<Vec<_>>(),
+    );
+    filter_record_batch(batch, &selection)
 }
 
 fn excluded_add_action_count(metadata: &ScanMetadata) -> Option<u64> {
@@ -604,6 +657,24 @@ mod tests {
             .expect("Kernel predicate evaluator must return Boolean");
 
         Ok(filter_record_batch(batch, selection)?)
+    }
+
+    #[test]
+    fn selection_vectors_keep_implicit_trailing_rows() -> Result<(), Box<dyn std::error::Error>> {
+        let batch = RecordBatch::try_from_iter([(
+            "id",
+            Arc::new(Int32Array::from(vec![1, 2, 3])) as Arc<dyn arrow::array::Array>,
+        )])?;
+
+        let selected = apply_selection_vector(&batch, &[false])?;
+        let ids = selected
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .ok_or("expected Int32 ids")?;
+
+        assert_eq!(ids.values(), &[2, 3]);
+        Ok(())
     }
 
     #[test]

--- a/src/delta/snapshot.rs
+++ b/src/delta/snapshot.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use arrow::datatypes::SchemaRef;
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use snafu::ResultExt;
 
 use super::{
@@ -12,7 +12,9 @@ use super::{
 };
 use crate::{
     DeltaReaderError, DeltaSnapshotSelection, DeltaStorageOptions,
-    error::{SchemaConversionSnafu, SnapshotLoadSnafu, StorageInitializationSnafu},
+    error::{
+        ScanPlanningSnafu, SchemaConversionSnafu, SnapshotLoadSnafu, StorageInitializationSnafu,
+    },
 };
 
 const TRACING_TARGET: &str = "delta_arrow_reader";
@@ -26,6 +28,7 @@ pub(crate) struct ArrowTableSnapshot {
     protocol: DeltaProtocol,
     schema: SchemaRef,
     engine_context: Arc<DeltaKernelEngineContext>,
+    eager_scan_metadata: Option<Arc<[RecordBatch]>>,
 }
 
 pub(crate) struct KernelTableSnapshot {
@@ -59,6 +62,7 @@ impl KernelTableSnapshot {
             protocol: self.protocol,
             schema,
             engine_context: self.engine_context,
+            eager_scan_metadata: None,
         })
     }
 }
@@ -91,6 +95,23 @@ impl ArrowTableSnapshot {
 
     pub(crate) fn partition_columns(&self) -> &[String] {
         self.snapshot.partition_columns()
+    }
+
+    pub(crate) fn eager_scan_metadata(&self) -> Option<&[RecordBatch]> {
+        self.eager_scan_metadata.as_deref()
+    }
+
+    pub(crate) fn with_eager_scan_metadata(mut self) -> Result<Self, DeltaReaderError> {
+        let metadata = self
+            .snapshot
+            .build_scan(None, None, true)
+            .and_then(|scan| scan.materialize_scan_metadata(self.engine_context.as_ref()))
+            .boxed()
+            .context(ScanPlanningSnafu {
+                reason: "eager_scan_metadata_materialization_failed",
+            })?;
+        self.eager_scan_metadata = Some(metadata);
+        Ok(self)
     }
 }
 

--- a/src/delta/snapshot.rs
+++ b/src/delta/snapshot.rs
@@ -101,7 +101,7 @@ impl ArrowTableSnapshot {
         self.eager_scan_metadata.as_deref()
     }
 
-    pub(crate) fn with_eager_scan_metadata(mut self) -> Result<Self, DeltaReaderError> {
+    pub(crate) fn materialize_eager_scan_metadata(mut self) -> Result<Self, DeltaReaderError> {
         let metadata = self
             .snapshot
             .build_scan(None, None, true)

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -145,6 +145,30 @@ impl DeltaTableBuilder {
         Ok(DeltaTable::new(snapshot, self.execution_options))
     }
 
+    /// Loads a table and eagerly retains its active Delta scan metadata in memory.
+    ///
+    /// This moves Delta log and checkpoint replay into initialization so later scans of this
+    /// immutable snapshot can plan without reopening the Delta log. It increases initialization
+    /// time and retains active-file metadata and statistics for the lifetime of the table.
+    /// Parquet footer and data reads remain query-time operations. Load a new table to observe a
+    /// newer snapshot.
+    pub async fn load_table_with_eager_scan_metadata(self) -> Result<DeltaTable, DeltaReaderError> {
+        let snapshot = load_delta_table_snapshot(
+            self.table_location,
+            self.storage_options,
+            self.snapshot_selection,
+        )
+        .await?;
+        validate_protocol(snapshot.protocol())?;
+        let snapshot = tokio::task::spawn_blocking(move || snapshot.with_eager_scan_metadata())
+            .await
+            .boxed()
+            .context(ScanPlanningSnafu {
+                reason: "eager_scan_metadata_task_failed",
+            })??;
+        Ok(DeltaTable::new(snapshot, self.execution_options))
+    }
+
     /// Loads a Delta Kernel snapshot without converting its logical Arrow schema.
     pub async fn load_snapshot(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
         let snapshot = load_kernel_table_snapshot(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -151,7 +151,8 @@ impl DeltaTableBuilder {
     /// immutable snapshot can plan without reopening the Delta log. It increases initialization
     /// time and retains active-file metadata and statistics for the lifetime of the table.
     /// Parquet footer and data reads remain query-time operations. Load a new table to observe a
-    /// newer snapshot.
+    /// newer snapshot. Unlike [`Self::load_table`], unsupported protocols fail during
+    /// initialization because materialization constructs a scan.
     pub async fn load_table_with_eager_scan_metadata(self) -> Result<DeltaTable, DeltaReaderError> {
         let snapshot = load_delta_table_snapshot(
             self.table_location,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -161,12 +161,13 @@ impl DeltaTableBuilder {
         )
         .await?;
         validate_protocol(snapshot.protocol())?;
-        let snapshot = tokio::task::spawn_blocking(move || snapshot.with_eager_scan_metadata())
-            .await
-            .boxed()
-            .context(ScanPlanningSnafu {
-                reason: "eager_scan_metadata_task_failed",
-            })??;
+        let snapshot =
+            tokio::task::spawn_blocking(move || snapshot.materialize_eager_scan_metadata())
+                .await
+                .boxed()
+                .context(ScanPlanningSnafu {
+                    reason: "eager_scan_metadata_task_failed",
+                })??;
         Ok(DeltaTable::new(snapshot, self.execution_options))
     }
 

--- a/src/reader/planning.rs
+++ b/src/reader/planning.rs
@@ -164,11 +164,15 @@ pub(crate) fn plan_unpartitioned_scan(
             "Delta scan metadata expansion"
         )
         .entered();
-        scan.collect_file_metadata(snapshot.engine_context())
-            .boxed()
-            .context(ScanPlanningSnafu {
-                reason: "kernel_scan_metadata_failed",
-            })?
+        scan.collect_file_metadata(
+            snapshot.engine_context(),
+            snapshot.version(),
+            snapshot.eager_scan_metadata(),
+        )
+        .boxed()
+        .context(ScanPlanningSnafu {
+            reason: "kernel_scan_metadata_failed",
+        })?
     };
     let estimated_input_rows = checked_sum(
         metadata.files.iter().map(|file| file.estimated_rows),

--- a/src/reader/planning.rs
+++ b/src/reader/planning.rs
@@ -4799,7 +4799,7 @@ mod tests {
         )?;
         let lazy =
             super::plan_unpartitioned_scan(&snapshot, None, &[], None, true, Default::default())?;
-        let snapshot = snapshot.with_eager_scan_metadata()?;
+        let snapshot = snapshot.materialize_eager_scan_metadata()?;
         table.disable_delta_log()?;
 
         let plan =
@@ -4820,7 +4820,7 @@ mod tests {
     fn eager_metadata_represents_an_empty_table_without_reopening_the_log()
     -> Result<(), Box<dyn std::error::Error>> {
         let (table, snapshot) = loaded_snapshot("eager-empty-table")?;
-        let snapshot = snapshot.with_eager_scan_metadata()?;
+        let snapshot = snapshot.materialize_eager_scan_metadata()?;
         table.disable_delta_log()?;
 
         let plan =
@@ -4867,7 +4867,7 @@ mod tests {
             false,
             Default::default(),
         )?;
-        let snapshot = snapshot.with_eager_scan_metadata()?;
+        let snapshot = snapshot.materialize_eager_scan_metadata()?;
         table.disable_delta_log()?;
 
         let plan = super::plan_unpartitioned_scan(
@@ -4966,7 +4966,7 @@ mod tests {
             true,
             Default::default(),
         )?;
-        let snapshot = snapshot.with_eager_scan_metadata()?;
+        let snapshot = snapshot.materialize_eager_scan_metadata()?;
         table.disable_delta_log()?;
         let plan = super::plan_unpartitioned_scan(
             &snapshot,

--- a/src/reader/planning.rs
+++ b/src/reader/planning.rs
@@ -4517,6 +4517,34 @@ mod tests {
         plan.file_tasks.iter()
     }
 
+    fn assert_file_task_parity(expected: &DeltaScanFileTask, actual: &DeltaScanFileTask) {
+        assert_eq!(actual.path, expected.path);
+        assert_eq!(actual.file_size, expected.file_size);
+        assert_eq!(actual.parquet_byte_range, expected.parquet_byte_range);
+        assert_eq!(actual.modification_time_ms, expected.modification_time_ms);
+        assert_eq!(actual.partition_values, expected.partition_values);
+        assert_eq!(
+            actual.deletion_vector.is_present(),
+            expected.deletion_vector.is_present()
+        );
+        assert_eq!(
+            actual.transform.clone().into_expression(),
+            expected.transform.clone().into_expression()
+        );
+    }
+
+    fn assert_unpartitioned_plan_parity(
+        expected: &DeltaUnpartitionedScanPlan,
+        actual: &DeltaUnpartitionedScanPlan,
+    ) {
+        assert_eq!(actual.file_tasks.len(), expected.file_tasks.len());
+        for (expected, actual) in expected.file_tasks.iter().zip(&actual.file_tasks) {
+            assert_file_task_parity(expected, actual);
+        }
+        assert_eq!(actual.estimated_input_bytes, expected.estimated_input_bytes);
+        assert_eq!(actual.estimated_input_rows, expected.estimated_input_rows);
+    }
+
     fn execution_file_stream(permit: FileReadPermit, batch: RecordBatch) -> FileBatchStream {
         Box::pin(stream::unfold(
             (Some(batch), permit),
@@ -4741,7 +4769,7 @@ mod tests {
     }
 
     #[test]
-    fn eager_metadata_keeps_only_active_files_after_log_reconciliation()
+    fn eager_metadata_matches_lazy_active_files_after_log_reconciliation()
     -> Result<(), Box<dyn std::error::Error>> {
         let table = DeltaLogTable::new_with_metadata_and_adds(
             "eager-active-files",
@@ -4768,13 +4796,16 @@ mod tests {
             &table.0.to_string_lossy(),
             &DeltaStorageOptions::new(),
             DeltaSnapshotSelection::Latest,
-        )?
-        .with_eager_scan_metadata()?;
+        )?;
+        let lazy =
+            super::plan_unpartitioned_scan(&snapshot, None, &[], None, true, Default::default())?;
+        let snapshot = snapshot.with_eager_scan_metadata()?;
         table.disable_delta_log()?;
 
         let plan =
             super::plan_unpartitioned_scan(&snapshot, None, &[], None, true, Default::default())?;
 
+        assert_unpartitioned_plan_parity(&lazy, &plan);
         assert_eq!(
             unpartitioned_tasks(&plan)
                 .map(|task| task.path.as_str())
@@ -4807,7 +4838,7 @@ mod tests {
     }
 
     #[test]
-    fn eager_metadata_preserves_partition_pruning_without_the_log()
+    fn eager_metadata_matches_lazy_partition_pruning_without_the_log()
     -> Result<(), Box<dyn std::error::Error>> {
         let table = DeltaLogTable::new_with_metadata_and_adds(
             "eager-partition-pruning",
@@ -4821,15 +4852,23 @@ mod tests {
             &table.0.to_string_lossy(),
             &DeltaStorageOptions::new(),
             DeltaSnapshotSelection::Latest,
-        )?
-        .with_eager_scan_metadata()?;
-        table.disable_delta_log()?;
+        )?;
         let predicate = DeltaPredicate::Compare {
             column: "region".to_owned(),
             op: DeltaComparison::Eq,
             value: DeltaScalar::Utf8("west".to_owned()),
         };
         let kernel_predicate = kernel_pruning_predicate(&predicate).ok_or("expected predicate")?;
+        let lazy = super::plan_unpartitioned_scan(
+            &snapshot,
+            None,
+            &[],
+            Some(kernel_predicate.clone()),
+            false,
+            Default::default(),
+        )?;
+        let snapshot = snapshot.with_eager_scan_metadata()?;
+        table.disable_delta_log()?;
 
         let plan = super::plan_unpartitioned_scan(
             &snapshot,
@@ -4840,6 +4879,7 @@ mod tests {
             Default::default(),
         )?;
 
+        assert_unpartitioned_plan_parity(&lazy, &plan);
         assert_eq!(
             unpartitioned_tasks(&plan)
                 .map(|task| task.path.as_str())
@@ -4851,7 +4891,7 @@ mod tests {
     }
 
     #[test]
-    fn statistics_pruning_preserves_surviving_files_and_deletion_vectors()
+    fn eager_metadata_matches_lazy_statistics_pruning_and_deletion_vectors()
     -> Result<(), Box<dyn std::error::Error>> {
         let adds = [
             dv_add_action(
@@ -4904,7 +4944,30 @@ mod tests {
         validate_predicate(&predicate, snapshot.schema().as_ref())?;
         let kernel_predicate =
             kernel_pruning_predicate(&predicate).ok_or("expected Kernel predicate")?;
-
+        let lazy_high = super::plan_unpartitioned_scan(
+            &snapshot,
+            None,
+            &[],
+            Some(kernel_predicate.clone()),
+            true,
+            Default::default(),
+        )?;
+        let low_predicate = kernel_pruning_predicate(&DeltaPredicate::Compare {
+            column: "id".to_owned(),
+            op: DeltaComparison::LtEq,
+            value: DeltaScalar::Int32(50),
+        })
+        .ok_or("expected second Kernel predicate")?;
+        let lazy_low = super::plan_unpartitioned_scan(
+            &snapshot,
+            None,
+            &[],
+            Some(low_predicate.clone()),
+            true,
+            Default::default(),
+        )?;
+        let snapshot = snapshot.with_eager_scan_metadata()?;
+        table.disable_delta_log()?;
         let plan = super::plan_unpartitioned_scan(
             &snapshot,
             None,
@@ -4913,7 +4976,17 @@ mod tests {
             true,
             Default::default(),
         )?;
+        let low_plan = super::plan_unpartitioned_scan(
+            &snapshot,
+            None,
+            &[],
+            Some(low_predicate),
+            true,
+            Default::default(),
+        )?;
 
+        assert_unpartitioned_plan_parity(&lazy_high, &plan);
+        assert_unpartitioned_plan_parity(&lazy_low, &low_plan);
         assert_eq!(
             unpartitioned_tasks(&plan)
                 .map(|task| task.path.as_str())
@@ -4944,6 +5017,17 @@ mod tests {
         assert!(!plain.deletion_vector.is_present());
         assert_eq!(plan.add_actions_excluded_during_planning, Some(2));
         assert_eq!(plan.estimated_input_rows, None);
+        assert_eq!(
+            unpartitioned_tasks(&low_plan)
+                .map(|task| task.path.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "id-dv-impossible.parquet",
+                "id-plain-impossible.parquet",
+                "id-plain-missing-stats.parquet",
+                "id-dv-missing-stats.parquet",
+            ]
+        );
         Ok(())
     }
 

--- a/src/reader/planning.rs
+++ b/src/reader/planning.rs
@@ -4339,6 +4339,11 @@ mod tests {
             )?;
             Ok(Self(path))
         }
+
+        fn disable_delta_log(&self) -> Result<(), Box<dyn std::error::Error>> {
+            fs::rename(self.0.join("_delta_log"), self.0.join("disabled-log"))?;
+            Ok(())
+        }
     }
 
     impl Drop for DeltaLogTable {
@@ -4732,6 +4737,116 @@ mod tests {
         assert_eq!(plan.estimated_input_bytes, Some(60));
         assert_eq!(plan.estimated_input_rows, Some(6));
         assert!(Arc::ptr_eq(&plan.engine_context, snapshot.engine_context()));
+        Ok(())
+    }
+
+    #[test]
+    fn eager_metadata_keeps_only_active_files_after_log_reconciliation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let table = DeltaLogTable::new_with_metadata_and_adds(
+            "eager-active-files",
+            METADATA_JSON,
+            &[
+                add("removed.parquet", 10, Some(1)),
+                add("active.parquet", 20, Some(2)),
+            ],
+        )?;
+        fs::write(
+            table.0.join("_delta_log/00000000000000000001.json"),
+            format!(
+                "{}\n",
+                serde_json::json!({
+                    "remove": {
+                        "path": "removed.parquet",
+                        "deletionTimestamp": 1_587_968_586_001_i64,
+                        "dataChange": true
+                    }
+                })
+            ),
+        )?;
+        let snapshot = load_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &DeltaStorageOptions::new(),
+            DeltaSnapshotSelection::Latest,
+        )?
+        .with_eager_scan_metadata()?;
+        table.disable_delta_log()?;
+
+        let plan =
+            super::plan_unpartitioned_scan(&snapshot, None, &[], None, true, Default::default())?;
+
+        assert_eq!(
+            unpartitioned_tasks(&plan)
+                .map(|task| task.path.as_str())
+                .collect::<Vec<_>>(),
+            ["active.parquet"]
+        );
+        assert_eq!(plan.estimated_input_rows, Some(2));
+        Ok(())
+    }
+
+    #[test]
+    fn eager_metadata_represents_an_empty_table_without_reopening_the_log()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (table, snapshot) = loaded_snapshot("eager-empty-table")?;
+        let snapshot = snapshot.with_eager_scan_metadata()?;
+        table.disable_delta_log()?;
+
+        let plan =
+            super::plan_unpartitioned_scan(&snapshot, None, &[], None, true, Default::default())?;
+
+        assert!(snapshot.eager_scan_metadata().is_some());
+        assert!(
+            snapshot
+                .eager_scan_metadata()
+                .unwrap_or_default()
+                .is_empty()
+        );
+        assert!(plan.file_tasks.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn eager_metadata_preserves_partition_pruning_without_the_log()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let table = DeltaLogTable::new_with_metadata_and_adds(
+            "eager-partition-pruning",
+            PARTITIONED_METADATA_JSON,
+            &[
+                add_with_partition("west.parquet", 10, 2, "west"),
+                add_with_partition("east.parquet", 10, 2, "east"),
+            ],
+        )?;
+        let snapshot = load_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &DeltaStorageOptions::new(),
+            DeltaSnapshotSelection::Latest,
+        )?
+        .with_eager_scan_metadata()?;
+        table.disable_delta_log()?;
+        let predicate = DeltaPredicate::Compare {
+            column: "region".to_owned(),
+            op: DeltaComparison::Eq,
+            value: DeltaScalar::Utf8("west".to_owned()),
+        };
+        let kernel_predicate = kernel_pruning_predicate(&predicate).ok_or("expected predicate")?;
+
+        let plan = super::plan_unpartitioned_scan(
+            &snapshot,
+            None,
+            &[],
+            Some(kernel_predicate),
+            false,
+            Default::default(),
+        )?;
+
+        assert_eq!(
+            unpartitioned_tasks(&plan)
+                .map(|task| task.path.as_str())
+                .collect::<Vec<_>>(),
+            ["west.parquet"]
+        );
+        assert_eq!(plan.add_actions_excluded_during_planning, Some(1));
         Ok(())
     }
 

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -210,6 +210,10 @@ fn streaming_reader_contract_is_public() {
         .with_snapshot_selection(DeltaSnapshotSelection::Version(1))
         .with_execution_options(DeltaScanExecutionOptions::new());
     assert_future::<Result<DeltaTable, DeltaReaderError>>(builder.load_table());
+    let eager_builder = DeltaTableBuilder::new("file:///tmp/table");
+    assert_future::<Result<DeltaTable, DeltaReaderError>>(
+        eager_builder.load_table_with_eager_scan_metadata(),
+    );
     let snapshot_builder = DeltaTableBuilder::new("file:///tmp/table");
     assert_future::<Result<DeltaTableSnapshot, DeltaReaderError>>(snapshot_builder.load_snapshot());
 

--- a/tests/reader/datafusion_adapter.rs
+++ b/tests/reader/datafusion_adapter.rs
@@ -125,6 +125,11 @@ impl TestTable {
         )?;
         Ok(())
     }
+
+    fn disable_delta_log(&self) -> TestResult {
+        fs::rename(self.0.join("_delta_log"), self.0.join("disabled-log"))?;
+        Ok(())
+    }
 }
 
 impl Drop for TestTable {
@@ -280,6 +285,34 @@ async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> T
             .value(0),
         10
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn registered_eager_table_reuses_metadata_across_sql_queries_without_the_log() -> TestResult {
+    let fixture = TestTable::partitioned("eager-metadata-registration")?;
+    let table = DeltaTableBuilder::new(fixture.uri())
+        .load_table_with_eager_scan_metadata()
+        .await?;
+    let context = SessionContext::new();
+    register_table(&context, "orders", table, ScanOptions::default())?;
+    fixture.disable_delta_log()?;
+
+    for (region, expected_ids) in [("west", vec![1, 2]), ("east", vec![3, 4])] {
+        let plan = context
+            .sql(&format!(
+                "SELECT id FROM orders WHERE region = '{region}' ORDER BY id"
+            ))
+            .await?
+            .create_physical_plan()
+            .await?;
+        let metrics = collect_scan_metrics(plan.as_ref());
+        let batches = collect_plan(&context, plan).await?;
+
+        assert_eq!(ids(&batches), expected_ids);
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].snapshot().reader_metrics.files_planned, 1);
+    }
     Ok(())
 }
 

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -23,6 +23,10 @@ use delta_arrow_reader::{
 use delta_arrow_reader::{
     DeltaScan, DeltaScanExecutionOptions, DeltaScanMetrics, DeltaTableBuilder,
 };
+use delta_kernel::Snapshot;
+use delta_kernel_default_engine::{
+    DefaultEngineBuilder, executor::tokio::TokioMultiThreadExecutor, storage::store_from_url,
+};
 use futures_util::StreamExt;
 use futures_util::TryStreamExt;
 use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
@@ -409,6 +413,52 @@ fn eager_scan_metadata_supports_concurrent_planning_without_the_delta_log() -> T
         assert_eq!(sorted_ids(&high_batches), [5, 6, 7, 8]);
         assert_eq!(low_metrics.snapshot().files_planned, 1);
         assert_eq!(high_metrics.snapshot().files_planned, 1);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
+fn eager_scan_metadata_loads_from_a_checkpoint_without_json_logs() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("eager-checkpoint")?;
+        let table_url: url::Url = fixture.normalized_uri()?.parse()?;
+        let engine = DefaultEngineBuilder::new(store_from_url(&table_url)?)
+            .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )))
+            .build();
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+        snapshot.checkpoint(&engine, None)?;
+
+        let delta_log = fixture.0.join("_delta_log");
+        fs::remove_file(delta_log.join("00000000000000000000.json"))?;
+        fs::remove_file(delta_log.join("00000000000000000001.json"))?;
+        assert!(
+            delta_log
+                .join("00000000000000000001.checkpoint.parquet")
+                .is_file()
+        );
+
+        let table = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_eager_scan_metadata()
+            .await?;
+        fixture.disable_delta_log()?;
+        let (batches, metrics) = collect_scan(
+            table
+                .scan()
+                .with_predicate(DeltaPredicate::Compare {
+                    column: "id".into(),
+                    op: DeltaComparison::Gt,
+                    value: DeltaScalar::Int32(4),
+                })
+                .build()
+                .await?,
+        )
+        .await?;
+
+        assert_eq!(table.version(), 1);
+        assert_eq!(sorted_ids(&batches), [5, 6, 7, 8]);
+        assert_eq!(metrics.snapshot().files_planned, 1);
         Ok::<_, Box<dyn Error>>(())
     })
 }

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -110,6 +110,11 @@ impl TestTable {
             .map_err(|()| "test path cannot become a file URL".into())
     }
 
+    fn disable_delta_log(&self) -> TestResult {
+        fs::rename(self.0.join("_delta_log"), self.0.join("disabled-log"))?;
+        Ok(())
+    }
+
     fn write_parquet(
         &self,
         name: &str,
@@ -347,7 +352,7 @@ fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestRes
         let (expected_high, _) =
             collect_scan(lazy.scan().with_predicate(high_ids.clone()).build().await?).await?;
 
-        fs::rename(fixture.0.join("_delta_log"), fixture.0.join("disabled-log"))?;
+        fixture.disable_delta_log()?;
 
         let (actual_low, low_metrics) =
             collect_scan(eager.scan().with_predicate(low_ids).build().await?).await?;
@@ -658,17 +663,20 @@ fn stream_is_pull_driven_reports_one_error_and_retains_drop_metrics() -> TestRes
 }
 
 #[test]
-fn delta_kernel_matches_direct_results() -> TestResult {
+fn eager_metadata_preserves_direct_and_delta_kernel_results_without_the_log() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("backend-parity")?;
-        let direct = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
+        let direct = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_eager_scan_metadata()
+            .await?;
         let kernel = DeltaTableBuilder::new(fixture.uri())
             .with_execution_options(
                 DeltaScanExecutionOptions::new()
                     .with_parquet_backend(ParquetReaderBackend::DeltaKernel),
             )
-            .load_table()
+            .load_table_with_eager_scan_metadata()
             .await?;
+        fixture.disable_delta_log()?;
         let kernel_options = DeltaScanExecutionOptions::new()
             .with_parquet_backend(ParquetReaderBackend::DeltaKernel);
         let predicate = DeltaPredicate::Compare {

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -335,6 +335,10 @@ fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestRes
         let eager = DeltaTableBuilder::new(fixture.uri())
             .load_table_with_eager_scan_metadata()
             .await?;
+        let fixed = DeltaTableBuilder::new(fixture.uri())
+            .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
+            .load_table_with_eager_scan_metadata()
+            .await?;
         let lazy = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let low_ids = DeltaPredicate::Compare {
             column: "id".into(),
@@ -358,11 +362,15 @@ fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestRes
             collect_scan(eager.scan().with_predicate(low_ids).build().await?).await?;
         let (actual_high, high_metrics) =
             collect_scan(eager.scan().with_predicate(high_ids).build().await?).await?;
+        let (fixed_batches, fixed_metrics) = collect_scan(fixed.scan().build().await?).await?;
 
         assert_eq!(sorted_ids(&actual_low), sorted_ids(&expected_low));
         assert_eq!(sorted_ids(&actual_high), sorted_ids(&expected_high));
+        assert_eq!(fixed.version(), 0);
+        assert_eq!(sorted_ids(&fixed_batches), [1, 2, 3, 4]);
         assert_eq!(low_metrics.snapshot().files_planned, 1);
         assert_eq!(high_metrics.snapshot().files_planned, 1);
+        assert_eq!(fixed_metrics.snapshot().files_planned, 1);
         Ok::<_, Box<dyn Error>>(())
     })
 }
@@ -389,6 +397,14 @@ fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
         Err(error) => error,
     };
     assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
+    let eager = runtime
+        .block_on(DeltaTableBuilder::new(fixture.uri()).load_table_with_eager_scan_metadata());
+    let error = match eager {
+        Ok(_) => panic!("unsupported protocol eagerly loaded a table"),
+        Err(error) => error,
+    };
+    assert_eq!(error.code(), "unsupported_protocol");
+    assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
     Ok(())
 }
 
@@ -414,7 +430,11 @@ fn eager_metadata_failure_returns_no_table_and_redacts_the_source() -> TestResul
             .to_string()
             .contains("eager_scan_metadata_materialization_failed")
     );
-    assert!(error.source().is_some());
+    assert!(
+        error
+            .source()
+            .is_some_and(|source| source.downcast_ref::<delta_kernel::Error>().is_some())
+    );
     assert!(!error.to_string().contains(INVALID_SIZE));
     assert!(!format!("{error:?}").contains(INVALID_SIZE));
     Ok(())

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -303,6 +303,45 @@ fn local_end_to_end_example_reads_without_sql() -> TestResult {
 }
 
 #[test]
+fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("eager-scan-metadata")?;
+        let eager = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_eager_scan_metadata()
+            .await?;
+        let lazy = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
+        let low_ids = DeltaPredicate::Compare {
+            column: "id".into(),
+            op: DeltaComparison::LtEq,
+            value: DeltaScalar::Int32(4),
+        };
+        let high_ids = DeltaPredicate::Compare {
+            column: "id".into(),
+            op: DeltaComparison::Gt,
+            value: DeltaScalar::Int32(4),
+        };
+
+        let (expected_low, _) =
+            collect_scan(lazy.scan().with_predicate(low_ids.clone()).build().await?).await?;
+        let (expected_high, _) =
+            collect_scan(lazy.scan().with_predicate(high_ids.clone()).build().await?).await?;
+
+        fs::rename(fixture.0.join("_delta_log"), fixture.0.join("disabled-log"))?;
+
+        let (actual_low, low_metrics) =
+            collect_scan(eager.scan().with_predicate(low_ids).build().await?).await?;
+        let (actual_high, high_metrics) =
+            collect_scan(eager.scan().with_predicate(high_ids).build().await?).await?;
+
+        assert_eq!(sorted_ids(&actual_low), sorted_ids(&expected_low));
+        assert_eq!(sorted_ids(&actual_high), sorted_ids(&expected_high));
+        assert_eq!(low_metrics.snapshot().files_planned, 1);
+        assert_eq!(high_metrics.snapshot().files_planned, 1);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
 fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
     let fixture = TestTable::unsupported("unsupported")?;
     let runtime = runtime()?;

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -376,6 +376,44 @@ fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestRes
 }
 
 #[test]
+fn eager_scan_metadata_supports_concurrent_planning_without_the_delta_log() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("eager-concurrent-planning")?;
+        let table = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_eager_scan_metadata()
+            .await?;
+        fixture.disable_delta_log()?;
+
+        let (low_scan, high_scan) = tokio::try_join!(
+            table
+                .scan()
+                .with_predicate(DeltaPredicate::Compare {
+                    column: "id".into(),
+                    op: DeltaComparison::LtEq,
+                    value: DeltaScalar::Int32(4),
+                })
+                .build(),
+            table
+                .scan()
+                .with_predicate(DeltaPredicate::Compare {
+                    column: "id".into(),
+                    op: DeltaComparison::Gt,
+                    value: DeltaScalar::Int32(4),
+                })
+                .build(),
+        )?;
+        let ((low_batches, low_metrics), (high_batches, high_metrics)) =
+            tokio::try_join!(collect_scan(low_scan), collect_scan(high_scan))?;
+
+        assert_eq!(sorted_ids(&low_batches), [1, 2, 3, 4]);
+        assert_eq!(sorted_ids(&high_batches), [5, 6, 7, 8]);
+        assert_eq!(low_metrics.snapshot().files_planned, 1);
+        assert_eq!(high_metrics.snapshot().files_planned, 1);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
 fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
     let fixture = TestTable::unsupported("unsupported")?;
     let runtime = runtime()?;

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -70,6 +70,27 @@ impl TestTable {
         Ok(table)
     }
 
+    fn malformed_add(name: &str, invalid_size: &str) -> TestResult<Self> {
+        let table = Self::empty(name)?;
+        table.write_log(
+            0,
+            &[
+                protocol(1),
+                metadata(),
+                json!({
+                    "add": {
+                        "path": "secret.parquet",
+                        "partitionValues": {},
+                        "size": invalid_size,
+                        "modificationTime": 1587968586000_i64,
+                        "dataChange": true
+                    }
+                }),
+            ],
+        )?;
+        Ok(table)
+    }
+
     fn empty(name: &str) -> TestResult<Self> {
         let nonce = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
         let path = Path::new("target")
@@ -363,6 +384,34 @@ fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
         Err(error) => error,
     };
     assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
+    Ok(())
+}
+
+#[test]
+fn eager_metadata_failure_returns_no_table_and_redacts_the_source() -> TestResult {
+    const INVALID_SIZE: &str = "secret-not-a-file-size";
+    let fixture = TestTable::malformed_add("eager-failure", INVALID_SIZE)?;
+    let runtime = runtime()?;
+
+    let lazy = runtime.block_on(DeltaTableBuilder::new(fixture.uri()).load_table())?;
+    assert_eq!(lazy.version(), 0);
+    let error = match runtime
+        .block_on(DeltaTableBuilder::new(fixture.uri()).load_table_with_eager_scan_metadata())
+    {
+        Ok(_) => return Err("malformed eager metadata should not return a table".into()),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.code(), "scan_planning");
+    assert_eq!(error.phase(), DeltaReaderPhase::ScanPlanning);
+    assert!(
+        error
+            .to_string()
+            .contains("eager_scan_metadata_materialization_failed")
+    );
+    assert!(error.source().is_some());
+    assert!(!error.to_string().contains(INVALID_SIZE));
+    assert!(!format!("{error:?}").contains(INVALID_SIZE));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- add `DeltaTableBuilder::load_table_with_eager_scan_metadata()` as the explicit opt-in loading API
- materialize reconciled active-file metadata with all statistics during initialization and reuse it through Delta Kernel's `scan_metadata_from`
- keep lazy loading unchanged and share the cached planning path across streaming, DataFusion, and both Parquet backends
- preserve Kernel error sources while keeping table locations and credentials out of public errors and debug output

## Correctness coverage

- cached and lazy file-task parity for unfiltered, partition-pruned, statistics-pruned, deletion-vector, and column-mapping scans
- repeated and concurrent planning from one eager table after `_delta_log` is unavailable
- real V1 checkpoint initialization after JSON commit removal, followed by planning after all log files are unavailable
- direct and Delta Kernel backend result parity, plus repeated DataFusion SQL queries from one registered eager table
- empty tables, reconciled add/remove actions, implicit selection-vector tails, malformed eager metadata, unsupported protocols, and fixed snapshot versions

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked`
- `cargo test --locked --features datafusion`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `git diff --check`
- `cargo package --locked`

Closes #30
