### PR TITLE
perf: reduce memory retained by eager Delta metadata caching

### DIFF
--- a/src/delta/kernel.rs
+++ b/src/delta/kernel.rs
@@ -191,7 +191,11 @@ impl KernelScan {
         for metadata in self.scan.scan_metadata(engine_context.engine.as_ref())? {
             let metadata = metadata?;
             let data = metadata.scan_files.apply_selection_vector()?;
-            let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data)?.into();
+            let mut batch: RecordBatch = ArrowEngineData::try_from_engine_data(data)?.into();
+            // Cached replay consumes JSON stats and reconstructs typed stats per predicate.
+            if let Ok(index) = batch.schema().index_of("stats_parsed") {
+                batch.remove_column(index);
+            }
             if batch.num_rows() > 0 {
                 batches.push(batch);
             }

--- a/src/delta/kernel.rs
+++ b/src/delta/kernel.rs
@@ -192,7 +192,8 @@ impl KernelScan {
             let metadata = metadata?;
             let data = metadata.scan_files.apply_selection_vector()?;
             let mut batch: RecordBatch = ArrowEngineData::try_from_engine_data(data)?.into();
-            // Cached replay consumes JSON stats and reconstructs typed stats per predicate.
+            // Cached replay rebuilds typed stats from JSON `stats`, so retaining
+            // `stats_parsed` would only duplicate the same statistics in memory.
             if let Ok(index) = batch.schema().index_of("stats_parsed") {
                 batch.remove_column(index);
             }

--- a/src/reader/planning.rs
+++ b/src/reader/planning.rs
@@ -4967,6 +4967,12 @@ mod tests {
             Default::default(),
         )?;
         let snapshot = snapshot.materialize_eager_scan_metadata()?;
+        assert!(snapshot.eager_scan_metadata().is_some_and(|batches| {
+            batches.iter().all(|batch| {
+                batch.schema().index_of("stats").is_ok()
+                    && batch.schema().index_of("stats_parsed").is_err()
+            })
+        }));
         table.disable_delta_log()?;
         let plan = super::plan_unpartitioned_scan(
             &snapshot,

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -38,6 +38,19 @@ struct TestTable(PathBuf);
 
 impl TestTable {
     fn two_versions(name: &str) -> TestResult<Self> {
+        Self::two_versions_with_metadata(name, metadata())
+    }
+
+    fn two_versions_with_parsed_stats_only_checkpoint(name: &str) -> TestResult<Self> {
+        let mut table_metadata = metadata();
+        table_metadata["metaData"]["configuration"] = json!({
+            "delta.checkpoint.writeStatsAsJson": "false",
+            "delta.checkpoint.writeStatsAsStruct": "true"
+        });
+        Self::two_versions_with_metadata(name, table_metadata)
+    }
+
+    fn two_versions_with_metadata(name: &str, table_metadata: Value) -> TestResult<Self> {
         let table = Self::empty(name)?;
         let first = table.write_parquet(
             "part-0.parquet",
@@ -53,7 +66,11 @@ impl TestTable {
         )?;
         table.write_log(
             0,
-            &[protocol(1), metadata(), add("part-0.parquet", first, 1, 4)],
+            &[
+                protocol(1),
+                table_metadata,
+                add("part-0.parquet", first, 1, 4),
+            ],
         )?;
         table.write_log(1, &[add("part-1.parquet", second, 5, 8)])?;
         Ok(table)
@@ -418,9 +435,10 @@ fn eager_scan_metadata_supports_concurrent_planning_without_the_delta_log() -> T
 }
 
 #[test]
-fn eager_scan_metadata_loads_from_a_checkpoint_without_json_logs() -> TestResult {
+fn eager_scan_metadata_preserves_pruning_from_a_parsed_stats_only_checkpoint() -> TestResult {
     runtime()?.block_on(async {
-        let fixture = TestTable::two_versions("eager-checkpoint")?;
+        let fixture =
+            TestTable::two_versions_with_parsed_stats_only_checkpoint("eager-checkpoint")?;
         let table_url: url::Url = fixture.normalized_uri()?.parse()?;
         let engine = DefaultEngineBuilder::new(store_from_url(&table_url)?)
             .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(


### PR DESCRIPTION
## Summary

- Remove the redundant top-level `stats_parsed` column after Delta Kernel materializes eager scan metadata.
- Keep the JSON `stats` representation required by cached replay, so each query still reconstructs only the typed statistics needed by its predicate.
- Add regression coverage for lazy/eager file-task parity and for a parsed-stats-only checkpoint with the JSON transaction logs removed.

## Why this is safe

Eager materialization still requests `StatsOptions::all()`. This lets Delta Kernel synthesize JSON stats for checkpoints configured with `writeStatsAsJson=false` before the typed duplicate is discarded. Cached queries continue through `scan_metadata_from`, which consumes the canonical scan-row schema and performs predicate and statistics pruning. No public API or dependency changes.

## Measured impact

On the pinned local MinIO HIP v416 plus schedule v202 fixture:

- Retained Arrow buffers: 4,059,597 -> 2,936,117 bytes (-27.7%, 1,123,480 bytes saved).
- Median post-initialization RSS across 12 counterbalanced process pairs: 52.08 -> 50.72 MiB (-2.6%, 1.36 MiB saved).
- Median initialization: 73.292 -> 72.543 ms.
- Selective-query planning median across 720 queries: 10.583 -> 10.652 ms (+0.069 ms); p95 improved from 11.678 to 11.656 ms.
- Query results and Parquet I/O remained identical.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked`
- `cargo test --locked --features datafusion`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `cargo package --locked`

Related to #44. The parsed-stats-only regression also covers the compatibility concern tracked in #45.