### PR TITLE
docs: quantify eager metadata caching performance and memory tradeoffs

### DIFF
--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -239,6 +239,12 @@ struct QueryMeasurement {
 struct RepetitionMeasurement {
     table_initialization_micros: u64,
     session_total_micros: u64,
+    #[cfg(test)]
+    #[allow(dead_code)]
+    table_load_count: usize,
+    #[cfg(test)]
+    #[allow(dead_code)]
+    table_registration_count: usize,
     query_measurements: Vec<QueryMeasurement>,
 }
 
@@ -1388,9 +1394,13 @@ async fn run_repetition(
         ScanMetadataMode::Lazy => builder.load_table().await?,
         ScanMetadataMode::Eager => builder.load_table_with_eager_scan_metadata().await?,
     };
+    #[cfg(test)]
+    let table_load_count = 1;
     let table_initialization_micros =
         saturating_u64(table_initialization_started.elapsed().as_micros());
     register_table(&context, "orders", table, scan_options)?;
+    #[cfg(test)]
+    let table_registration_count = 1;
 
     let mut query_measurements = Vec::with_capacity(config.queries_per_table);
     for _ in 0..config.queries_per_table {
@@ -1400,6 +1410,10 @@ async fn run_repetition(
     Ok(RepetitionMeasurement {
         table_initialization_micros,
         session_total_micros,
+        #[cfg(test)]
+        table_load_count,
+        #[cfg(test)]
+        table_registration_count,
         query_measurements,
     })
 }
@@ -2286,15 +2300,25 @@ mod tests {
                 assert_eq!(summary.repetitions, 1);
                 assert_eq!(summary.read.scan_count, 1);
                 assert_eq!(summary.read.files_planned, 4);
+                assert_eq!(repetitions[0].table_load_count, 1);
+                assert_eq!(repetitions[0].table_registration_count, 1);
                 assert_eq!(repetitions[0].query_measurements.len(), 3);
                 assert!(
                     repetitions[0].session_total_micros
                         >= repetitions[0].table_initialization_micros
                 );
                 for measurement in &repetitions[0].query_measurements {
+                    let [metrics] = measurement.metrics.as_slice() else {
+                        return Err("expected one fresh Delta scan per query".into());
+                    };
+                    let reader = &metrics.reader_metrics;
                     assert_eq!(measurement.produced_rows, expected_rows);
                     assert!(measurement.produced_batches > 0);
-                    assert!(!measurement.metrics.is_empty());
+                    assert_eq!(reader.scan_partitions_started, 4);
+                    assert_eq!(reader.scan_partitions_completed, 4);
+                    assert_eq!(reader.file_tasks_started, 4);
+                    assert_eq!(reader.file_tasks_completed, 4);
+                    assert_eq!(reader.scheduler_rows_emitted, expected_rows as u64);
                 }
             }
             Ok::<_, Box<dyn Error>>(())
@@ -2319,11 +2343,15 @@ mod tests {
             RepetitionMeasurement {
                 table_initialization_micros: 10,
                 session_total_micros: 100,
+                table_load_count: 1,
+                table_registration_count: 1,
                 query_measurements: [1, 2, 3].map(query).into(),
             },
             RepetitionMeasurement {
                 table_initialization_micros: 30,
                 session_total_micros: 300,
+                table_load_count: 1,
+                table_registration_count: 1,
                 query_measurements: [4, 5, 100].map(query).into(),
             },
         ];

--- a/docs/content/benchmarks.md
+++ b/docs/content/benchmarks.md
@@ -230,3 +230,41 @@ query selectivity, available statistics, memory pressure, hardware load, and
 the number of queries that reuse the loaded table. The local fixture above is a
 reproducible comparison of the two lifecycles; measure representative tables on
 their real storage before choosing a production default.
+
+### Representative real-S3 result
+
+On August 27, 2026, we also compared the modes against the latest snapshots of
+two production-shaped tables in S3. This used the direct Parquet backend through
+DataFusion, the unreleased eager-metadata implementation at commit `a6adb83`,
+16 target partitions, an 8,192-row batch size, and the machine described in
+[Environment](#environment). One warmup pair was discarded. Four measured
+pairs alternated whether lazy or eager mode ran first; each isolated process
+loaded both tables once, then ran the HIP and schedule queries three times each.
+Table initialization and complete-session values below are medians across the
+four processes for each mode. Planning values are medians across the 12 query
+executions for each table and mode.
+
+| Measurement, median | Lazy | Eager | Difference |
+| --- | ---: | ---: | ---: |
+| Table initialization | 1.196 s | 4.089 s | +2.894 s |
+| Complete six-query session | 50.205 s | 42.451 s | -7.754 s (-15.4%) |
+| HIP physical planning | 2.097 s | 5.1 ms | -99.76% |
+| Schedule physical planning | 756 ms | 1.1 ms | -99.86% |
+
+Both modes returned the same results and performed the same Parquet I/O. Each
+HIP query returned 15,252,906 rows in 2,483 batches and read 505,642,366 bytes
+with 1,044 full-file GETs. Each schedule query returned 58,161 rows in 12
+batches and read 1,217,686 bytes with four range GETs and four full-file GETs.
+
+We measured memory separately because allocator state from a completed query can
+hide the retained-cache cost. Across six counterbalanced initialization-only
+pairs, loading both tables increased median resident memory from 38.5 MiB to
+68.7 MiB, a 30.2 MiB increase. Across four counterbalanced pairs that each ran
+one HIP and one schedule query, median peak resident memory increased from
+233.9 MiB to 248.9 MiB, a 15.0 MiB or 6.4% increase. These Linux measurements
+used `VmRSS` and `VmHWM` from `/proc/self/status`.
+
+This is a dated case study, not a universal performance promise or a pinned
+public fixture. The live table snapshots can advance. Cache memory scales with
+active-file metadata, statistics width, partition values, and deletion-vector
+metadata rather than table row count or total Parquet data size.

--- a/docs/content/scan-planning.md
+++ b/docs/content/scan-planning.md
@@ -26,6 +26,12 @@ and deletion-vector information follow the selected files in either mode.
 Parquet footer pruning happens later and is not part of this initialization
 choice.
 
+In one dated real-S3 case study, eager initialization reduced the median time
+for a six-query session by 15.4% while adding 30.2 MiB of resident memory after
+initialization and 15.0 MiB to full-session peak memory. See the
+[methodology, results, and limitations](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/#representative-real-s3-result)
+before applying those measurements to another table or workload.
+
 ## Choose a partition target
 
 The partition target is the number of independent groups the reader tries to

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -155,6 +155,8 @@ impl DeltaTableBuilder {
     /// Parquet footer and data reads remain query-time operations. Load a new table to observe a
     /// newer snapshot. Unlike [`Self::load_table`], unsupported protocols fail during
     /// initialization because materialization constructs a scan.
+    /// See [the scan-planning guide](crate::guides::concepts::scan_planning) for measured
+    /// tradeoffs.
     pub async fn load_table_with_eager_scan_metadata(self) -> Result<DeltaTable, DeltaReaderError> {
         let snapshot = load_delta_table_snapshot(
             self.table_location,

--- a/src/reader/planning.rs
+++ b/src/reader/planning.rs
@@ -5934,7 +5934,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_plan_applies_nested_kernel_column_mapping_transform()
+    fn eager_metadata_preserves_nested_kernel_column_mapping_transform_without_the_log()
     -> Result<(), Box<dyn std::error::Error>> {
         let adds = [add("mapped.parquet", 10, Some(2))];
         let table = DeltaLogTable::new_with_protocol_metadata_and_adds(
@@ -5948,10 +5948,20 @@ mod tests {
             &DeltaStorageOptions::new(),
             DeltaSnapshotSelection::Latest,
         )?;
+        let lazy_plan = plan_scan(&snapshot, None, &[], None, false, Default::default())?;
+        let snapshot = snapshot.materialize_eager_scan_metadata()?;
+        table.disable_delta_log()?;
         let plan = plan_scan(&snapshot, None, &[], None, false, Default::default())?;
+        let lazy_task = planned_tasks(&lazy_plan)
+            .next()
+            .ok_or("expected one lazy mapped task")?;
         let task = planned_tasks(&plan)
             .next()
-            .ok_or("expected one mapped task")?;
+            .ok_or("expected one eager mapped task")?;
+
+        assert_eq!(planned_tasks(&lazy_plan).count(), 1);
+        assert_eq!(planned_tasks(&plan).count(), 1);
+        assert_file_task_parity(lazy_task, task);
 
         assert_eq!(
             field_names(&plan.physical_schema),


### PR DESCRIPTION
## Summary

- prove lazy and eager file-task parity for nested Delta column mapping after the log becomes unavailable
- prove the repeated-query benchmark loads and registers one table while building a fresh scan for every query in both metadata modes
- publish a dated real-S3 case study covering initialization cost, repeated-query latency, planning time, retained memory, and peak memory
- link the stable API reference to the shared scan-planning guidance used by both the documentation site and docs.rs

This is follow-up hardening and performance documentation for #29.

## Verification

- `cargo test --locked`
- `cargo test --locked --features datafusion`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `cargo package --locked`
- `python -m zensical build --strict -f docs/mkdocs.yml`
- `cargo fmt --all -- --check`
- `git diff --check`
