### PR TITLE
fix: warm all-features cache first

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Warm default test cache
-        run: cargo test --locked --no-run
       - name: Warm all-features test cache
         run: cargo test --locked --all-features --no-run
+      - name: Warm default test cache
+        run: cargo test --locked --no-run
       - name: Check sccache writes
         id: sccache-writes
         continue-on-error: true
@@ -86,8 +86,8 @@ jobs:
         run: |
           sccache --zero-stats
           cargo clean
-          cargo test --locked --no-run
           cargo test --locked --all-features --no-run
+          cargo test --locked --no-run
       - name: Verify retried sccache writes
         if: steps.sccache-writes.outcome == 'failure'
         shell: bash


### PR DESCRIPTION
## Summary

- warm the cold all-features test graph before the default graph
- keep retry ordering identical to the primary warm path

## Why

PR #58 reused none of the 42 Windows sccache objects written by the preceding warmer, despite using the same runner image, Rust toolchain, and all-features Cargo command. The remaining difference was that the warmer built the default graph first while the PR built all-features from a cold target directory.

## Validation

- YAML parses successfully
- `git diff --check` passes
- after merge, validate the next Windows cache warm and a fresh PR check