### PR TITLE
docs: explain eager Delta scan metadata initialization

### DIFF
--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -19,6 +19,29 @@ At a high level, the reader does three things:
 Once loaded, a `DeltaTable` always points to the same snapshot. To read a newer
 snapshot, load the table again.
 
+## Remote I/O phases
+
+For a table in remote storage, the read path has three distinct I/O phases.
+Only the first phase changes when you opt into eager Delta scan metadata
+initialization:
+
+| Phase | Lazy initialization | Eager initialization |
+| --- | --- | --- |
+| 1. Delta scan metadata | Every scan build performs Delta log/checkpoint replay and selects active files. | Table initialization performs the replay once. Later scan builds select files from the retained metadata. |
+| 2. Parquet footer | The query reads footers and prunes row groups. | Unchanged. |
+| 3. Parquet data | The query reads the selected row groups. | Unchanged. |
+
+A successful eager load therefore needs no later Delta log/checkpoint reads for
+file discovery from that table. It does not move Parquet footer or Parquet data
+I/O into initialization, and it does not change deletion-vector behavior.
+
+The retained Delta scan metadata contains reconciled active `add` metadata and
+available file statistics, not raw JSON commit files. It belongs to one exact
+snapshot and remains in memory for the lifetime of that loaded table.
+Separately loaded tables do not share this memory. There is no TTL, eviction,
+persistence, incremental update, or background refresh; load another table to
+observe a newer snapshot.
+
 ## Streaming API
 
 With the streaming API, these stages appear as a table, a single-use scan, and a

--- a/docs/content/benchmarks.md
+++ b/docs/content/benchmarks.md
@@ -150,3 +150,83 @@ We kept all benchmark data in local MinIO so that public-network delays would
 not affect the results. Hardware and system load still affect absolute times,
 so we will rerun these comparisons when the readers or their execution settings
 change.
+
+## Compare lazy and eager scan metadata
+
+Use the provider-execution benchmark to compare repeated queries against one
+loaded table. Run a matched pair in which only the scan metadata mode and output
+path differ:
+
+```bash
+cargo bench --locked -p delta-arrow-reader --bench reader --all-features -- \
+  --mode provider-exec \
+  --seed 0 \
+  --output target/eager-metadata-lazy.csv \
+  --provider-exec-temp-dir target/eager-metadata-bench \
+  --provider-exec-storage-profile local \
+  --provider-exec-workload provider_many_unequal_files \
+  --provider-exec-query filter_tail_ids \
+  --provider-exec-backend direct-parquet \
+  --provider-exec-scan-metadata-mode lazy \
+  --provider-exec-queries-per-table 3 \
+  --provider-exec-scheduling-profile prefetch_2_ap_target_scan_3x \
+  --provider-exec-parquet-metadata-size-hint-bytes 65536 \
+  --provider-exec-parquet-full-file-read-threshold-bytes disabled \
+  --provider-exec-repetitions 5
+
+cargo bench --locked -p delta-arrow-reader --bench reader --all-features -- \
+  --mode provider-exec \
+  --seed 0 \
+  --output target/eager-metadata-eager.csv \
+  --provider-exec-temp-dir target/eager-metadata-bench \
+  --provider-exec-storage-profile local \
+  --provider-exec-workload provider_many_unequal_files \
+  --provider-exec-query filter_tail_ids \
+  --provider-exec-backend direct-parquet \
+  --provider-exec-scan-metadata-mode eager \
+  --provider-exec-queries-per-table 3 \
+  --provider-exec-scheduling-profile prefetch_2_ap_target_scan_3x \
+  --provider-exec-parquet-metadata-size-hint-bytes 65536 \
+  --provider-exec-parquet-full-file-read-threshold-bytes disabled \
+  --provider-exec-repetitions 5
+```
+
+Each repetition loads and registers a new table, then runs the configured query
+three times against that same table. Keep `--seed`, the temporary directory,
+workload, query, backend, storage, scheduling, Parquet settings, repetition
+count, and query count identical between the two commands. Use at least three
+queries per table so the comparison includes metadata reuse rather than only
+the initialization tradeoff.
+
+The CSV separates the relevant timing boundaries:
+
+- `table_initialization_micros_*` measures table loading. It ends before
+  DataFusion table registration.
+- `planning_micros_*` measures SQL and physical-plan creation for each query,
+  including Delta scan planning. Its percentiles include every query from every
+  repetition.
+- `total_micros_*` measures planning and execution for each query, but excludes
+  table initialization and registration.
+- `session_total_micros_*` starts immediately before table loading and ends
+  after all benchmark queries, output checks, and metrics collection finish. It
+  includes initialization, registration, planning, and execution. Its
+  percentiles use one complete session per repetition.
+
+Before comparing timings, confirm that both CSV rows have the same
+`fixture_fingerprint`, `seed`, workload, query, storage, backend, scheduling,
+repetition count, and query count. `scan_metadata_mode` should be the only
+lifecycle setting that differs.
+
+Eager mode moves Delta log/checkpoint replay into table initialization, so first
+compare `table_initialization_micros_*` and `planning_micros_*` to confirm that
+the work moved between phases. Then compare `session_total_micros_*` to judge
+the end-to-end effect for the chosen number of queries. The per-query
+`total_micros_*` fields help show whether execution time masks a planning-time
+difference.
+
+Do not treat one query count as a universal break-even point. The result depends
+on Delta history and checkpoint shape, active-file count, object-store latency,
+query selectivity, available statistics, memory pressure, hardware load, and
+the number of queries that reuse the loaded table. The local fixture above is a
+reproducible comparison of the two lifecycles; measure representative tables on
+their real storage before choosing a production default.

