### PR TITLE
fix: align cache warm test command

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Warm default test cache
         run: cargo test --locked --no-run
       - name: Warm all-features test cache
-        run: cargo test --locked --all-targets --all-features --no-run
+        run: cargo test --locked --all-features --no-run
       - name: Check sccache writes
         id: sccache-writes
         continue-on-error: true
@@ -87,7 +87,7 @@ jobs:
           sccache --zero-stats
           cargo clean
           cargo test --locked --no-run
-          cargo test --locked --all-targets --all-features --no-run
+          cargo test --locked --all-features --no-run
       - name: Verify retried sccache writes
         if: steps.sccache-writes.outcome == 'failure'
         shell: bash


### PR DESCRIPTION
## Summary

- align the all-features cache warm command with the CI consumer
- apply the same command in the cache-write retry path

## Verification

- parsed `.github/workflows/cache-warm.yml` as YAML
- ran `git diff --check`
- confirmed both warm paths use `cargo test --locked --all-features --no-run`