### PR TITLE
fix: cache Windows build targets

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: core-ci
-          cache-targets: false
+          shared-key: ${{ matrix.os == 'windows-2022' && 'core-ci-targets' || 'core-ci' }}
+          cache-targets: ${{ matrix.os == 'windows-2022' }}
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10
       - name: Verify Rust host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: core-ci
-          cache-targets: false
+          shared-key: ${{ matrix.os == 'windows-2022' && 'core-ci-targets' || 'core-ci' }}
+          cache-targets: ${{ matrix.os == 'windows-2022' }}
           save-if: false
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10


### PR DESCRIPTION
## Summary

- cache Cargo dependency target artifacts only on Windows
- restore those artifacts in the Windows PR platform check
- use a new cache namespace so existing registry-only entries do not prevent the first target cache save

## Why

Two clean Windows PR runs each had exactly 233 sccache hits and 38 misses, including one immediately after a successful aligned cold all-features warmer. None of the warmer-created Windows objects were reusable across runners. Linux and macOS remained at 100% hits.

The existing `Swatinem/rust-cache` action already supports dependency target artifacts. Enabling that built-in fallback only for Windows avoids the unstable per-object sccache keys without adding an action or changing test coverage.

## Validation

- both workflow files parse successfully
- `git diff --check` passes
- post-merge warmer and a clean PR rerun will verify the target archive restore and Windows duration