--- a/docs/content/datafusion.md
+++ b/docs/content/datafusion.md
@@ -42,10 +42,58 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The first step loads the table's Delta metadata. Registering the table gives it
-a name in DataFusion, but does not open its Parquet data files. DataFusion reads
-those files when `collect` runs the query. The `LIMIT` keeps this first result
-small.
+The first step loads an immutable Delta snapshot and its Arrow schema.
+Registering the table gives it a name in DataFusion, but does not open its
+Parquet files. DataFusion plans and reads those files when `collect` runs the
+query. The `LIMIT` keeps this first result small.
+
+## Reuse scan metadata across SQL queries
+
+Opt into eager Delta scan metadata initialization before registering a table
+that will serve several SQL queries:
+
+```no_run
+use datafusion::prelude::SessionContext;
+use delta_arrow_reader::{
+    DeltaTableBuilder,
+    datafusion::{ScanOptions, register_table},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let context = SessionContext::new();
+    let table = DeltaTableBuilder::new("/tmp/example-delta-table")
+        .load_table_with_eager_scan_metadata()
+        .await?;
+
+    register_table(
+        &context,
+        "orders",
+        table,
+        ScanOptions::default(),
+    )?;
+
+    let batches = context
+        .sql("SELECT * FROM orders LIMIT 100")
+        .await?
+        .collect()
+        .await?;
+    println!("batches={}", batches.len());
+    Ok(())
+}
+```
+
+Registration does not build another cache. Every SQL query through the
+registered provider shares the loaded table and its retained Delta scan
+metadata without another Delta log/checkpoint replay. Parquet footer and
+Parquet data I/O remain query-specific and follow each query's projection and
+predicate.
+
+Choose eager loading for named, high-use tables and keep one-shot or rarely
+queried tables on the default `load_table` path. The crate does not maintain a
+table-name registry or choose a mode automatically. To refresh a registered
+table, load a new immutable snapshot and replace the registration with the new
+table.
 
 Once the query works, you can read about [how the reader works](https://mag1cfrog.github.io/delta-arrow-reader/architecture/)
 or use the [Rust API reference](https://docs.rs/delta-arrow-reader) to explore

--- a/docs/content/scan-planning.md
+++ b/docs/content/scan-planning.md
@@ -7,6 +7,25 @@ before it opens any Parquet data files.
 If you only need to run a query, the defaults are a good place to start. This
 page is for readers who want to understand or tune how the work is divided.
 
+## Choose a metadata initialization mode
+
+`DeltaTableBuilder::load_table` uses lazy Delta scan metadata initialization.
+Each scan build performs Delta log/checkpoint replay before Delta Kernel applies
+the query predicate and selects active files.
+
+`DeltaTableBuilder::load_table_with_eager_scan_metadata` instead materializes a
+query-unfiltered set of reconciled active `add` metadata during table
+initialization. It retains all available file statistics, so later scan builds
+can still make query-specific data-skipping decisions. Those builds pass the
+retained metadata to Delta Kernel through `Scan::scan_metadata_from`; Delta
+Kernel remains responsible for applying the query predicate and selecting
+files.
+
+Both modes produce the same file tasks. Partition values, schema transforms,
+and deletion-vector information follow the selected files in either mode.
+Parquet footer pruning happens later and is not part of this initialization
+choice.
+
 ## Choose a partition target
 
 The partition target is the number of independent groups the reader tries to
@@ -34,10 +53,12 @@ storage, or stress probes while planning a scan.
 
 ## Select the files
 
-Delta Kernel walks the snapshot metadata, removes files that are no longer
-active, and applies partition and data-statistics pruning. Each selected file
-becomes a scan task with its path, size and row estimates when available,
-partition values, schema transforms, and deletion-vector information.
+Delta Kernel consumes the table's Delta scan metadata. Lazy Delta
+log/checkpoint replay reconciles the active `add` metadata for that scan; eager
+mode starts from the retained reconciled result. Delta Kernel then applies
+partition and data-statistics pruning. Each selected file becomes a scan task
+with its path, size and row estimates when available, partition values, schema
+transforms, and deletion-vector information.
 
 Choosing the partition target before this step keeps host policy separate from
 table shape. Parquet file size is not a reliable estimate of decoded Arrow

--- a/docs/content/streaming-reader.md
+++ b/docs/content/streaming-reader.md
@@ -36,8 +36,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Loading the table and reading its rows happen at different times. `load_table`
-loads the Delta metadata, and `build` works out which files and columns the scan
-needs. The data files are not read until the returned batch stream is polled.
+loads an immutable Delta snapshot and its Arrow schema. Each `build` then
+evaluates the Delta scan metadata to select the active files and columns it
+needs. Parquet files are not read until the returned batch stream is polled.
+
+## Reuse scan metadata across queries
+
+The default `load_table` path is a good fit for a table that you will query once
+or only occasionally. If one process will plan several queries against the same
+loaded table, opt into eager Delta scan metadata initialization:
+
+```no_run
+use delta_arrow_reader::DeltaTableBuilder;
+use futures_util::TryStreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let table = DeltaTableBuilder::new("/tmp/example-delta-table")
+        .load_table_with_eager_scan_metadata()
+        .await?;
+
+    let scan = table
+        .scan()
+        .with_projection(["id", "name"])
+        .with_limit(100)
+        .build()
+        .await?;
+    let mut batches = scan.into_stream();
+
+    while let Some(batch) = batches.try_next().await? {
+        println!("rows={}", batch.num_rows());
+    }
+
+    Ok(())
+}
+```
+
+The eager method resolves only after the active-file metadata and available
+file statistics have been materialized. Later scan builds reuse that retained
+metadata without another Delta log/checkpoint replay. This can help repeated
+selective queries where metadata planning is a large part of latency. The
+metadata remains in memory for the lifetime of the loaded table.
+
+Eager initialization does not read Parquet footers or Parquet data. A scan
+build still applies its own projection and predicate, and polling the returned
+stream performs the query's Parquet I/O. The loaded table stays pinned to one
+immutable snapshot; load the table again to see a newer version.
 
 ## Filter rows
 


### PR DESCRIPTION
## Summary

- document lazy and eager scan-metadata initialization for streaming and DataFusion users
- explain which remote I/O phase moves, what metadata is retained, and the snapshot lifetime
- add reproducible paired benchmark commands and timing interpretation

## Validation

- python -m zensical build --strict -f docs/mkdocs.yml
- cargo test --locked --doc --all-features
- git diff --check origin/main...HEAD

Closes #33