### PR TITLE
fix: treat sccache writes as best effort

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -74,22 +74,7 @@ jobs:
       - name: Warm default test cache
         run: cargo test --locked --no-run
       - name: Check sccache writes
-        id: sccache-writes
         continue-on-error: true
-        shell: bash
-        run: >-
-          sccache --show-stats --stats-format json |
-          python -c 'import json, sys; errors = json.load(sys.stdin)["stats"]["cache_write_errors"]; sys.exit(f"sccache reported {errors} cache write errors") if errors else None'
-      - name: Retry cache writes
-        if: steps.sccache-writes.outcome == 'failure'
-        shell: bash
-        run: |
-          sccache --zero-stats
-          cargo clean
-          cargo test --locked --all-features --no-run
-          cargo test --locked --no-run
-      - name: Verify retried sccache writes
-        if: steps.sccache-writes.outcome == 'failure'
         shell: bash
         run: >-
           sccache --show-stats --stats-format json |


### PR DESCRIPTION
## Summary
- keep sccache write verification visible as a soft failure
- remove the immediate clean rebuild and hard failure when GitHub throttles cache writes
- allow the Windows target cache to publish after successful builds

## Validation
- parsed `.github/workflows/cache-warm.yml` with PyYAML
- `git diff --check`

The sccache GitHub Actions backend documents cache rate limiting as best effort: builds continue even when storage does not.