### PR TITLE
fix: cancel stale cache warm runs

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: sccache-write
-  queue: max
+  cancel-in-progress: true
 
 jobs:
   core:


### PR DESCRIPTION
## Summary

- cancel an in-progress cache warmer when a newer main commit arrives
- remove the stale FIFO cache-warm queue

## Verification

- parsed `.github/workflows/cache-warm.yml` as YAML
- ran `git diff --check`
- confirmed `queue` is absent and `cancel-in-progress` is enabled