### PR TITLE
feat: expose eager Delta metadata cache lifecycle tracing

### DIFF
--- a/src/delta/snapshot.rs
+++ b/src/delta/snapshot.rs
@@ -106,8 +106,8 @@ impl ArrowTableSnapshot {
 
     pub(crate) fn materialize_eager_scan_metadata(mut self) -> Result<Self, DeltaReaderError> {
         let snapshot_version = self.version();
-        let started_at = Instant::now();
         trace_scan_metadata_cache_build_started(snapshot_version);
+        let started_at = Instant::now();
         let result = self
             .snapshot
             .build_scan(None, None, true)
@@ -467,7 +467,10 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use arrow::datatypes::{DataType, TimeUnit};
+    use arrow::{
+        datatypes::{DataType, TimeUnit},
+        record_batch::RecordBatch,
+    };
     use futures_util::future;
     use object_store::{ObjectStoreExt, memory::InMemory, path::Path as ObjectStorePath};
     use tracing::{
@@ -905,11 +908,13 @@ mod tests {
     fn eager_cache_build_tracing_reports_retained_metadata_without_sensitive_values()
     -> Result<(), Box<dyn std::error::Error>> {
         const OBJECT_KEY: &str = "secret-object-key.parquet";
+        const SECOND_OBJECT_KEY: &str = "second-secret-object-key.parquet";
         const STORAGE_VALUE: &str = "secret-storage-value";
         let table = DeltaLogTable::new("eager-cache-tracing")?;
         table.write_log(
             2,
-            r#"{"add":{"path":"secret-object-key.parquet","partitionValues":{},"size":10,"modificationTime":1587968586000,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"id\":1},\"maxValues\":{\"id\":1},\"nullCount\":{\"id\":0}}"}}"#,
+            r#"{"add":{"path":"secret-object-key.parquet","partitionValues":{},"size":10,"modificationTime":1587968586000,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"id\":1},\"maxValues\":{\"id\":1},\"nullCount\":{\"id\":0}}"}}
+{"add":{"path":"second-secret-object-key.parquet","partitionValues":{},"size":10,"modificationTime":1587968586001,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"id\":2},\"maxValues\":{\"id\":2},\"nullCount\":{\"id\":0}}"}}"#,
         )?;
         let snapshot = load_delta_table_snapshot_blocking(
             &table.0.to_string_lossy(),
@@ -918,7 +923,17 @@ mod tests {
         )?;
         let table_path = table.0.to_string_lossy().into_owned();
         let (result, events) = capture_events(|| snapshot.materialize_eager_scan_metadata());
-        result?;
+        let snapshot = result?;
+        let cached_metadata = snapshot
+            .eager_scan_metadata()
+            .ok_or("eager metadata missing")?;
+        let expected_batch_count = cached_metadata.len().to_string();
+        let expected_file_count = cached_metadata
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>()
+            .to_string();
+        assert_eq!(expected_file_count, "2");
 
         assert_eq!(events.len(), 2);
         assert_eq!(
@@ -948,21 +963,19 @@ mod tests {
             completed.fields.get("snapshot_version").map(String::as_str),
             Some("2")
         );
-        assert!(
+        assert_eq!(
             completed
                 .fields
                 .get("cached_batch_count")
-                .ok_or("cached batch count missing")?
-                .parse::<usize>()?
-                > 0
+                .map(String::as_str),
+            Some(expected_batch_count.as_str())
         );
-        assert!(
+        assert_eq!(
             completed
                 .fields
                 .get("cached_file_count")
-                .ok_or("cached file count missing")?
-                .parse::<usize>()?
-                > 0
+                .map(String::as_str),
+            Some(expected_file_count.as_str())
         );
         completed
             .fields
@@ -972,6 +985,7 @@ mod tests {
         let captured = format!("{events:?}");
         assert!(!captured.contains(&table_path));
         assert!(!captured.contains(OBJECT_KEY));
+        assert!(!captured.contains(SECOND_OBJECT_KEY));
         assert!(!captured.contains(STORAGE_VALUE));
         Ok(())
     }

--- a/src/delta/snapshot.rs
+++ b/src/delta/snapshot.rs
@@ -1,6 +1,6 @@
 //! Immutable Delta snapshot loading.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use snafu::ResultExt;
@@ -21,6 +21,9 @@ const TRACING_TARGET: &str = "delta_arrow_reader";
 const SNAPSHOT_LOAD_STARTED_EVENT: &str = "snapshot_load.started";
 const SNAPSHOT_LOAD_COMPLETED_EVENT: &str = "snapshot_load.completed";
 const SNAPSHOT_LOAD_FAILED_EVENT: &str = "snapshot_load.failed";
+const SCAN_METADATA_CACHE_BUILD_STARTED_EVENT: &str = "scan_metadata_cache_build.started";
+const SCAN_METADATA_CACHE_BUILD_COMPLETED_EVENT: &str = "scan_metadata_cache_build.completed";
+const SCAN_METADATA_CACHE_BUILD_FAILED_EVENT: &str = "scan_metadata_cache_build.failed";
 
 #[derive(Clone)]
 pub(crate) struct ArrowTableSnapshot {
@@ -102,16 +105,37 @@ impl ArrowTableSnapshot {
     }
 
     pub(crate) fn materialize_eager_scan_metadata(mut self) -> Result<Self, DeltaReaderError> {
-        let metadata = self
+        let snapshot_version = self.version();
+        let started_at = Instant::now();
+        trace_scan_metadata_cache_build_started(snapshot_version);
+        let result = self
             .snapshot
             .build_scan(None, None, true)
             .and_then(|scan| scan.materialize_scan_metadata(self.engine_context.as_ref()))
             .boxed()
             .context(ScanPlanningSnafu {
                 reason: "eager_scan_metadata_materialization_failed",
-            })?;
-        self.eager_scan_metadata = Some(metadata);
-        Ok(self)
+            });
+
+        match result {
+            Ok(metadata) => {
+                trace_scan_metadata_cache_build_completed(
+                    snapshot_version,
+                    metadata.as_ref(),
+                    started_at.elapsed().as_micros(),
+                );
+                self.eager_scan_metadata = Some(metadata);
+                Ok(self)
+            }
+            Err(error) => {
+                trace_scan_metadata_cache_build_failed(
+                    snapshot_version,
+                    started_at.elapsed().as_micros(),
+                    &error,
+                );
+                Err(error)
+            }
+        }
     }
 }
 
@@ -273,6 +297,47 @@ fn trace_snapshot_load_failed(selection: &'static str, error: &DeltaReaderError)
         target: TRACING_TARGET,
         event = SNAPSHOT_LOAD_FAILED_EVENT,
         selection,
+        error_code = error.code(),
+        error_phase = error.phase().as_str()
+    );
+}
+
+fn trace_scan_metadata_cache_build_started(snapshot_version: u64) {
+    tracing::debug!(
+        target: TRACING_TARGET,
+        event = SCAN_METADATA_CACHE_BUILD_STARTED_EVENT,
+        snapshot_version,
+        outcome = "started"
+    );
+}
+
+fn trace_scan_metadata_cache_build_completed(
+    snapshot_version: u64,
+    metadata: &[RecordBatch],
+    elapsed_micros: u128,
+) {
+    tracing::debug!(
+        target: TRACING_TARGET,
+        event = SCAN_METADATA_CACHE_BUILD_COMPLETED_EVENT,
+        snapshot_version,
+        outcome = "completed",
+        cached_batch_count = metadata.len(),
+        cached_file_count = metadata.iter().map(RecordBatch::num_rows).sum::<usize>(),
+        elapsed_micros
+    );
+}
+
+fn trace_scan_metadata_cache_build_failed(
+    snapshot_version: u64,
+    elapsed_micros: u128,
+    error: &DeltaReaderError,
+) {
+    tracing::debug!(
+        target: TRACING_TARGET,
+        event = SCAN_METADATA_CACHE_BUILD_FAILED_EVENT,
+        snapshot_version,
+        outcome = "failed",
+        elapsed_micros,
         error_code = error.code(),
         error_phase = error.phase().as_str()
     );
@@ -480,11 +545,9 @@ mod tests {
         fn event(&self, event: &Event<'_>) {
             let mut visitor = FieldVisitor::default();
             event.record(&mut visitor);
-            if visitor
-                .0
-                .get("event")
-                .is_some_and(|name| name.starts_with("snapshot_load."))
-                && let Some(events) = &self.0
+            if visitor.0.get("event").is_some_and(|name| {
+                name.starts_with("snapshot_load.") || name.starts_with("scan_metadata_cache_build.")
+            }) && let Some(events) = &self.0
                 && let Ok(mut events) = events.lock()
             {
                 events.push(CapturedEvent {
@@ -519,6 +582,10 @@ mod tests {
         fn record_i64(&mut self, field: &Field, value: i64) {
             self.0.insert(field.name().to_owned(), value.to_string());
         }
+
+        fn record_u128(&mut self, field: &Field, value: u128) {
+            self.0.insert(field.name().to_owned(), value.to_string());
+        }
     }
 
     struct DeltaLogTable(PathBuf);
@@ -548,6 +615,15 @@ mod tests {
             )?;
             Ok(Self(path))
         }
+
+        fn write_log(&self, version: u64, contents: &str) -> Result<(), std::io::Error> {
+            fs::write(
+                self.0
+                    .join("_delta_log")
+                    .join(format!("{version:020}.json")),
+                format!("{contents}\n"),
+            )
+        }
     }
 
     impl Drop for DeltaLogTable {
@@ -574,6 +650,23 @@ mod tests {
             .join(unique_name(name)?);
         fs::create_dir_all(&path)?;
         Ok(DeltaLogTable(path))
+    }
+
+    fn capture_events<T>(run: impl FnOnce() -> T) -> (T, Vec<CapturedEvent>) {
+        let _lock = TRACING_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let collector = EventCollector::capturing();
+        let capture = collector.clone();
+        TRACING_TEST_GLOBAL_SUBSCRIBER.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(EventCollector::default());
+        });
+        let result = tracing::subscriber::with_default(collector, || {
+            tracing::callsite::rebuild_interest_cache();
+            run()
+        });
+        tracing::callsite::rebuild_interest_cache();
+        (result, capture.events())
     }
 
     #[test]
@@ -744,19 +837,9 @@ mod tests {
 
     #[test]
     fn tracing_emits_only_the_bounded_load_fields() -> Result<(), Box<dyn std::error::Error>> {
-        let _lock = TRACING_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let table = DeltaLogTable::new("tracing")?;
-        let collector = EventCollector::capturing();
-        let capture = collector.clone();
         let secret_uri = "ftp://user:password@example.com/table?token=secret";
-
-        TRACING_TEST_GLOBAL_SUBSCRIBER.call_once(|| {
-            let _ = tracing::subscriber::set_global_default(EventCollector::default());
-        });
-        tracing::subscriber::with_default(collector, || {
-            tracing::callsite::rebuild_interest_cache();
+        let (result, events) = capture_events(|| {
             load_delta_table_snapshot_blocking(
                 &table.0.to_string_lossy(),
                 &DeltaStorageOptions::new(),
@@ -771,10 +854,9 @@ mod tests {
                 .is_err()
             );
             Ok::<_, DeltaReaderError>(())
-        })?;
-        tracing::callsite::rebuild_interest_cache();
+        });
+        result?;
 
-        let events = capture.events();
         assert_eq!(events.len(), 4);
         assert!(events.iter().all(|event| {
             event.target == TRACING_TARGET
@@ -816,6 +898,181 @@ mod tests {
                 ("selection".to_owned(), "version".to_owned()),
             ])
         );
+        Ok(())
+    }
+
+    #[test]
+    fn eager_cache_build_tracing_reports_retained_metadata_without_sensitive_values()
+    -> Result<(), Box<dyn std::error::Error>> {
+        const OBJECT_KEY: &str = "secret-object-key.parquet";
+        const STORAGE_VALUE: &str = "secret-storage-value";
+        let table = DeltaLogTable::new("eager-cache-tracing")?;
+        table.write_log(
+            2,
+            r#"{"add":{"path":"secret-object-key.parquet","partitionValues":{},"size":10,"modificationTime":1587968586000,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"id\":1},\"maxValues\":{\"id\":1},\"nullCount\":{\"id\":0}}"}}"#,
+        )?;
+        let snapshot = load_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &storage_options(&[("secret-option", STORAGE_VALUE)]),
+            DeltaSnapshotSelection::Latest,
+        )?;
+        let table_path = table.0.to_string_lossy().into_owned();
+        let (result, events) = capture_events(|| snapshot.materialize_eager_scan_metadata());
+        result?;
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].fields,
+            BTreeMap::from([
+                (
+                    "event".to_owned(),
+                    "scan_metadata_cache_build.started".to_owned(),
+                ),
+                ("outcome".to_owned(), "started".to_owned()),
+                ("snapshot_version".to_owned(), "2".to_owned()),
+            ])
+        );
+        let completed = &events[1];
+        assert_eq!(completed.target, TRACING_TARGET);
+        assert_eq!(completed.level, Level::DEBUG);
+        assert_eq!(completed.fields.len(), 6);
+        assert_eq!(
+            completed.fields.get("event").map(String::as_str),
+            Some("scan_metadata_cache_build.completed")
+        );
+        assert_eq!(
+            completed.fields.get("outcome").map(String::as_str),
+            Some("completed")
+        );
+        assert_eq!(
+            completed.fields.get("snapshot_version").map(String::as_str),
+            Some("2")
+        );
+        assert!(
+            completed
+                .fields
+                .get("cached_batch_count")
+                .ok_or("cached batch count missing")?
+                .parse::<usize>()?
+                > 0
+        );
+        assert!(
+            completed
+                .fields
+                .get("cached_file_count")
+                .ok_or("cached file count missing")?
+                .parse::<usize>()?
+                > 0
+        );
+        completed
+            .fields
+            .get("elapsed_micros")
+            .ok_or("elapsed time missing")?
+            .parse::<u128>()?;
+        let captured = format!("{events:?}");
+        assert!(!captured.contains(&table_path));
+        assert!(!captured.contains(OBJECT_KEY));
+        assert!(!captured.contains(STORAGE_VALUE));
+        Ok(())
+    }
+
+    #[test]
+    fn eager_cache_build_tracing_reports_an_empty_cache() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let table = DeltaLogTable::new("empty-eager-cache-tracing")?;
+        let snapshot = load_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &DeltaStorageOptions::new(),
+            DeltaSnapshotSelection::Latest,
+        )?;
+        let (result, events) = capture_events(|| snapshot.materialize_eager_scan_metadata());
+        result?;
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[1]
+                .fields
+                .get("cached_batch_count")
+                .map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            events[1]
+                .fields
+                .get("cached_file_count")
+                .map(String::as_str),
+            Some("0")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn eager_cache_build_tracing_reports_redacted_failure_without_completion()
+    -> Result<(), Box<dyn std::error::Error>> {
+        const INVALID_SIZE: &str = "secret-not-a-file-size";
+        const OBJECT_KEY: &str = "secret-malformed-object.parquet";
+        let table = DeltaLogTable::new("failed-eager-cache-tracing")?;
+        table.write_log(
+            2,
+            r#"{"add":{"path":"secret-malformed-object.parquet","partitionValues":{},"size":"secret-not-a-file-size","modificationTime":1587968586000,"dataChange":true}}"#,
+        )?;
+        let snapshot = load_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &DeltaStorageOptions::new(),
+            DeltaSnapshotSelection::Latest,
+        )?;
+        let (result, events) = capture_events(|| snapshot.materialize_eager_scan_metadata());
+        let error = match result {
+            Ok(_) => return Err("malformed eager metadata should fail".into()),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code(), "scan_planning");
+        assert_eq!(events.len(), 2);
+        assert!(
+            events
+                .iter()
+                .all(|event| { event.target == TRACING_TARGET && event.level == Level::DEBUG })
+        );
+        assert_eq!(
+            events[0].fields.get("event").map(String::as_str),
+            Some("scan_metadata_cache_build.started")
+        );
+        assert_eq!(
+            events[1].fields.get("event").map(String::as_str),
+            Some("scan_metadata_cache_build.failed")
+        );
+        assert_eq!(
+            events[1].fields.get("outcome").map(String::as_str),
+            Some("failed")
+        );
+        assert_eq!(
+            events[1].fields.get("snapshot_version").map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(
+            events[1].fields.get("error_code").map(String::as_str),
+            Some("scan_planning")
+        );
+        assert_eq!(
+            events[1].fields.get("error_phase").map(String::as_str),
+            Some("scan_planning")
+        );
+        assert_eq!(events[1].fields.len(), 6);
+        events[1]
+            .fields
+            .get("elapsed_micros")
+            .ok_or("elapsed time missing")?
+            .parse::<u128>()?;
+        assert!(events.iter().all(|event| {
+            event
+                .fields
+                .get("event")
+                .is_none_or(|name| name != "scan_metadata_cache_build.completed")
+        }));
+        let captured = format!("{events:?}");
+        assert!(!captured.contains(INVALID_SIZE));
+        assert!(!captured.contains(OBJECT_KEY));
         Ok(())
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -54,6 +54,8 @@ use crate::{
 };
 
 const TRACING_TARGET: &str = "delta_arrow_reader";
+const DELTA_LOG_SCAN_METADATA_SOURCE: &str = "delta_log";
+const EAGER_CACHE_SCAN_METADATA_SOURCE: &str = "eager_cache";
 
 /// Configures and loads one immutable Delta table snapshot.
 ///
@@ -389,7 +391,12 @@ impl<'table> DeltaScanBuilder<'table> {
 
         let snapshot_version = self.table.version();
         let backend = self.execution_options.parquet_backend();
-        trace_planning_started(snapshot_version, backend);
+        let scan_metadata_source = if self.table.snapshot.eager_scan_metadata().is_some() {
+            EAGER_CACHE_SCAN_METADATA_SOURCE
+        } else {
+            DELTA_LOG_SCAN_METADATA_SOURCE
+        };
+        trace_planning_started(snapshot_version, backend, scan_metadata_source);
         let snapshot = Arc::clone(&self.table.snapshot);
         let projection = self.projection;
         let predicate = self.predicate;
@@ -426,7 +433,12 @@ impl<'table> DeltaScanBuilder<'table> {
 
         match result {
             Ok(plan) => {
-                trace_planning_completed(snapshot_version, backend, plan.partitions.len());
+                trace_planning_completed(
+                    snapshot_version,
+                    backend,
+                    plan.partitions.len(),
+                    scan_metadata_source,
+                );
                 Ok(DeltaScan {
                     plan: Arc::new(plan),
                     predicate,
@@ -435,7 +447,7 @@ impl<'table> DeltaScanBuilder<'table> {
                 })
             }
             Err(error) => {
-                trace_planning_failed(snapshot_version, backend, &error);
+                trace_planning_failed(snapshot_version, backend, scan_metadata_source, &error);
                 Err(error)
             }
         }
@@ -689,13 +701,18 @@ pub(crate) fn delta_kernel_executor(
     backend::kernel_reader::delta_kernel_file_executor(plan)
 }
 
-fn trace_planning_started(snapshot_version: u64, backend: ParquetReaderBackend) {
+fn trace_planning_started(
+    snapshot_version: u64,
+    backend: ParquetReaderBackend,
+    scan_metadata_source: &'static str,
+) {
     tracing::debug!(
         target: TRACING_TARGET,
         event = "scan_planning.started",
         snapshot_version,
         backend = ?backend,
         partition_count = tracing::field::Empty,
+        scan_metadata_source,
         outcome = "started"
     );
 }
@@ -704,6 +721,7 @@ fn trace_planning_completed(
     snapshot_version: u64,
     backend: ParquetReaderBackend,
     partition_count: usize,
+    scan_metadata_source: &'static str,
 ) {
     tracing::debug!(
         target: TRACING_TARGET,
@@ -711,6 +729,7 @@ fn trace_planning_completed(
         snapshot_version,
         backend = ?backend,
         partition_count,
+        scan_metadata_source,
         outcome = "completed"
     );
 }
@@ -718,6 +737,7 @@ fn trace_planning_completed(
 fn trace_planning_failed(
     snapshot_version: u64,
     backend: ParquetReaderBackend,
+    scan_metadata_source: &'static str,
     error: &DeltaReaderError,
 ) {
     tracing::debug!(
@@ -726,6 +746,7 @@ fn trace_planning_failed(
         snapshot_version,
         backend = ?backend,
         partition_count = tracing::field::Empty,
+        scan_metadata_source,
         outcome = "failed",
         error_code = error.code(),
         error_phase = error.phase().as_str()
@@ -798,10 +819,12 @@ fn trace_execution_dropped(
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::VecDeque,
+        collections::{BTreeMap, VecDeque},
+        fmt, fs,
         future::pending,
-        sync::{Arc, Mutex},
-        time::Duration,
+        path::{Path, PathBuf},
+        sync::{Arc, Mutex, Once},
+        time::{Duration, SystemTime, UNIX_EPOCH},
     };
 
     use arrow::{
@@ -813,17 +836,20 @@ mod tests {
     use tokio::{sync::Notify, time::timeout};
     use tracing::{
         Event, Level, Metadata, Subscriber,
+        field::{Field as TracingField, Visit},
         span::{Attributes, Id, Record},
         subscriber::{Interest, with_default},
     };
 
     use super::{
-        DeltaBatchStream, trace_execution_completed, trace_execution_dropped,
+        DeltaBatchStream, DeltaTable, trace_execution_completed, trace_execution_dropped,
         trace_execution_failed, trace_execution_started, trace_planning_completed,
         trace_planning_failed, trace_planning_started,
     };
     use crate::{
-        DeltaScanExecutionOptions, DeltaScanMetrics, ParquetReaderBackend,
+        DeltaScanExecutionOptions, DeltaScanMetrics, DeltaSnapshotSelection, DeltaStorageOptions,
+        ParquetReaderBackend,
+        delta::snapshot::load_delta_table_snapshot_blocking,
         error::InvalidConfigurationSnafu,
         reader::{
             metrics::DeltaScanMetricsConfig,
@@ -834,8 +860,11 @@ mod tests {
         },
     };
 
+    static TRACING_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static TRACING_TEST_GLOBAL_SUBSCRIBER: Once = Once::new();
+
     #[derive(Clone, Default)]
-    struct EventFields(Arc<Mutex<Vec<Vec<String>>>>);
+    struct EventFields(Arc<Mutex<Vec<BTreeMap<String, String>>>>);
 
     impl Subscriber for EventFields {
         fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
@@ -861,18 +890,89 @@ mod tests {
         fn event(&self, event: &Event<'_>) {
             let metadata = event.metadata();
             assert_eq!(metadata.target(), "delta_arrow_reader");
-            self.0.lock().expect("event lock").push(
-                metadata
-                    .fields()
-                    .iter()
-                    .map(|field| field.name().to_owned())
-                    .collect(),
-            );
+            let mut fields = metadata
+                .fields()
+                .iter()
+                .map(|field| (field.name().to_owned(), "<empty>".to_owned()))
+                .collect();
+            event.record(&mut FieldVisitor(&mut fields));
+            self.0.lock().expect("event lock").push(fields);
         }
 
         fn enter(&self, _span: &Id) {}
 
         fn exit(&self, _span: &Id) {}
+    }
+
+    struct FieldVisitor<'fields>(&'fields mut BTreeMap<String, String>);
+
+    impl Visit for FieldVisitor<'_> {
+        fn record_debug(&mut self, field: &TracingField, value: &dyn fmt::Debug) {
+            self.0.insert(field.name().to_owned(), format!("{value:?}"));
+        }
+
+        fn record_str(&mut self, field: &TracingField, value: &str) {
+            self.0.insert(field.name().to_owned(), value.to_owned());
+        }
+
+        fn record_u64(&mut self, field: &TracingField, value: u64) {
+            self.0.insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_i64(&mut self, field: &TracingField, value: i64) {
+            self.0.insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_u128(&mut self, field: &TracingField, value: u128) {
+            self.0.insert(field.name().to_owned(), value.to_string());
+        }
+    }
+
+    struct DeltaLogTable(PathBuf);
+
+    impl DeltaLogTable {
+        fn new(name: &str) -> Result<Self, Box<dyn std::error::Error>> {
+            let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+            let path = Path::new("target")
+                .join("delta-arrow-reader-tracing-tests")
+                .join(format!("{}-{name}-{nanos}", std::process::id()));
+            fs::create_dir_all(path.join("_delta_log"))?;
+            fs::write(
+                path.join("_delta_log/00000000000000000000.json"),
+                r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"tracing-test","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}
+{"add":{"path":"secret-planning-object.parquet","partitionValues":{},"size":10,"modificationTime":1587968586000,"dataChange":true}}
+"#,
+            )?;
+            Ok(Self(path))
+        }
+    }
+
+    impl Drop for DeltaLogTable {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn capture_events<T>(run: impl FnOnce() -> T) -> (T, Vec<BTreeMap<String, String>>) {
+        let _lock = TRACING_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = EventFields(Arc::clone(&events));
+        TRACING_TEST_GLOBAL_SUBSCRIBER.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(EventFields::default());
+        });
+        let result = with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
+            run()
+        });
+        tracing::callsite::rebuild_interest_cache();
+        let captured = events
+            .lock()
+            .map(|events| events.clone())
+            .unwrap_or_default();
+        (result, captured)
     }
 
     struct ControlledMerge {
@@ -1031,24 +1131,18 @@ mod tests {
 
     #[test]
     fn lifecycle_tracing_has_only_bounded_fields() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = EventFields(Arc::clone(&events));
         let error = InvalidConfigurationSnafu { reason: "test" }.build();
 
-        let _ = tracing::subscriber::set_global_default(EventFields::default());
-        with_default(subscriber, || {
-            tracing::callsite::rebuild_interest_cache();
-            trace_planning_started(7, ParquetReaderBackend::Direct);
-            trace_planning_completed(7, ParquetReaderBackend::Direct, 2);
-            trace_planning_failed(7, ParquetReaderBackend::Direct, &error);
+        let (_, events) = capture_events(|| {
+            trace_planning_started(7, ParquetReaderBackend::Direct, "eager_cache");
+            trace_planning_completed(7, ParquetReaderBackend::Direct, 2, "eager_cache");
+            trace_planning_failed(7, ParquetReaderBackend::Direct, "eager_cache", &error);
             trace_execution_started(7, ParquetReaderBackend::Direct, 2);
             trace_execution_completed(7, ParquetReaderBackend::Direct, 2);
             trace_execution_failed(7, ParquetReaderBackend::Direct, 2, &error);
             trace_execution_dropped(7, ParquetReaderBackend::Direct, 2);
         });
-        tracing::callsite::rebuild_interest_cache();
 
-        let events = events.lock().expect("event lock");
         assert_eq!(events.len(), 7);
         let allowed = [
             "backend",
@@ -1057,16 +1151,92 @@ mod tests {
             "event",
             "outcome",
             "partition_count",
+            "scan_metadata_source",
             "snapshot_version",
         ];
         for fields in events.iter() {
-            assert!(fields.iter().all(|field| allowed.contains(&field.as_str())));
-            assert!(fields.contains(&"event".to_owned()));
-            assert!(fields.contains(&"snapshot_version".to_owned()));
-            assert!(fields.contains(&"backend".to_owned()));
-            assert!(fields.contains(&"partition_count".to_owned()));
-            assert!(fields.contains(&"outcome".to_owned()));
+            assert!(fields.keys().all(|field| allowed.contains(&field.as_str())));
+            assert!(fields.contains_key("event"));
+            assert!(fields.contains_key("snapshot_version"));
+            assert!(fields.contains_key("backend"));
+            assert!(fields.contains_key("partition_count"));
+            assert!(fields.contains_key("outcome"));
+            if fields
+                .get("event")
+                .is_some_and(|event| event.starts_with("scan_planning."))
+            {
+                assert_eq!(
+                    fields.get("scan_metadata_source").map(String::as_str),
+                    Some("eager_cache")
+                );
+            }
         }
+    }
+
+    #[test]
+    fn planning_tracing_reports_the_table_metadata_source_on_success_and_failure()
+    -> Result<(), Box<dyn std::error::Error>> {
+        const OBJECT_KEY: &str = "secret-planning-object.parquet";
+        const STORAGE_VALUE: &str = "secret-planning-storage-value";
+        let fixture = DeltaLogTable::new("planning-source")?;
+        let mut storage_options = DeltaStorageOptions::new();
+        storage_options.insert("secret-option".to_owned(), STORAGE_VALUE.to_owned());
+        let snapshot = load_delta_table_snapshot_blocking(
+            &fixture.0.to_string_lossy(),
+            &storage_options,
+            DeltaSnapshotSelection::Latest,
+        )?;
+        let eager_snapshot = snapshot.clone().materialize_eager_scan_metadata()?;
+        let lazy = DeltaTable::new(snapshot, DeltaScanExecutionOptions::new());
+        let eager = DeltaTable::new(eager_snapshot, DeltaScanExecutionOptions::new());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let (eager_result, eager_events) =
+            capture_events(|| runtime.block_on(eager.scan().build()));
+        let _ = eager_result?;
+        assert_eq!(eager_events.len(), 2);
+        assert_eq!(
+            eager_events[0].get("event").map(String::as_str),
+            Some("scan_planning.started")
+        );
+        assert_eq!(
+            eager_events[1].get("event").map(String::as_str),
+            Some("scan_planning.completed")
+        );
+        assert!(eager_events.iter().all(|event| {
+            event.get("scan_metadata_source").map(String::as_str) == Some("eager_cache")
+        }));
+
+        let (failed_result, failed_events) =
+            capture_events(|| runtime.block_on(eager.scan().with_projection(["missing"]).build()));
+        assert!(failed_result.is_err());
+        assert_eq!(failed_events.len(), 2);
+        assert_eq!(
+            failed_events[0].get("event").map(String::as_str),
+            Some("scan_planning.started")
+        );
+        assert_eq!(
+            failed_events[1].get("event").map(String::as_str),
+            Some("scan_planning.failed")
+        );
+        assert!(failed_events.iter().all(|event| {
+            event.get("scan_metadata_source").map(String::as_str) == Some("eager_cache")
+        }));
+
+        let (lazy_result, lazy_events) = capture_events(|| runtime.block_on(lazy.scan().build()));
+        let _ = lazy_result?;
+        assert_eq!(lazy_events.len(), 2);
+        assert!(lazy_events.iter().all(|event| {
+            event.get("scan_metadata_source").map(String::as_str) == Some("delta_log")
+        }));
+
+        let captured = format!("{eager_events:?}{failed_events:?}{lazy_events:?}");
+        assert!(!captured.contains(&fixture.0.to_string_lossy().into_owned()));
+        assert!(!captured.contains(OBJECT_KEY));
+        assert!(!captured.contains(STORAGE_VALUE));
+        Ok(())
     }
 
     #[tokio::test]

--- a/tests/eager_metadata_tracing.rs
+++ b/tests/eager_metadata_tracing.rs
@@ -1,0 +1,265 @@
+//! End-to-end tracing coverage for public eager metadata initialization.
+
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    fmt, fs,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use delta_arrow_reader::{DeltaStorageOptions, DeltaTableBuilder};
+use tracing::{
+    Event, Level, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+    subscriber::Interest,
+};
+
+type TestResult<T = ()> = Result<T, Box<dyn Error>>;
+
+const TRACING_TARGET: &str = "delta_arrow_reader";
+const PROTOCOL_JSON: &str = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#;
+const METADATA_JSON: &str = r#"{"metaData":{"id":"tracing-test","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
+const FIRST_OBJECT_KEY: &str = "secret-first-object.parquet";
+const SECOND_OBJECT_KEY: &str = "secret-second-object.parquet";
+const MALFORMED_OBJECT_KEY: &str = "secret-malformed-object.parquet";
+const INVALID_SIZE: &str = "secret-not-a-file-size";
+const STORAGE_VALUE: &str = "secret-storage-value";
+
+#[derive(Clone, Default)]
+struct EventCollector(Arc<Mutex<Vec<BTreeMap<String, String>>>>);
+
+impl EventCollector {
+    fn events(&self) -> Vec<BTreeMap<String, String>> {
+        self.0
+            .lock()
+            .map(|events| events.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl Subscriber for EventCollector {
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        if metadata.target() == TRACING_TARGET && *metadata.level() == Level::DEBUG {
+            Interest::always()
+        } else {
+            Interest::sometimes()
+        }
+    }
+
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.target() == TRACING_TARGET && *metadata.level() == Level::DEBUG
+    }
+
+    fn new_span(&self, _attributes: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        if visitor
+            .0
+            .get("event")
+            .is_some_and(|name| name.starts_with("scan_metadata_cache_build."))
+            && let Ok(mut events) = self.0.lock()
+        {
+            events.push(visitor.0);
+        }
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+#[derive(Default)]
+struct FieldVisitor(BTreeMap<String, String>);
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.0.insert(field.name().to_owned(), format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.insert(field.name().to_owned(), value.to_owned());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+}
+
+struct DeltaLogTable(PathBuf);
+
+impl DeltaLogTable {
+    fn new(name: &str, add_actions: &str) -> TestResult<Self> {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let path = Path::new("target")
+            .join("delta-arrow-reader-eager-tracing-tests")
+            .join(format!("{}-{name}-{nanos}", std::process::id()));
+        fs::create_dir_all(path.join("_delta_log"))?;
+        fs::write(
+            path.join("_delta_log/00000000000000000000.json"),
+            [PROTOCOL_JSON, METADATA_JSON, add_actions, ""].join("\n"),
+        )?;
+        Ok(Self(path))
+    }
+
+    fn uri(&self) -> String {
+        self.0.to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for DeltaLogTable {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn storage_options() -> DeltaStorageOptions {
+    [("secret-option".to_owned(), STORAGE_VALUE.to_owned())]
+        .into_iter()
+        .collect()
+}
+
+#[test]
+fn public_eager_initialization_emits_complete_structured_lifecycle_events() -> TestResult {
+    let success = DeltaLogTable::new(
+        "success",
+        concat!(
+            "{\"add\":{\"path\":\"secret-first-object.parquet\",\"partitionValues\":{},\"size\":10,\"modificationTime\":1587968586000,\"dataChange\":true}}\n",
+            "{\"add\":{\"path\":\"secret-second-object.parquet\",\"partitionValues\":{},\"size\":10,\"modificationTime\":1587968586001,\"dataChange\":true}}"
+        ),
+    )?;
+    let failure = DeltaLogTable::new(
+        "failure",
+        "{\"add\":{\"path\":\"secret-malformed-object.parquet\",\"partitionValues\":{},\"size\":\"secret-not-a-file-size\",\"modificationTime\":1587968586000,\"dataChange\":true}}",
+    )?;
+    let collector = EventCollector::default();
+    tracing::subscriber::set_global_default(collector.clone())?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    let table = runtime.block_on(
+        DeltaTableBuilder::new(success.uri())
+            .with_storage_options(storage_options())
+            .load_table_with_eager_scan_metadata(),
+    )?;
+    assert_eq!(table.version(), 0);
+    let error = match runtime.block_on(
+        DeltaTableBuilder::new(failure.uri())
+            .with_storage_options(storage_options())
+            .load_table_with_eager_scan_metadata(),
+    ) {
+        Ok(_) => return Err("malformed eager metadata should fail".into()),
+        Err(error) => error,
+    };
+    assert_eq!(error.code(), "scan_planning");
+
+    let events = collector.events();
+    let [started, completed, failure_started, failed] = events.as_slice() else {
+        return Err(format!("expected four cache-build events, got {}", events.len()).into());
+    };
+    assert_eq!(
+        started,
+        &BTreeMap::from([
+            (
+                "event".to_owned(),
+                "scan_metadata_cache_build.started".to_owned(),
+            ),
+            ("outcome".to_owned(), "started".to_owned()),
+            ("snapshot_version".to_owned(), "0".to_owned()),
+        ])
+    );
+    assert_eq!(
+        completed.get("event").map(String::as_str),
+        Some("scan_metadata_cache_build.completed")
+    );
+    assert_eq!(completed.len(), 6);
+    assert_eq!(
+        completed.get("outcome").map(String::as_str),
+        Some("completed")
+    );
+    assert_eq!(
+        completed.get("snapshot_version").map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(
+        completed.get("cached_file_count").map(String::as_str),
+        Some("2")
+    );
+    assert!(
+        completed
+            .get("cached_batch_count")
+            .ok_or("cached batch count missing")?
+            .parse::<usize>()?
+            > 0
+    );
+    completed
+        .get("elapsed_micros")
+        .ok_or("success elapsed time missing")?
+        .parse::<u128>()?;
+    assert_eq!(
+        failure_started,
+        &BTreeMap::from([
+            (
+                "event".to_owned(),
+                "scan_metadata_cache_build.started".to_owned(),
+            ),
+            ("outcome".to_owned(), "started".to_owned()),
+            ("snapshot_version".to_owned(), "0".to_owned()),
+        ])
+    );
+    assert_eq!(
+        failed.get("event").map(String::as_str),
+        Some("scan_metadata_cache_build.failed")
+    );
+    assert_eq!(failed.len(), 6);
+    assert_eq!(failed.get("outcome").map(String::as_str), Some("failed"));
+    assert_eq!(
+        failed.get("snapshot_version").map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(
+        failed.get("error_code").map(String::as_str),
+        Some("scan_planning")
+    );
+    assert_eq!(
+        failed.get("error_phase").map(String::as_str),
+        Some("scan_planning")
+    );
+    failed
+        .get("elapsed_micros")
+        .ok_or("failure elapsed time missing")?
+        .parse::<u128>()?;
+
+    let captured = format!("{events:?}");
+    for sensitive in [
+        success.uri(),
+        failure.uri(),
+        FIRST_OBJECT_KEY.to_owned(),
+        SECOND_OBJECT_KEY.to_owned(),
+        MALFORMED_OBJECT_KEY.to_owned(),
+        INVALID_SIZE.to_owned(),
+        STORAGE_VALUE.to_owned(),
+    ] {
+        assert!(!captured.contains(&sensitive));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- emit structured debug lifecycle events for eager Delta scan-metadata cache construction
- identify eager-cache versus Delta-log metadata on every scan-planning lifecycle event
- preserve bounded, redacted fields and verify the public async initialization boundary

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked`
- `cargo test --locked --features datafusion`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `git diff --check`
- `cargo package --locked`

Closes #31