### PR TITLE
docs: explain Delta metadata caching and improve reader guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Arrow batches, with optional SQL through DataFusion.
   <a href="https://crates.io/crates/delta-arrow-reader"><img alt="crates.io" src="https://img.shields.io/crates/v/delta-arrow-reader.svg"></a>
 </p>
 
-For guided examples and design details, see the
-[Delta Arrow Reader documentation](https://mag1cfrog.github.io/delta-arrow-reader/).
+The [Delta Arrow Reader documentation](https://mag1cfrog.github.io/delta-arrow-reader/)
+has guided examples and design details.
 
 ## When to use it
 
-Delta Arrow Reader fits Rust services, command-line tools, and data pipelines
-that read Delta Lake tables. It is especially useful when:
+Delta Arrow Reader is meant for Rust services, command-line tools, and data
+pipelines that read Delta Lake tables. It is a good fit when:
 
 - You need to read a large table without holding all of it in memory.
 - You want to process each batch as soon as it arrives.
@@ -67,7 +67,7 @@ return one live row and seven times as long to scan the full table.**
 Databricks now
 [recommends deletion vectors for most tables and is rolling out automatic enablement for new tables](https://docs.databricks.com/aws/en/admin/workspace-settings/deletion-vectors).
 
-## Install
+## Installation
 
 Add the reader, Tokio, and the futures utilities used by the example:
 
@@ -101,24 +101,24 @@ while let Some(batch) = batches.try_next().await? {
 # }
 ```
 
-When you load a table, the reader selects the latest or requested version and
-reads its schema. By default, it evaluates Delta scan metadata (the information
-used to choose files) each time it builds a scan. For repeated queries against
-the same loaded table,
+Loading a table selects the latest or requested version and reads its schema.
+By default, the reader evaluates Delta scan metadata, which it uses to choose
+files, each time it builds a scan. For repeated queries against the same loaded
+table,
 [eager scan-metadata initialization](https://mag1cfrog.github.io/delta-arrow-reader/streaming-reader/#reuse-scan-metadata-across-queries)
-caches this information in memory when the table loads so later scans can reuse
-it. The cache works with both the streaming API and DataFusion. Parquet data is
-still read separately when each scan executes.
+caches that metadata in memory when the table loads. Later scans can reuse the
+cache through either the streaming API or DataFusion. Each scan still reads
+its Parquet data separately when it runs.
 
-Once this works, the
+The
 [streaming reader quickstart](https://mag1cfrog.github.io/delta-arrow-reader/streaming-reader/)
 shows how to select columns, filter rows, limit results, and inspect metrics.
 
 ## Query with DataFusion
 
 Enable the `datafusion` feature to query a Delta table through a DataFusion
-`SessionContext`. Registration only makes an already loaded table available by
-name in DataFusion; it does not change when its scan metadata is evaluated.
+`SessionContext`. Registration gives an already loaded table a name in
+DataFusion. It does not change when the reader evaluates scan metadata, and
 Parquet data is read only when DataFusion executes a query.
 
 The [DataFusion quickstart](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -83,6 +83,9 @@ from Delta Funnel.
 
 ## Go deeper
 
+- [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/) follows one loaded table through
+  several queries and explains when keeping its file metadata in memory can
+  save planning time.
 - [Scan planning](https://mag1cfrog.github.io/delta-arrow-reader/scan-planning/) explains how the reader chooses a partition
   target, groups files, and optionally splits large files.
 - [Read scheduling](https://mag1cfrog.github.io/delta-arrow-reader/read-scheduling/) explains concurrency, prefetching,

--- a/docs/content/datafusion.md
+++ b/docs/content/datafusion.md
@@ -1,8 +1,8 @@
-# Query a Table with DataFusion
+# Query a table with DataFusion
 
-Use this path when your application already uses DataFusion or you want to
-query a Delta table with SQL. This quickstart registers one table and reads a
-small result from it.
+Use DataFusion when your application already depends on it or when you want to
+query a Delta table with SQL. This quickstart loads one table, registers it by
+name, and runs a query that returns a small result.
 
 ## Before you start
 
@@ -42,15 +42,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The first step loads an immutable Delta snapshot and its Arrow schema.
-Registering the table gives it a name in DataFusion, but does not open its
-Parquet files. DataFusion plans and reads those files when `collect` runs the
-query. The `LIMIT` keeps this first result small.
+`load_table` selects one Delta table version and reads its Arrow schema.
+`register_table` makes that loaded table available in DataFusion as `orders`.
+Registration does not open any Parquet files. DataFusion plans the read and
+opens those files when `collect` runs the query. The `LIMIT` keeps this first
+result small.
 
 ## Reuse scan metadata across SQL queries
 
-Opt into eager Delta scan metadata initialization before registering a table
-that will serve several SQL queries:
+If the registered table will serve several SQL queries, cache its reusable scan
+metadata before registration:
 
 ```no_run
 use datafusion::prelude::SessionContext;
@@ -83,21 +84,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Registration does not build another cache. Every SQL query through the
-registered provider shares the loaded table and its retained Delta scan
-metadata without another Delta log/checkpoint replay. Parquet footer and
-Parquet data I/O remain query-specific and follow each query's projection and
-predicate.
+`load_table_with_eager_scan_metadata` builds the cache while loading the table.
+`register_table` uses that same loaded table and does not build another cache.
+All SQL queries through the registered provider can therefore reuse the cached
+metadata without replaying the Delta log or checkpoint. Each query still
+applies its own projection and predicate and reads its own Parquet footers and
+data.
 
-Choose eager loading for named, high-use tables and keep one-shot or rarely
-queried tables on the default `load_table` path. The crate does not maintain a
-table-name registry or choose a mode automatically. To refresh a registered
-table, load a new immutable snapshot and replace the registration with the new
-table.
+Use eager loading for a named table that will be queried repeatedly. Keep a
+table on the default `load_table` path when you will query it only once or
+occasionally. The crate does not maintain a table-name registry or choose a
+mode automatically.
 
-For a closer look at how one loaded table reuses this cache across queries, see
-the [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
+A registered table stays on the Delta version that was loaded. To read a newer
+version, load the table again and replace the existing registration.
 
-Once the query works, you can read about [how the reader works](https://mag1cfrog.github.io/delta-arrow-reader/architecture/)
-or use the [Rust API reference](https://docs.rs/delta-arrow-reader) to explore
-scan options and metrics.
+The [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/)
+follows this cache across several queries. For the rest of the read path, see
+[how the reader works](https://mag1cfrog.github.io/delta-arrow-reader/architecture/).
+The [Rust API reference](https://docs.rs/delta-arrow-reader) documents the
+available scan options and metrics.

--- a/docs/content/datafusion.md
+++ b/docs/content/datafusion.md
@@ -95,6 +95,9 @@ table-name registry or choose a mode automatically. To refresh a registered
 table, load a new immutable snapshot and replace the registration with the new
 table.
 
+For a closer look at how one loaded table reuses this cache across queries, see
+the [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
+
 Once the query works, you can read about [how the reader works](https://mag1cfrog.github.io/delta-arrow-reader/architecture/)
 or use the [Rust API reference](https://docs.rs/delta-arrow-reader) to explore
 scan options and metrics.

--- a/docs/content/delta-metadata-lifecycle.md
+++ b/docs/content/delta-metadata-lifecycle.md
@@ -1,0 +1,153 @@
+# Delta metadata lifecycle
+
+Every Delta query needs to know which Parquet files belong to the loaded table
+version. It can then narrow that list using the query predicate, partition
+values, and file statistics. The Delta log or checkpoint supplies the file
+list. The list and the information used to prune it are the table's scan
+metadata.
+
+Delta Arrow Reader can prepare this metadata at two different times. The
+default lazy mode prepares it when each scan is built. Eager mode prepares the
+reusable part when the table loads and keeps it in memory for later scans.
+
+Only the timing changes. Each query still gets its own pruning pass, and
+Parquet footers and data are still read on demand. Eager mode does not create
+an index, reuse one query's file selection for another query, or change query
+results.
+
+## What happens before rows are read
+
+A query against remote storage can involve three rounds of I/O:
+
+1. The reader uses the Delta log or checkpoint to find the active files. Delta
+   Kernel applies the query predicate to their partition values and file
+   statistics, removing files that cannot match.
+2. The reader fetches the remaining Parquet footers. Row-group statistics may
+   narrow the read again.
+3. The reader fetches the selected Parquet row groups and produces Arrow
+   batches.
+
+The first round mixes work that can be reused with work that belongs to one
+query. Replaying the Delta history and reconciling the active files can be
+reused for a loaded table version. Applying a predicate cannot. Eager mode
+moves only the reusable work to table initialization.
+
+This difference matters most for a selective query. Statistics may reduce a
+large table to a few Parquet row groups, making the data read small, while
+Delta replay remains a fixed planning cost. On remote storage, that planning
+cost can take longer than reading the result. Reusing active-file metadata
+removes the repeated replay without changing the later pruning or Parquet I/O.
+
+## Lazy mode
+
+`DeltaTableBuilder::load_table()` uses lazy mode:
+
+```text
+table load -> table version and schema
+query 1 -> Delta replay -> query pruning -> Parquet footer/data
+query 2 -> Delta replay -> query pruning -> Parquet footer/data
+query 3 -> Delta replay -> query pruning -> Parquet footer/data
+```
+
+Loading the table selects a version and reads its schema. The reader waits
+until a scan is built to assemble the active-file metadata and ask Delta
+Kernel to prune it for that scan.
+
+This keeps table loading quick and avoids retaining an active-file cache. The
+tradeoff is that every scan against the loaded table repeats the Delta replay.
+Lazy mode usually fits tables that are queried once, queried occasionally, or
+loaded in a process with tight memory limits.
+
+## Eager mode
+
+`DeltaTableBuilder::load_table_with_eager_scan_metadata()` prepares the same
+reusable metadata while loading the table:
+
+```text
+table initialization -> Delta replay -> metadata cache
+                                           |
+query 1 -----------------------------------+-> pruning -> Parquet footer/data
+query 2 -----------------------------------+-> pruning -> Parquet footer/data
+query 3 -----------------------------------+-> pruning -> Parquet footer/data
+```
+
+The method returns after the cache is ready, so table initialization takes
+longer. The cache contains the reconciled Delta `add` metadata for the current
+active files, including available file statistics. It does not contain the raw
+commit history.
+
+When a scan is built, the reader gives this metadata back to Delta Kernel
+through `Scan::scan_metadata_from`. Delta Kernel applies that scan's predicate
+and statistics pruning. Different queries can therefore select different
+files while sharing the result of Delta replay.
+
+The cache belongs to one loaded table. If the same location is loaded twice,
+the two table objects have separate caches. Both also stay fixed at the exact
+table version they loaded.
+
+## Which mode should you use?
+
+This choice applies to the loaded table, whether you query it through the
+streaming API or DataFusion SQL. Both APIs support lazy and eager loading.
+
+| Consideration | Lazy | Eager |
+| --- | --- | --- |
+| Typical use | One query, occasional queries, or tight memory limits | Repeated queries against a named, high-use table in a long-lived session |
+| Table loading | Returns without building the active-file cache | Waits for Delta replay and cache creation |
+| Memory while loaded | No reusable active-file cache | Keeps active-file metadata and statistics in memory |
+| Each later scan | Replays Delta metadata, then prunes for the query | Reuses the cache, then prunes for the query |
+| Seeing a newer version | Load a new table | Load a new table |
+| Parquet footer and data reads | Per query | Per query; unchanged by the cache |
+
+Use lazy mode unless you know the table will serve repeated queries and the
+saved planning time justifies slower initialization and higher memory use. No
+single query count is a reliable break-even point. The result depends on the
+table history, checkpoint shape, file count, available statistics, storage
+latency, query selectivity, and memory pressure.
+
+## Results from a real S3 workload
+
+On August 27, 2026, a real-S3 benchmark loaded two production-shaped tables
+and ran six queries:
+
+| Measurement | Lazy | Eager |
+| --- | ---: | ---: |
+| Table initialization | 1.196 s | 4.089 s |
+| HIP physical planning | 2.097 s | 5.1 ms |
+| Schedule physical planning | 756 ms | 1.1 ms |
+| Complete six-query session | 50.205 s | 42.451 s |
+| Resident memory after initialization | 38.5 MiB | 68.7 MiB |
+| Full-session peak resident memory | 233.9 MiB | 248.9 MiB |
+
+The eager run spent more time and memory during initialization. After that,
+physical planning fell from seconds to milliseconds, and the six-query
+session finished sooner. Both runs returned the same results and performed the
+same Parquet I/O.
+
+These numbers come from one workload. They are not a performance guarantee or
+a general break-even point. The [benchmark methodology, environment, and limitations](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/#representative-real-s3-result)
+describe how the measurements were collected and what can affect them.
+
+## Version and refresh behavior
+
+The cache lasts as long as its loaded table and represents one exact Delta
+version. Commits written later do not change what existing queries see. To use
+a newer version, load the table again and replace the old table or DataFusion
+registration.
+
+Eager loading does not provide:
+
+- incremental refresh;
+- background polling;
+- TTL or eviction;
+- persistence across processes;
+- sharing between independently loaded tables; or
+- Parquet footer, row-group, or data caching.
+
+## Related guides
+
+- [Read a table with the streaming API](https://mag1cfrog.github.io/delta-arrow-reader/streaming-reader/)
+- [Register and query a table with DataFusion](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
+- [Understand how scans are planned](https://mag1cfrog.github.io/delta-arrow-reader/scan-planning/)
+- [Review the benchmark methodology](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/#compare-lazy-and-eager-scan-metadata)
+- [Open the eager-loading Rust API](https://docs.rs/delta-arrow-reader/latest/delta_arrow_reader/struct.DeltaTableBuilder.html#method.load_table_with_eager_scan_metadata)

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -1,12 +1,12 @@
 # Installation
 
 Delta Arrow Reader requires Rust 1.94 or newer. The dependencies you need
-depend on whether you want an Arrow stream or a DataFusion table.
+depend on whether you plan to use the streaming API or DataFusion.
 
 ## Streaming reader
 
-For streaming Arrow batches, add the reader, Tokio, and the futures utilities used
-by the quickstart:
+For streaming Arrow batches, add the reader, Tokio, and the futures utilities
+used by the quickstart:
 
 ```toml
 [dependencies]
@@ -15,7 +15,8 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
-You can now continue to the [streaming reader quickstart](https://mag1cfrog.github.io/delta-arrow-reader/streaming-reader/).
+The [streaming reader quickstart](https://mag1cfrog.github.io/delta-arrow-reader/streaming-reader/)
+shows how to load a table and consume its Arrow batches.
 
 ## DataFusion adapter
 
@@ -29,12 +30,13 @@ delta-arrow-reader = { version = "0.3.0", features = ["datafusion"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
-You can now continue to the [DataFusion quickstart](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/).
+The [DataFusion quickstart](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
+shows how to register a table and query it with SQL.
 
 ## Optional feature
 
 The streaming API and both Parquet backends are always available. The
-only optional feature adds the DataFusion integration.
+DataFusion integration is the only optional feature.
 
 | Feature | Default | Purpose |
 | --- | --- | --- |

--- a/docs/content/scan-planning.md
+++ b/docs/content/scan-planning.md
@@ -32,6 +32,9 @@ initialization and 15.0 MiB to full-session peak memory. See the
 [methodology, results, and limitations](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/#representative-real-s3-result)
 before applying those measurements to another table or workload.
 
+To see how this initialization choice plays out across several queries, follow
+the [lazy and eager metadata lifecycles](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
+
 ## Choose a partition target
 
 The partition target is the number of independent groups the reader tries to

--- a/docs/content/streaming-reader.md
+++ b/docs/content/streaming-reader.md
@@ -1,4 +1,4 @@
-# Read a Table as a Stream
+# Read a table as a stream
 
 In this quickstart, you will load a Delta table and read up to 100 rows from two
 columns. The rows arrive as Arrow record batches.
@@ -35,16 +35,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Loading the table and reading its rows happen at different times. `load_table`
-loads an immutable Delta snapshot and its Arrow schema. Each `build` then
-evaluates the Delta scan metadata to select the active files and columns it
-needs. Parquet files are not read until the returned batch stream is polled.
+Loading the table and reading its rows are separate steps. `load_table` selects
+one Delta table version and reads its Arrow schema. The loaded table stays on
+that version. Each `build` evaluates the Delta scan metadata to choose the
+active files and requested columns. The reader opens the Parquet files only
+after you poll the returned batch stream.
 
 ## Reuse scan metadata across queries
 
-The default `load_table` path is a good fit for a table that you will query once
-or only occasionally. If one process will plan several queries against the same
-loaded table, opt into eager Delta scan metadata initialization:
+The default `load_table` path works well when you query a table once or only
+occasionally. If one process will run several queries against the same loaded
+table, you can cache its reusable scan metadata during table loading:
 
 ```no_run
 use delta_arrow_reader::DeltaTableBuilder;
@@ -72,23 +73,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The eager method resolves only after the active-file metadata and available
-file statistics have been materialized. Later scan builds reuse that retained
-metadata without another Delta log/checkpoint replay. This can help repeated
-selective queries where metadata planning is a large part of latency. The
-metadata remains in memory for the lifetime of the loaded table.
+`load_table_with_eager_scan_metadata` returns after it has built the cache. The
+cache holds active-file metadata and available file statistics in memory.
+Later scan builds reuse it instead of replaying the Delta log or checkpoint.
+This reduces repeated planning work when metadata accounts for much of a
+selective query's latency. The cache remains in memory as long as the loaded
+table does.
 
-Eager initialization does not read Parquet footers or Parquet data. A scan
-build still applies its own projection and predicate, and polling the returned
-stream performs the query's Parquet I/O. The loaded table stays pinned to one
-immutable snapshot; load the table again to see a newer version.
+The cache does not contain Parquet footers or Parquet data. Each scan still
+applies its own projection and predicate, then performs its Parquet I/O when
+you poll the returned stream. Load the table again when you want to read a
+newer Delta version.
 
-To understand what the eager method caches, and why it helps only some
-workloads, read about the [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
+The [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/)
+explains what the eager method caches and when the tradeoff is worthwhile.
 
 ## Filter rows
 
-Once the basic scan works, you can add a predicate before building it:
+Add a predicate before building the scan to filter its rows:
 
 ```ignore
 use delta_arrow_reader::{DeltaComparison, DeltaPredicate, DeltaScalar};
@@ -104,14 +106,15 @@ let scan = table
     .await?;
 ```
 
-A predicate does two jobs. It helps the reader skip files that cannot contain
-matching rows, and it filters the rows that are read. The final result stays
-correct even when the table statistics cannot skip a file.
+A predicate can help the reader skip files that cannot contain matching rows.
+It also filters the rows read from the remaining files. If the table statistics
+cannot rule out a file, the reader reads and filters it so the result remains
+correct.
 
 ## Inspect scan metrics
 
-If you want to see what the scan did, save its metrics handle before consuming
-the stream:
+Save the metrics handle before consuming the stream to inspect what the scan
+did:
 
 ```ignore
 let mut batches = scan.into_stream();

--- a/docs/content/streaming-reader.md
+++ b/docs/content/streaming-reader.md
@@ -83,6 +83,9 @@ build still applies its own projection and predicate, and polling the returned
 stream performs the query's Parquet I/O. The loaded table stays pinned to one
 immutable snapshot; load the table again to see a newer version.
 
+To understand what the eager method caches, and why it helps only some
+workloads, read about the [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
+
 ## Filter rows
 
 Once the basic scan works, you can add a predicate before building it:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - DataFusion quickstart: datafusion.md
   - How it works:
       - Architecture: architecture.md
+      - Delta metadata lifecycle: delta-metadata-lifecycle.md
       - Scan planning: scan-planning.md
       - Read scheduling: read-scheduling.md
   - Performance:

--- a/src/guides.rs
+++ b/src/guides.rs
@@ -21,6 +21,9 @@ pub mod concepts {
     #[doc = include_str!("../docs/content/architecture.md")]
     pub mod architecture {}
 
+    #[doc = include_str!("../docs/content/delta-metadata-lifecycle.md")]
+    pub mod delta_metadata_lifecycle {}
+
     #[doc = include_str!("../docs/content/scan-planning.md")]
     pub mod scan_planning {}
 


### PR DESCRIPTION
## Summary

- add a dedicated explanation of lazy and eager Delta metadata lifecycles
- show which remote I/O moves to table initialization and which work remains query-specific
- document mode selection, snapshot refresh behavior, memory costs, and the real-S3 measurements
- publish the page in the documentation site and docs.rs, with links from related guides
- make the README, streaming quickstart, DataFusion quickstart, and installation guidance read more naturally

## Validation

- `python -m zensical build --strict -f docs/mkdocs.yml`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `cargo test --locked --all-features --doc`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #42