### PR TITLE
perf: adapt Parquet range reads to observed transport costs

### DIFF
--- a/docs/content/reference/metrics.md
+++ b/docs/content/reference/metrics.md
@@ -26,6 +26,14 @@ usable after its batch stream finishes or is dropped.
 | `deletion_vector_rows_deleted` | Rows removed by those masks. |
 | `deletion_vector_failures` | Deletion-vector read or masking failures. |
 | `deletion_vector_coordinate_rejections` | Deletion-vector coordinate operations rejected by safety checks. |
+| `parquet_data_file_ranges_requested` | Normalized, non-overlapping exact ranges requested through Direct Parquet multi-range calls. |
+| `parquet_data_file_range_bytes_requested` | Bytes covered by those normalized exact ranges. |
+| `parquet_data_file_range_requests_planned` | Physical range requests selected by the automatic planner. Store-delegated calls do not contribute because their physical plan is not visible. |
+| `parquet_data_file_range_bytes_planned` | Bytes covered by the automatically planned physical requests. |
+| `parquet_data_file_cold_start_range_plans` | Automatic plans selected without a usable transport estimate. Safety bounds may still merge a large exact plan. |
+| `parquet_data_file_exact_range_plans` | Automatic plans where a usable estimate favored the normalized minimum-byte ranges. |
+| `parquet_data_file_merged_range_plans` | Automatic plans where a usable estimate favored including gaps to reduce physical requests. |
+| `parquet_data_file_store_delegated_range_calls` | Multi-range calls passed to the store's own implementation. |
 | `parquet_data_file_range_get_operations` | Ranged operations observed by the Direct Parquet wrapper. A forwarded store-provided multi-range call counts once. |
 | `parquet_data_file_full_get_operations` | Direct Parquet data-file GET operations without a range. |
 | `parquet_data_file_bytes_received` | Bytes delivered successfully through the `Direct` backend's object-store boundary. |
@@ -34,9 +42,9 @@ usable after its batch stream finishes or is dropped.
 `add_actions_excluded_during_planning` is not an exact active-file count. Delta
 Kernel's final selection also reconciles Add and Remove actions.
 
-The four Parquet I/O fields are `Some`, including `Some(0)`, for
-`Direct`. They are `None` for `DeltaKernel` because its object-store
-calls happen behind the Kernel reader boundary.
+The Parquet I/O and range-planning fields are `Some`, including `Some(0)`,
+for `Direct`. They are `None` for `DeltaKernel` because its object-store calls
+happen behind the Kernel reader boundary.
 
 ## DataFusion metrics
 
@@ -70,10 +78,22 @@ are not network billing counters.
   to the underlying store, so failed operations still count. A forwarded
   store-provided multi-range call counts once because the wrapper cannot see
   how the store performs that call.
+- Requested range counts and bytes describe the normalized minimum-byte plan.
+  Planned request counts and bytes describe the physical plan selected for
+  built-in remote stores. These counters advance before the physical reads
+  start, so they also include plans whose reads later fail.
+- Exactly one decision counter advances for each non-empty multi-range call.
+  Automatic calls count as cold start, exact, or merged. Calls that use the
+  store's own multi-range implementation count as store-delegated; their
+  internal physical request count and planned bytes are not observable here.
+- For automatic plans with requested bytes, aggregate byte amplification is
+  `parquet_data_file_range_bytes_planned` divided by
+  `parquet_data_file_range_bytes_requested`. Calculate the ratio from the
+  aggregate counters rather than averaging ratios from individual calls.
 - Received bytes count successful response chunks delivered through the
-  wrapper. Fixed-gap remote reads can include footers, column data, coalesced
-  gaps, and repeated reads. A store-provided multi-range call reports the bytes
-  returned to Parquet; any extra work inside the store is not visible.
+  wrapper. Merged reads can include unrequested gaps. A store-provided
+  multi-range call reports the bytes returned to Parquet; any extra work inside
+  the store is not visible.
 - Admitted task bytes add the estimated span of each task. A whole-file task
   contributes its file size, while a ranged task contributes its range length.
 

--- a/docs/content/reference/metrics.md
+++ b/docs/content/reference/metrics.md
@@ -26,14 +26,14 @@ usable after its batch stream finishes or is dropped.
 | `deletion_vector_rows_deleted` | Rows removed by those masks. |
 | `deletion_vector_failures` | Deletion-vector read or masking failures. |
 | `deletion_vector_coordinate_rejections` | Deletion-vector coordinate operations rejected by safety checks. |
-| `parquet_data_file_ranges_requested` | Normalized, non-overlapping exact ranges requested through Direct Parquet multi-range calls. |
-| `parquet_data_file_range_bytes_requested` | Bytes covered by those normalized exact ranges. |
-| `parquet_data_file_range_requests_planned` | Physical range requests selected by the automatic planner. Store-delegated calls do not contribute because their physical plan is not visible. |
-| `parquet_data_file_range_bytes_planned` | Bytes covered by the automatically planned physical requests. |
+| `parquet_data_file_exact_ranges_requested` | Normalized, non-overlapping exact ranges requested through Direct Parquet multi-range calls. |
+| `parquet_data_file_exact_range_bytes_requested` | Bytes covered by those normalized exact ranges. |
+| `parquet_data_file_physical_range_requests_planned` | Physical range requests selected by the automatic planner. Store-delegated calls do not contribute because their physical plan is not visible. |
+| `parquet_data_file_physical_range_bytes_planned` | Bytes covered by the automatically planned physical requests. |
 | `parquet_data_file_cold_start_range_plans` | Automatic plans selected without a usable transport estimate. Safety bounds may still merge a large exact plan. |
-| `parquet_data_file_exact_range_plans` | Automatic plans where a usable estimate favored the normalized minimum-byte ranges. |
-| `parquet_data_file_merged_range_plans` | Automatic plans where a usable estimate favored including gaps to reduce physical requests. |
-| `parquet_data_file_store_delegated_range_calls` | Multi-range calls passed to the store's own implementation. |
+| `parquet_data_file_cost_based_exact_range_plans` | Automatic plans where a usable estimate favored the normalized minimum-byte ranges. |
+| `parquet_data_file_cost_based_merged_range_plans` | Automatic plans where a usable estimate favored including gaps to reduce physical requests. |
+| `parquet_data_file_store_delegated_range_plans` | Range-planning decisions passed to the store's own multi-range implementation. |
 | `parquet_data_file_range_get_operations` | Ranged operations observed by the Direct Parquet wrapper. A forwarded store-provided multi-range call counts once. |
 | `parquet_data_file_full_get_operations` | Direct Parquet data-file GET operations without a range. |
 | `parquet_data_file_bytes_received` | Bytes delivered successfully through the `Direct` backend's object-store boundary. |
@@ -83,12 +83,13 @@ are not network billing counters.
   built-in remote stores. These counters advance before the physical reads
   start, so they also include plans whose reads later fail.
 - Exactly one decision counter advances for each non-empty multi-range call.
-  Automatic calls count as cold start, exact, or merged. Calls that use the
-  store's own multi-range implementation count as store-delegated; their
-  internal physical request count and planned bytes are not observable here.
+  Automatic calls count as cold start, cost-based exact, or cost-based merged.
+  Calls that use the store's own multi-range implementation count as
+  store-delegated; their internal physical request count and planned bytes are
+  not observable here.
 - For automatic plans with requested bytes, aggregate byte amplification is
-  `parquet_data_file_range_bytes_planned` divided by
-  `parquet_data_file_range_bytes_requested`. Calculate the ratio from the
+  `parquet_data_file_physical_range_bytes_planned` divided by
+  `parquet_data_file_exact_range_bytes_requested`. Calculate the ratio from the
   aggregate counters rather than averaging ratios from individual calls.
 - Received bytes count successful response chunks delivered through the
   wrapper. Merged reads can include unrequested gaps. A store-provided

--- a/src/reader/backend/direct_parquet.rs
+++ b/src/reader/backend/direct_parquet.rs
@@ -927,6 +927,7 @@ mod tests {
         fail_range_target: AtomicUsize,
         corrupt_range_target: AtomicUsize,
         range_calls: AtomicUsize,
+        multi_range_calls: AtomicUsize,
         started: tokio::sync::Semaphore,
         release: tokio::sync::Semaphore,
         cancelled: Arc<AtomicBool>,
@@ -945,10 +946,15 @@ mod tests {
                 fail_range_target: AtomicUsize::new(0),
                 corrupt_range_target: AtomicUsize::new(0),
                 range_calls: AtomicUsize::new(0),
+                multi_range_calls: AtomicUsize::new(0),
                 started: tokio::sync::Semaphore::new(0),
                 release: tokio::sync::Semaphore::new(0),
                 cancelled: Arc::new(AtomicBool::new(false)),
             })
+        }
+
+        fn ungated(inner: Arc<dyn ObjectStore>) -> Arc<Self> {
+            Self::new(inner, GateRequest::Range(0))
         }
 
         async fn wait_started(&self) {
@@ -961,6 +967,10 @@ mod tests {
 
         fn was_cancelled(&self) -> bool {
             self.cancelled.load(Ordering::Acquire)
+        }
+
+        fn multi_range_call_count(&self) -> usize {
+            self.multi_range_calls.load(Ordering::Acquire)
         }
 
         fn gate_next_range(&self) {
@@ -1095,6 +1105,20 @@ mod tests {
                 range,
                 attributes,
             })
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &Path,
+            ranges: &[std::ops::Range<u64>],
+        ) -> ObjectStoreResult<Vec<bytes::Bytes>> {
+            self.multi_range_calls.fetch_add(1, Ordering::AcqRel);
+            object_store::coalesce_ranges(
+                ranges,
+                |range| self.get_range(location, range),
+                object_store::OBJECT_STORE_COALESCE_DEFAULT,
+            )
+            .await
         }
 
         fn delete_stream(
@@ -1732,7 +1756,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolves_and_reads_remote_like_memory_object_store_path()
+    async fn automatic_range_planning_reads_parquet_without_inner_multi_range_calls()
     -> Result<(), Box<dyn std::error::Error>> {
         let table_url = url::Url::parse("memory:///table/root/")?;
         let engine_context = Arc::new(DeltaKernelEngineContext::try_new(
@@ -1740,8 +1764,18 @@ mod tests {
             &DeltaStorageOptions::default(),
         )?);
         let store = engine_context.object_store();
-        let reader =
-            DirectParquetReader::new(engine_context, DeltaScanExecutionOptions::new(), metrics());
+        let metrics = metrics();
+        let mut reader = DirectParquetReader::new(
+            engine_context,
+            DeltaScanExecutionOptions::new(),
+            metrics.clone(),
+        );
+        let tracked_store = GatedObjectStore::ungated(Arc::clone(&store));
+        reader.store = Arc::new(MeteredParquetObjectStore::new(
+            Arc::clone(&tracked_store) as Arc<dyn ObjectStore>,
+            metrics.clone(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        ));
         let bytes = parquet_bytes()?;
         let task = task("part-00000.parquet", Some(u64::try_from(bytes.len())?))?;
         let object = reader.resolve_parquet_object(&task)?;
@@ -1765,6 +1799,27 @@ mod tests {
 
         assert_eq!(ids.values(), &[1, 2, 3]);
         assert!(stream.next_batch().await?.is_none());
+        let snapshot = metrics.snapshot();
+        assert!(
+            snapshot
+                .parquet_data_file_exact_ranges_requested
+                .is_some_and(|ranges| ranges > 0)
+        );
+        assert!(
+            snapshot
+                .parquet_data_file_physical_range_requests_planned
+                .is_some_and(|requests| requests > 0)
+        );
+        assert!(
+            snapshot
+                .parquet_data_file_cold_start_range_plans
+                .is_some_and(|plans| plans > 0)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_plans,
+            Some(0)
+        );
+        assert_eq!(tracked_store.multi_range_call_count(), 0);
         Ok(())
     }
 

--- a/src/reader/backend/direct_parquet.rs
+++ b/src/reader/backend/direct_parquet.rs
@@ -1,6 +1,7 @@
 //! Direct asynchronous Parquet data-file reader.
 
 mod metered_object_store;
+mod range_planning;
 mod row_group_pruning;
 mod schema_alignment;
 

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::VecDeque,
-    fmt,
+    fmt, io,
     ops::Range,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -84,12 +84,23 @@ impl MeteredParquetObjectStore {
         location: &Path,
         range: Range<u64>,
     ) -> Result<(Bytes, CompletedRangeRead)> {
+        let expected_bytes = range.end - range.start;
         let request_started = Instant::now();
         let result = self
             .get_opts(location, GetOptions::new().with_range(Some(range)))
             .await?;
         let payload_started = Instant::now();
         let bytes = result.bytes().await?;
+        if u64::try_from(bytes.len()).unwrap_or(u64::MAX) != expected_bytes {
+            return Err(object_store::Error::Generic {
+                store: "delta-arrow-reader",
+                source: io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "object store returned a byte range with an unexpected length",
+                )
+                .into(),
+            });
+        }
         let payload_finished = Instant::now();
         let completed_read = CompletedRangeRead {
             request_latency: payload_started.saturating_duration_since(request_started),
@@ -809,6 +820,37 @@ mod tests {
 
         task.abort();
         assert!(task.await.is_err_and(|error| error.is_cancelled()));
+        assert_eq!(store.current_transport_estimate(), None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn truncated_automatic_plan_does_not_update_transport_estimates()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let truncated = PutPayload::from_static(b"abc")
+            .into_iter()
+            .next()
+            .ok_or_else(missing_chunk)?;
+        let metrics = direct_metrics();
+        let store = MeteredParquetObjectStore::new(
+            Arc::new(ScriptedGetStore::new(test_get_result(
+                GetResultPayload::Stream(stream::iter([Ok(truncated)]).boxed()),
+                0..8,
+            ))),
+            metrics.clone(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        let started = Instant::now();
+        for _ in 0..2 {
+            store.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
+        }
+
+        let error = store
+            .get_ranges(&Path::from("data.parquet"), &[0..4, 4..8])
+            .await
+            .expect_err("truncated range unexpectedly succeeded");
+        assert!(error.to_string().contains("unexpected length"));
+        assert_eq!(metrics.snapshot().parquet_data_file_bytes_received, Some(3));
         assert_eq!(store.current_transport_estimate(), None);
         Ok(())
     }

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -1,25 +1,43 @@
 //! Object-store metering for direct Parquet data-file reads.
 
-use std::{fmt, ops::Range, sync::Arc};
+use std::{
+    collections::VecDeque,
+    fmt,
+    ops::Range,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{StreamExt, stream, stream::BoxStream};
 use object_store::{
     CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, ObjectStoreExt, ObjectStoreScheme, PutMultipartOptions, PutOptions, PutPayload,
-    PutResult, RenameOptions, Result, path::Path,
+    ObjectStore, ObjectStoreScheme, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    RenameOptions, Result, path::Path,
 };
 use tracing::Instrument;
 use url::Url;
 
-use super::range_planning::{choose_range_plan, execute_range_plan};
+use super::range_planning::{TransportEstimate, choose_range_plan, execute_range_plan};
 use crate::DeltaScanMetrics;
+
+const TRANSPORT_SAMPLE_WINDOW: usize = 9;
+const MIN_TRANSPORT_SAMPLES: usize = 3;
 
 pub(crate) struct MeteredParquetObjectStore {
     inner: Arc<dyn ObjectStore>,
     metrics: DeltaScanMetrics,
     multi_range_read_strategy: MultiRangeReadStrategy,
+    transport_samples: Mutex<VecDeque<TransportEstimate>>,
+}
+
+/// Timing and byte count for one fully consumed physical range read.
+struct CompletedRangeRead {
+    request_latency: Duration,
+    payload_started: Instant,
+    payload_finished: Instant,
+    bytes_received: usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -53,8 +71,126 @@ impl MeteredParquetObjectStore {
             inner,
             metrics,
             multi_range_read_strategy,
+            transport_samples: Mutex::new(VecDeque::with_capacity(TRANSPORT_SAMPLE_WINDOW)),
         }
     }
+
+    /// Reads one physical range and measures request latency separately from payload delivery.
+    async fn read_range_with_timing(
+        &self,
+        location: &Path,
+        range: Range<u64>,
+    ) -> Result<(Bytes, CompletedRangeRead)> {
+        let request_started = Instant::now();
+        let result = self
+            .get_opts(location, GetOptions::new().with_range(Some(range)))
+            .await?;
+        let payload_started = Instant::now();
+        let bytes = result.bytes().await?;
+        let payload_finished = Instant::now();
+        let completed_read = CompletedRangeRead {
+            request_latency: payload_started.saturating_duration_since(request_started),
+            payload_started,
+            payload_finished,
+            bytes_received: bytes.len(),
+        };
+        Ok((bytes, completed_read))
+    }
+
+    /// Returns robust latency and shared-throughput estimates after enough plans have completed.
+    fn current_transport_estimate(&self) -> Option<TransportEstimate> {
+        let samples = self
+            .transport_samples
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if samples.len() < MIN_TRANSPORT_SAMPLES {
+            return None;
+        }
+
+        let mut latencies = samples
+            .iter()
+            .map(|sample| sample.request_latency)
+            .collect::<Vec<_>>();
+        let mut throughputs = samples
+            .iter()
+            .map(|sample| sample.shared_throughput_bytes_per_second)
+            .collect::<Vec<_>>();
+        latencies.sort_unstable();
+        throughputs.sort_unstable();
+        let middle = samples.len() / 2;
+        Some(TransportEstimate {
+            request_latency: latencies[middle],
+            shared_throughput_bytes_per_second: throughputs[middle],
+        })
+    }
+
+    /// Adds one sample after every physical range in a chosen plan finishes successfully.
+    ///
+    /// Overlapping payload intervals count once when calculating delivery time. This produces
+    /// one aggregate throughput sample instead of assigning full bandwidth to each request.
+    fn record_completed_range_reads(&self, completed_reads: &[CompletedRangeRead]) {
+        let Some(sample) = transport_sample(completed_reads) else {
+            return;
+        };
+
+        let mut samples = self
+            .transport_samples
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if samples.len() == TRANSPORT_SAMPLE_WINDOW {
+            samples.pop_front();
+        }
+        samples.push_back(sample);
+    }
+}
+
+/// Summarizes one fully completed physical plan without double-counting concurrent delivery time.
+fn transport_sample(completed_reads: &[CompletedRangeRead]) -> Option<TransportEstimate> {
+    if completed_reads.is_empty() {
+        return None;
+    }
+
+    let mut latencies = completed_reads
+        .iter()
+        .map(|read| read.request_latency)
+        .collect::<Vec<_>>();
+    latencies.sort_unstable();
+    let request_latency = latencies[latencies.len() / 2];
+
+    let mut delivery_intervals = completed_reads
+        .iter()
+        .map(|read| (read.payload_started, read.payload_finished))
+        .collect::<Vec<_>>();
+    delivery_intervals.sort_unstable();
+    let (mut interval_start, mut interval_end) = delivery_intervals[0];
+    let mut delivery_time = Duration::ZERO;
+    for (next_start, next_end) in delivery_intervals.into_iter().skip(1) {
+        if next_start <= interval_end {
+            interval_end = interval_end.max(next_end);
+        } else {
+            delivery_time = delivery_time
+                .saturating_add(interval_end.saturating_duration_since(interval_start));
+            (interval_start, interval_end) = (next_start, next_end);
+        }
+    }
+    delivery_time =
+        delivery_time.saturating_add(interval_end.saturating_duration_since(interval_start));
+
+    let delivery_nanos = delivery_time.as_nanos();
+    let bytes_received = completed_reads.iter().fold(0_u128, |total, read| {
+        total.saturating_add(read.bytes_received as u128)
+    });
+    if delivery_nanos == 0 || bytes_received == 0 {
+        return None;
+    }
+    let throughput = bytes_received
+        .saturating_mul(1_000_000_000)
+        .checked_div(delivery_nanos)
+        .unwrap_or(0);
+    Some(TransportEstimate {
+        request_latency,
+        shared_throughput_bytes_per_second: u64::try_from(throughput).unwrap_or(u64::MAX),
+    })
 }
 
 impl fmt::Debug for MeteredParquetObjectStore {
@@ -135,11 +271,28 @@ impl ObjectStore for MeteredParquetObjectStore {
                 Ok(results)
             }
             MultiRangeReadStrategy::ChooseAutomatically => {
-                let physical_ranges = choose_range_plan(ranges, None);
-                execute_range_plan(ranges, &physical_ranges, |range| {
-                    self.get_range(location, range)
+                let physical_ranges = choose_range_plan(ranges, self.current_transport_estimate());
+                let completed_reads =
+                    Arc::new(Mutex::new(Vec::with_capacity(physical_ranges.len())));
+                let results = execute_range_plan(ranges, &physical_ranges, |range| {
+                    let completed_reads = Arc::clone(&completed_reads);
+                    async move {
+                        let (bytes, completed_read) =
+                            self.read_range_with_timing(location, range).await?;
+                        completed_reads
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push(completed_read);
+                        Ok::<Bytes, object_store::Error>(bytes)
+                    }
                 })
-                .await
+                .await?;
+                self.record_completed_range_reads(
+                    &completed_reads
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner),
+                );
+                Ok(results)
             }
         }
     }
@@ -234,6 +387,7 @@ mod tests {
             Arc, Mutex,
             atomic::{AtomicU64, Ordering},
         },
+        time::{Duration, Instant},
     };
 
     use async_trait::async_trait;
@@ -242,10 +396,15 @@ mod tests {
     use object_store::{
         Attributes, CopyOptions, Error, GetOptions, GetResult, GetResultPayload, ListResult,
         MultipartUpload, ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions,
-        PutPayload, PutResult, RenameOptions, Result, memory::InMemory, path::Path,
+        PutPayload, PutResult, RenameOptions, Result,
+        memory::InMemory,
+        path::Path,
+        throttle::{ThrottleConfig, ThrottledStore},
     };
 
-    use super::{MeteredParquetObjectStore, MultiRangeReadStrategy};
+    use super::{
+        CompletedRangeRead, MeteredParquetObjectStore, MultiRangeReadStrategy, TransportEstimate,
+    };
     use crate::{DeltaScanMetrics, ParquetReaderBackend, reader::metrics::DeltaScanMetricsConfig};
 
     fn direct_metrics() -> DeltaScanMetrics {
@@ -258,6 +417,20 @@ mod tests {
             estimated_input_rows: Some(1),
             estimated_input_bytes: Some(1),
         })
+    }
+
+    /// Creates a one-second payload observation for estimator tests.
+    fn completed_read(
+        payload_started: Instant,
+        latency_millis: u64,
+        bytes_received: usize,
+    ) -> CompletedRangeRead {
+        CompletedRangeRead {
+            request_latency: Duration::from_millis(latency_millis),
+            payload_started,
+            payload_finished: payload_started + Duration::from_secs(1),
+            bytes_received,
+        }
     }
 
     async fn memory_store(metrics: DeltaScanMetrics) -> Result<MeteredParquetObjectStore> {
@@ -391,6 +564,117 @@ mod tests {
         let snapshot = delegated_metrics.snapshot();
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(1));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(8));
+        Ok(())
+    }
+
+    #[test]
+    fn transport_estimate_uses_bounded_medians_after_three_plans() {
+        let store = MeteredParquetObjectStore::new(
+            Arc::new(InMemory::new()),
+            direct_metrics(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        let started = Instant::now();
+
+        for (latency_millis, bytes_received) in [(10, 1_000), (100, 9_000)] {
+            store.record_completed_range_reads(&[completed_read(
+                started,
+                latency_millis,
+                bytes_received,
+            )]);
+        }
+        assert_eq!(store.current_transport_estimate(), None);
+
+        store.record_completed_range_reads(&[completed_read(started, 20, 5_000)]);
+        assert_eq!(
+            store.current_transport_estimate(),
+            Some(TransportEstimate {
+                request_latency: Duration::from_millis(20),
+                shared_throughput_bytes_per_second: 5_000,
+            })
+        );
+
+        for latency_millis in 1..=12 {
+            store.record_completed_range_reads(&[completed_read(started, latency_millis, 1_000)]);
+        }
+        assert_eq!(
+            store
+                .current_transport_estimate()
+                .map(|estimate| estimate.request_latency),
+            Some(Duration::from_millis(8))
+        );
+    }
+
+    #[test]
+    fn concurrent_payloads_produce_one_shared_throughput_sample() {
+        let store = MeteredParquetObjectStore::new(
+            Arc::new(InMemory::new()),
+            direct_metrics(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        let started = Instant::now();
+        for _ in 0..3 {
+            store.record_completed_range_reads(&[
+                completed_read(started, 10, 500),
+                completed_read(started, 10, 500),
+            ]);
+        }
+
+        assert_eq!(
+            store
+                .current_transport_estimate()
+                .map(|estimate| estimate.shared_throughput_bytes_per_second),
+            Some(1_000)
+        );
+    }
+
+    #[tokio::test]
+    async fn only_successful_automatic_plans_update_transport_estimates() -> Result<()> {
+        let inner = InMemory::new();
+        inner
+            .put(
+                &Path::from("data.parquet"),
+                PutPayload::from_static(b"0123456789abcdef"),
+            )
+            .await?;
+        let throttled = ThrottledStore::new(
+            inner,
+            ThrottleConfig {
+                wait_get_per_call: Duration::from_millis(1),
+                wait_get_per_byte: Duration::from_micros(10),
+                ..Default::default()
+            },
+        );
+        let store = MeteredParquetObjectStore::new(
+            Arc::new(throttled),
+            direct_metrics(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        for _ in 0..3 {
+            let results = store
+                .get_ranges(&Path::from("data.parquet"), &[0..4, 8..12])
+                .await?;
+            assert_eq!(results[0].as_ref(), b"0123");
+            assert_eq!(results[1].as_ref(), b"89ab");
+        }
+        assert!(store.current_transport_estimate().is_some());
+
+        let failed_store = MeteredParquetObjectStore::new(
+            Arc::new(InMemory::new()),
+            direct_metrics(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        let started = Instant::now();
+        for _ in 0..2 {
+            failed_store.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
+        }
+        assert!(
+            failed_store
+                .get_ranges(&Path::from("missing.parquet"), &[0..4, 8..12])
+                .await
+                .is_err()
+        );
+        assert_eq!(failed_store.current_transport_estimate(), None);
         Ok(())
     }
 

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -6,14 +6,14 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{StreamExt, stream, stream::BoxStream};
 use object_store::{
-    CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
-    OBJECT_STORE_COALESCE_DEFAULT, ObjectMeta, ObjectStore, ObjectStoreExt, ObjectStoreScheme,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result, path::Path,
+    CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, ObjectStoreExt, ObjectStoreScheme, PutMultipartOptions, PutOptions, PutPayload,
+    PutResult, RenameOptions, Result, path::Path,
 };
 use tracing::Instrument;
 use url::Url;
 
-use super::range_planning::{execute_range_plan, merge_ranges};
+use super::range_planning::{choose_range_plan, execute_range_plan};
 use crate::DeltaScanMetrics;
 
 pub(crate) struct MeteredParquetObjectStore {
@@ -26,19 +26,19 @@ pub(crate) struct MeteredParquetObjectStore {
 pub(crate) enum MultiRangeReadStrategy {
     /// Pass the original range list to the store's `get_ranges` implementation.
     UseStoreImplementation,
-    /// Apply the object-store default 1 MiB gap before calling the inner store.
-    CoalesceWithDefaultGap,
+    /// Choose a physical range plan from recent remote transport observations.
+    ChooseAutomatically,
 }
 
 impl MultiRangeReadStrategy {
     /// Uses the store implementation for local, memory, and custom URL schemes. Built-in remote
-    /// stores keep the current default-gap coalescing behavior.
+    /// stores choose their physical range plan automatically.
     pub(crate) fn for_table_url(table_url: &Url) -> Self {
         match ObjectStoreScheme::parse(table_url) {
             Ok((ObjectStoreScheme::Local | ObjectStoreScheme::Memory, _)) | Err(_) => {
                 Self::UseStoreImplementation
             }
-            Ok(_) => Self::CoalesceWithDefaultGap,
+            Ok(_) => Self::ChooseAutomatically,
         }
     }
 }
@@ -134,8 +134,8 @@ impl ObjectStore for MeteredParquetObjectStore {
                 }
                 Ok(results)
             }
-            MultiRangeReadStrategy::CoalesceWithDefaultGap => {
-                let physical_ranges = merge_ranges(ranges, OBJECT_STORE_COALESCE_DEFAULT);
+            MultiRangeReadStrategy::ChooseAutomatically => {
+                let physical_ranges = choose_range_plan(ranges, None);
                 execute_range_plan(ranges, &physical_ranges, |range| {
                     self.get_range(location, range)
                 })
@@ -261,7 +261,7 @@ mod tests {
     }
 
     async fn memory_store(metrics: DeltaScanMetrics) -> Result<MeteredParquetObjectStore> {
-        memory_store_with_strategy(metrics, MultiRangeReadStrategy::CoalesceWithDefaultGap).await
+        memory_store_with_strategy(metrics, MultiRangeReadStrategy::ChooseAutomatically).await
     }
 
     async fn memory_store_with_strategy(
@@ -295,7 +295,7 @@ mod tests {
         ] {
             assert_eq!(
                 MultiRangeReadStrategy::for_table_url(&url::Url::parse(location)?),
-                MultiRangeReadStrategy::CoalesceWithDefaultGap,
+                MultiRangeReadStrategy::ChooseAutomatically,
                 "{location}"
             );
         }
@@ -347,7 +347,7 @@ mod tests {
         let failure_store = MeteredParquetObjectStore::new(
             Arc::new(InMemory::new()),
             failure_metrics.clone(),
-            MultiRangeReadStrategy::CoalesceWithDefaultGap,
+            MultiRangeReadStrategy::ChooseAutomatically,
         );
         let result = failure_store
             .get_opts(
@@ -366,16 +366,16 @@ mod tests {
 
     #[tokio::test]
     async fn multi_range_strategies_preserve_results_and_expose_metrics() -> Result<()> {
-        let coalesced_metrics = direct_metrics();
-        let coalesced_store = memory_store(coalesced_metrics.clone()).await?;
-        let bytes = coalesced_store
+        let automatic_metrics = direct_metrics();
+        let automatic_store = memory_store(automatic_metrics.clone()).await?;
+        let bytes = automatic_store
             .get_ranges(&Path::from("data.parquet"), &[0..4, 8..12])
             .await?;
         assert_eq!(bytes[0].as_ref(), b"0123");
         assert_eq!(bytes[1].as_ref(), b"89ab");
-        let snapshot = coalesced_metrics.snapshot();
-        assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(1));
-        assert_eq!(snapshot.parquet_data_file_bytes_received, Some(12));
+        let snapshot = automatic_metrics.snapshot();
+        assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(2));
+        assert_eq!(snapshot.parquet_data_file_bytes_received, Some(8));
 
         let delegated_metrics = direct_metrics();
         let delegated_store = memory_store_with_strategy(

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -158,17 +158,26 @@ impl MeteredParquetObjectStore {
     }
 
     /// Records the exact request and chosen physical plan before its reads start.
-    fn record_chosen_range_plan(&self, plan: &ChosenRangePlan) {
+    fn record_chosen_range_plan_metrics(&self, plan: &ChosenRangePlan) {
         self.metrics
-            .record_parquet_data_file_ranges_requested(plan.exact_range_count, plan.exact_bytes);
-        self.metrics
-            .record_parquet_data_file_range_plan(plan.physical_ranges.len(), plan.planned_bytes);
+            .record_parquet_data_file_exact_ranges_requested(
+                plan.exact_range_count,
+                plan.exact_bytes,
+            );
+        self.metrics.record_parquet_data_file_physical_range_plan(
+            plan.physical_ranges.len(),
+            plan.planned_bytes,
+        );
         match plan.decision {
             RangePlanDecision::ColdStart => self
                 .metrics
                 .record_parquet_data_file_cold_start_range_plan(),
-            RangePlanDecision::Exact => self.metrics.record_parquet_data_file_exact_range_plan(),
-            RangePlanDecision::Merged => self.metrics.record_parquet_data_file_merged_range_plan(),
+            RangePlanDecision::CostBasedExact => self
+                .metrics
+                .record_parquet_data_file_cost_based_exact_range_plan(),
+            RangePlanDecision::CostBasedMerged => self
+                .metrics
+                .record_parquet_data_file_cost_based_merged_range_plan(),
         }
     }
 }
@@ -286,12 +295,13 @@ impl ObjectStore for MeteredParquetObjectStore {
         match self.multi_range_read_strategy {
             MultiRangeReadStrategy::UseStoreImplementation => {
                 let exact_ranges = merge_ranges(ranges, 0);
-                self.metrics.record_parquet_data_file_ranges_requested(
-                    exact_ranges.len(),
-                    range_bytes(&exact_ranges),
-                );
                 self.metrics
-                    .record_parquet_data_file_store_delegated_range_call();
+                    .record_parquet_data_file_exact_ranges_requested(
+                        exact_ranges.len(),
+                        range_bytes(&exact_ranges),
+                    );
+                self.metrics
+                    .record_parquet_data_file_store_delegated_range_plan();
                 self.metrics.record_parquet_data_file_range_get_operation();
                 let results = self
                     .inner
@@ -309,7 +319,7 @@ impl ObjectStore for MeteredParquetObjectStore {
             }
             MultiRangeReadStrategy::ChooseAutomatically => {
                 let plan = choose_range_plan(ranges, self.current_transport_estimate());
-                self.record_chosen_range_plan(&plan);
+                self.record_chosen_range_plan_metrics(&plan);
                 let physical_ranges = plan.physical_ranges;
                 let completed_reads =
                     Arc::new(Mutex::new(Vec::with_capacity(physical_ranges.len())));
@@ -588,15 +598,30 @@ mod tests {
         assert_eq!(bytes[0].as_ref(), b"0123");
         assert_eq!(bytes[1].as_ref(), b"89ab");
         let snapshot = automatic_metrics.snapshot();
-        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
-        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(2));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(8));
-        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
-        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(0));
-        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(0));
+        assert_eq!(snapshot.parquet_data_file_exact_ranges_requested, Some(2));
         assert_eq!(
-            snapshot.parquet_data_file_store_delegated_range_calls,
+            snapshot.parquet_data_file_exact_range_bytes_requested,
+            Some(8)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_requests_planned,
+            Some(2)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_bytes_planned,
+            Some(8)
+        );
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_exact_range_plans,
+            Some(0)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_merged_range_plans,
+            Some(0)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_plans,
             Some(0)
         );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(2));
@@ -615,15 +640,30 @@ mod tests {
         assert_eq!(bytes[0].as_ref(), b"0123");
         assert_eq!(bytes[1].as_ref(), b"89ab");
         let snapshot = delegated_metrics.snapshot();
-        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
-        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(0));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(0));
-        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(0));
-        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(0));
-        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(0));
+        assert_eq!(snapshot.parquet_data_file_exact_ranges_requested, Some(2));
         assert_eq!(
-            snapshot.parquet_data_file_store_delegated_range_calls,
+            snapshot.parquet_data_file_exact_range_bytes_requested,
+            Some(8)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_requests_planned,
+            Some(0)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_bytes_planned,
+            Some(0)
+        );
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(0));
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_exact_range_plans,
+            Some(0)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_merged_range_plans,
+            Some(0)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_plans,
             Some(1)
         );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(1));
@@ -641,10 +681,14 @@ mod tests {
         );
         for (physical_ranges, planned_bytes, decision) in [
             (vec![0..2, 4..6, 8..10], 6, RangePlanDecision::ColdStart),
-            (vec![0..2, 4..6, 8..10], 6, RangePlanDecision::Exact),
-            (vec![0..6, 8..10], 8, RangePlanDecision::Merged),
+            (
+                vec![0..2, 4..6, 8..10],
+                6,
+                RangePlanDecision::CostBasedExact,
+            ),
+            (vec![0..6, 8..10], 8, RangePlanDecision::CostBasedMerged),
         ] {
-            store.record_chosen_range_plan(&ChosenRangePlan {
+            store.record_chosen_range_plan_metrics(&ChosenRangePlan {
                 exact_range_count: 3,
                 exact_bytes: 6,
                 physical_ranges,
@@ -654,13 +698,28 @@ mod tests {
         }
 
         let snapshot = metrics.snapshot();
-        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(9));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(18));
-        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(8));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(20));
+        assert_eq!(snapshot.parquet_data_file_exact_ranges_requested, Some(9));
+        assert_eq!(
+            snapshot.parquet_data_file_exact_range_bytes_requested,
+            Some(18)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_requests_planned,
+            Some(8)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_bytes_planned,
+            Some(20)
+        );
         assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
-        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(1));
-        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(1));
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_exact_range_plans,
+            Some(1)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_merged_range_plans,
+            Some(1)
+        );
     }
 
     #[test]
@@ -773,10 +832,19 @@ mod tests {
         );
         assert_eq!(failed_store.current_transport_estimate(), None);
         let snapshot = failed_metrics.snapshot();
-        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
-        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(2));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(8));
+        assert_eq!(snapshot.parquet_data_file_exact_ranges_requested, Some(2));
+        assert_eq!(
+            snapshot.parquet_data_file_exact_range_bytes_requested,
+            Some(8)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_requests_planned,
+            Some(2)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_bytes_planned,
+            Some(8)
+        );
         assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
         Ok(())
     }
@@ -877,7 +945,7 @@ mod tests {
         assert_eq!(
             metrics
                 .snapshot()
-                .parquet_data_file_store_delegated_range_calls,
+                .parquet_data_file_store_delegated_range_plans,
             Some(0)
         );
 
@@ -888,10 +956,13 @@ mod tests {
                 .is_err()
         );
         let snapshot = metrics.snapshot();
-        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
+        assert_eq!(snapshot.parquet_data_file_exact_ranges_requested, Some(2));
         assert_eq!(
-            snapshot.parquet_data_file_store_delegated_range_calls,
+            snapshot.parquet_data_file_exact_range_bytes_requested,
+            Some(8)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_plans,
             Some(1)
         );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(1));

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -419,6 +419,7 @@ mod tests {
     };
 
     use async_trait::async_trait;
+    use bytes::Bytes;
     use chrono::{DateTime, Utc};
     use futures_util::{StreamExt, stream, stream::BoxStream};
     use object_store::{
@@ -588,6 +589,7 @@ mod tests {
             Some(0)
         );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(2));
+        assert_eq!(snapshot.parquet_data_file_full_get_operations, Some(0));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(8));
 
         let delegated_metrics = direct_metrics();
@@ -765,6 +767,49 @@ mod tests {
         assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(2));
         assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(8));
         assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancelled_partial_automatic_plan_does_not_update_transport_estimates()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let first = PutPayload::from_static(b"abc")
+            .into_iter()
+            .next()
+            .ok_or_else(missing_chunk)?;
+        let payload = stream::iter([Ok(first)])
+            .chain(stream::pending::<Result<Bytes>>())
+            .boxed();
+        let metrics = direct_metrics();
+        let store = Arc::new(MeteredParquetObjectStore::new(
+            Arc::new(ScriptedGetStore::new(test_get_result(
+                GetResultPayload::Stream(payload),
+                0..8,
+            ))),
+            metrics.clone(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        ));
+        let started = Instant::now();
+        for _ in 0..2 {
+            store.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
+        }
+
+        let task_store = Arc::clone(&store);
+        let task = tokio::spawn(async move {
+            task_store
+                .get_ranges(&Path::from("data.parquet"), &[0..4, 4..8])
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while metrics.snapshot().parquet_data_file_bytes_received != Some(3) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+
+        task.abort();
+        assert!(task.await.is_err_and(|error| error.is_cancelled()));
+        assert_eq!(store.current_transport_estimate(), None);
         Ok(())
     }
 

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -19,7 +19,10 @@ use object_store::{
 use tracing::Instrument;
 use url::Url;
 
-use super::range_planning::{TransportEstimate, choose_range_plan, execute_range_plan};
+use super::range_planning::{
+    ChosenRangePlan, RangePlanDecision, TransportEstimate, choose_range_plan, execute_range_plan,
+    merge_ranges, range_bytes,
+};
 use crate::DeltaScanMetrics;
 
 const TRANSPORT_SAMPLE_WINDOW: usize = 9;
@@ -142,6 +145,21 @@ impl MeteredParquetObjectStore {
         }
         samples.push_back(sample);
     }
+
+    /// Records the exact request and chosen physical plan before its reads start.
+    fn record_chosen_range_plan(&self, plan: &ChosenRangePlan) {
+        self.metrics
+            .record_parquet_data_file_ranges_requested(plan.exact_range_count, plan.exact_bytes);
+        self.metrics
+            .record_parquet_data_file_range_plan(plan.physical_ranges.len(), plan.planned_bytes);
+        match plan.decision {
+            RangePlanDecision::ColdStart => self
+                .metrics
+                .record_parquet_data_file_cold_start_range_plan(),
+            RangePlanDecision::Exact => self.metrics.record_parquet_data_file_exact_range_plan(),
+            RangePlanDecision::Merged => self.metrics.record_parquet_data_file_merged_range_plan(),
+        }
+    }
 }
 
 /// Summarizes one fully completed physical plan without double-counting concurrent delivery time.
@@ -250,11 +268,19 @@ impl ObjectStore for MeteredParquetObjectStore {
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+        if ranges.is_empty() {
+            return Ok(Vec::new());
+        }
+
         match self.multi_range_read_strategy {
             MultiRangeReadStrategy::UseStoreImplementation => {
-                if ranges.is_empty() {
-                    return Ok(Vec::new());
-                }
+                let exact_ranges = merge_ranges(ranges, 0);
+                self.metrics.record_parquet_data_file_ranges_requested(
+                    exact_ranges.len(),
+                    range_bytes(&exact_ranges),
+                );
+                self.metrics
+                    .record_parquet_data_file_store_delegated_range_call();
                 self.metrics.record_parquet_data_file_range_get_operation();
                 let results = self
                     .inner
@@ -271,7 +297,9 @@ impl ObjectStore for MeteredParquetObjectStore {
                 Ok(results)
             }
             MultiRangeReadStrategy::ChooseAutomatically => {
-                let physical_ranges = choose_range_plan(ranges, self.current_transport_estimate());
+                let plan = choose_range_plan(ranges, self.current_transport_estimate());
+                self.record_chosen_range_plan(&plan);
+                let physical_ranges = plan.physical_ranges;
                 let completed_reads =
                     Arc::new(Mutex::new(Vec::with_capacity(physical_ranges.len())));
                 let results = execute_range_plan(ranges, &physical_ranges, |range| {
@@ -403,7 +431,8 @@ mod tests {
     };
 
     use super::{
-        CompletedRangeRead, MeteredParquetObjectStore, MultiRangeReadStrategy, TransportEstimate,
+        ChosenRangePlan, CompletedRangeRead, MeteredParquetObjectStore, MultiRangeReadStrategy,
+        RangePlanDecision, TransportEstimate,
     };
     use crate::{DeltaScanMetrics, ParquetReaderBackend, reader::metrics::DeltaScanMetricsConfig};
 
@@ -547,6 +576,17 @@ mod tests {
         assert_eq!(bytes[0].as_ref(), b"0123");
         assert_eq!(bytes[1].as_ref(), b"89ab");
         let snapshot = automatic_metrics.snapshot();
+        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
+        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(2));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(8));
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
+        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(0));
+        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(0));
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_calls,
+            Some(0)
+        );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(2));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(8));
 
@@ -562,9 +602,52 @@ mod tests {
         assert_eq!(bytes[0].as_ref(), b"0123");
         assert_eq!(bytes[1].as_ref(), b"89ab");
         let snapshot = delegated_metrics.snapshot();
+        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
+        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(0));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(0));
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(0));
+        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(0));
+        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(0));
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_calls,
+            Some(1)
+        );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(1));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(8));
         Ok(())
+    }
+
+    #[test]
+    fn chosen_range_plan_metrics_distinguish_decisions() {
+        let metrics = direct_metrics();
+        let store = MeteredParquetObjectStore::new(
+            Arc::new(InMemory::new()),
+            metrics.clone(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        for (physical_ranges, planned_bytes, decision) in [
+            (vec![0..2, 4..6, 8..10], 6, RangePlanDecision::ColdStart),
+            (vec![0..2, 4..6, 8..10], 6, RangePlanDecision::Exact),
+            (vec![0..6, 8..10], 8, RangePlanDecision::Merged),
+        ] {
+            store.record_chosen_range_plan(&ChosenRangePlan {
+                exact_range_count: 3,
+                exact_bytes: 6,
+                physical_ranges,
+                planned_bytes,
+                decision,
+            });
+        }
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(9));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(18));
+        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(8));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(20));
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
+        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(1));
+        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(1));
     }
 
     #[test]
@@ -659,9 +742,10 @@ mod tests {
         }
         assert!(store.current_transport_estimate().is_some());
 
+        let failed_metrics = direct_metrics();
         let failed_store = MeteredParquetObjectStore::new(
             Arc::new(InMemory::new()),
-            direct_metrics(),
+            failed_metrics.clone(),
             MultiRangeReadStrategy::ChooseAutomatically,
         );
         let started = Instant::now();
@@ -675,6 +759,12 @@ mod tests {
                 .is_err()
         );
         assert_eq!(failed_store.current_transport_estimate(), None);
+        let snapshot = failed_metrics.snapshot();
+        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
+        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(2));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(8));
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(1));
         Ok(())
     }
 
@@ -697,6 +787,12 @@ mod tests {
             metrics.snapshot().parquet_data_file_range_get_operations,
             Some(0)
         );
+        assert_eq!(
+            metrics
+                .snapshot()
+                .parquet_data_file_store_delegated_range_calls,
+            Some(0)
+        );
 
         assert!(
             store
@@ -705,6 +801,12 @@ mod tests {
                 .is_err()
         );
         let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(2));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(8));
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_calls,
+            Some(1)
+        );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(1));
         assert_eq!(snapshot.parquet_data_file_bytes_received, Some(0));
         Ok(())

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -8,12 +8,12 @@ use futures_util::{StreamExt, stream, stream::BoxStream};
 use object_store::{
     CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
     OBJECT_STORE_COALESCE_DEFAULT, ObjectMeta, ObjectStore, ObjectStoreExt, ObjectStoreScheme,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result, coalesce_ranges,
-    path::Path,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result, path::Path,
 };
 use tracing::Instrument;
 use url::Url;
 
+use super::range_planning::{execute_range_plan, merge_ranges};
 use crate::DeltaScanMetrics;
 
 pub(crate) struct MeteredParquetObjectStore {
@@ -135,11 +135,10 @@ impl ObjectStore for MeteredParquetObjectStore {
                 Ok(results)
             }
             MultiRangeReadStrategy::CoalesceWithDefaultGap => {
-                coalesce_ranges(
-                    ranges,
-                    |range| self.get_range(location, range),
-                    OBJECT_STORE_COALESCE_DEFAULT,
-                )
+                let physical_ranges = merge_ranges(ranges, OBJECT_STORE_COALESCE_DEFAULT);
+                execute_range_plan(ranges, &physical_ranges, |range| {
+                    self.get_range(location, range)
+                })
                 .await
             }
         }

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -25,9 +25,9 @@ pub(super) enum RangePlanDecision {
     /// No usable transport estimate was available, so only safety bounds guided the plan.
     ColdStart,
     /// A usable transport estimate favored the normalized minimum-byte plan.
-    Exact,
+    CostBasedExact,
     /// A usable transport estimate favored including gaps to reduce physical requests.
-    Merged,
+    CostBasedMerged,
 }
 
 /// The exact request summary and physical ranges selected by the automatic planner.
@@ -127,9 +127,9 @@ pub(super) fn choose_range_plan(
                     .cloned()
                     .unwrap_or_else(|| exact_plan.clone());
                 let decision = if plan == *exact_plan {
-                    RangePlanDecision::Exact
+                    RangePlanDecision::CostBasedExact
                 } else {
-                    RangePlanDecision::Merged
+                    RangePlanDecision::CostBasedMerged
                 };
                 (plan, decision)
             }
@@ -322,7 +322,7 @@ mod tests {
         assert_eq!(cold_plan.decision, RangePlanDecision::ColdStart);
         let exact_plan = choose_range_plan(&requested_ranges, Some(low_bandwidth));
         assert_eq!(exact_plan.physical_ranges.len(), 11);
-        assert_eq!(exact_plan.decision, RangePlanDecision::Exact);
+        assert_eq!(exact_plan.decision, RangePlanDecision::CostBasedExact);
         assert_eq!(
             choose_range_plan(&requested_ranges, Some(near_boundary))
                 .physical_ranges
@@ -331,7 +331,7 @@ mod tests {
         );
         let merged_plan = choose_range_plan(&requested_ranges, Some(high_bandwidth));
         assert_eq!(merged_plan.physical_ranges.len(), 10);
-        assert_eq!(merged_plan.decision, RangePlanDecision::Merged);
+        assert_eq!(merged_plan.decision, RangePlanDecision::CostBasedMerged);
     }
 
     #[test]

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -6,6 +6,8 @@ use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt, stream};
 
 const MAX_CONCURRENT_RANGE_READS: usize = 10;
+const MAX_RANGE_READ_REQUESTS: usize = 64;
+const MAX_BYTE_AMPLIFICATION: u128 = 4;
 const DECISION_MARGIN_PERCENT: u128 = 10;
 
 /// Recent transport conditions used to compare physical range-read plans.
@@ -58,6 +60,9 @@ pub(super) fn merge_ranges(requested_ranges: &[Range<u64>], max_gap: u64) -> Vec
 /// Without a usable transport estimate, this returns the normalized minimum-byte
 /// plan. With an estimate, plans within ten percent of the best predicted score
 /// prefer fewer transferred bytes so small estimate changes do not cause churn.
+/// If the exact plan exceeds 64 requests, the cold plan uses at most 64 requests
+/// when that merge transfers no more than four times the exact bytes. Otherwise,
+/// it keeps the exact plan and relies on the execution concurrency bound.
 pub(super) fn choose_range_plan(
     requested_ranges: &[Range<u64>],
     estimate: Option<TransportEstimate>,
@@ -66,13 +71,16 @@ pub(super) fn choose_range_plan(
     let Some(exact_plan) = candidates.first() else {
         return Vec::new();
     };
+    let candidate_start =
+        usize::from(exact_plan.len() > MAX_RANGE_READ_REQUESTS && candidates.len() > 1);
+    let eligible_candidates = &candidates[candidate_start..];
     let Some(estimate) =
         estimate.filter(|estimate| estimate.shared_throughput_bytes_per_second > 0)
     else {
-        return exact_plan.clone();
+        return eligible_candidates[0].clone();
     };
 
-    let best_score = candidates
+    let best_score = eligible_candidates
         .iter()
         .map(|plan| plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS))
         .min()
@@ -80,7 +88,7 @@ pub(super) fn choose_range_plan(
     let competitive_score =
         best_score.saturating_add(best_score.saturating_mul(DECISION_MARGIN_PERCENT) / 100);
 
-    candidates
+    eligible_candidates
         .iter()
         .filter(|plan| plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS) <= competitive_score)
         .min_by_key(|plan| (planned_bytes(plan), plan.len()))
@@ -91,7 +99,8 @@ pub(super) fn choose_range_plan(
 /// Builds only plans that reduce the number of request waves.
 ///
 /// Each lower-wave candidate merges the smallest gaps required to reach that
-/// wave count. Plans that add bytes without removing a wave are omitted.
+/// wave count. Plans that add bytes without removing a wave or exceed the byte
+/// amplification limit are omitted.
 fn candidate_range_plans(
     requested_ranges: &[Range<u64>],
     max_concurrent_reads: usize,
@@ -104,6 +113,7 @@ fn candidate_range_plans(
     let max_concurrent_reads = max_concurrent_reads.max(1);
     let exact_waves = request_waves(exact_plan.len(), max_concurrent_reads);
     let mut candidates = vec![exact_plan.clone()];
+    let max_planned_bytes = planned_bytes(&exact_plan).saturating_mul(MAX_BYTE_AMPLIFICATION);
     let mut gaps = exact_plan
         .windows(2)
         .enumerate()
@@ -111,7 +121,10 @@ fn candidate_range_plans(
         .collect::<Vec<_>>();
     gaps.sort_unstable();
 
-    for target_waves in (1..exact_waves).rev() {
+    let highest_target_wave = exact_waves
+        .saturating_sub(1)
+        .min(MAX_RANGE_READ_REQUESTS / max_concurrent_reads);
+    for target_waves in (1..=highest_target_wave).rev() {
         let target_count = target_waves * max_concurrent_reads;
         let mut merge_gap = vec![false; exact_plan.len() - 1];
         for (_, index) in gaps.iter().take(exact_plan.len() - target_count) {
@@ -129,6 +142,9 @@ fn candidate_range_plans(
             }
         }
         plan.push(current_range);
+        if planned_bytes(&plan) > max_planned_bytes {
+            break;
+        }
         candidates.push(plan);
     }
 
@@ -265,6 +281,16 @@ mod tests {
             choose_range_plan(&requested_ranges, Some(high_bandwidth)).len(),
             10
         );
+    }
+
+    #[test]
+    fn cold_plan_limits_requests_without_exceeding_byte_amplification() {
+        let dense_ranges = spaced_ranges(&[1; 99]);
+        assert_eq!(choose_range_plan(&dense_ranges, None).len(), 60);
+
+        let sparse_ranges = spaced_ranges(&[1_000_000; 99]);
+        assert_eq!(choose_range_plan(&sparse_ranges, None).len(), 100);
+        assert_eq!(candidate_range_plans(&sparse_ranges, 10).len(), 1);
     }
 
     fn spaced_ranges(gaps: &[u64]) -> Vec<std::ops::Range<u64>> {

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -1,11 +1,21 @@
 //! Planning and execution helpers for Parquet byte-range reads.
 
-use std::{future::Future, ops::Range};
+use std::{future::Future, ops::Range, time::Duration};
 
 use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt, stream};
 
 const MAX_CONCURRENT_RANGE_READS: usize = 10;
+const DECISION_MARGIN_PERCENT: u128 = 10;
+
+/// Recent transport conditions used to compare physical range-read plans.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct TransportEstimate {
+    /// Typical time for a request to reach payload availability.
+    pub(super) request_latency: Duration,
+    /// Typical aggregate payload throughput across concurrent requests.
+    pub(super) shared_throughput_bytes_per_second: u64,
+}
 
 /// Combines overlapping ranges and ranges separated by at most `max_gap` bytes.
 ///
@@ -41,6 +51,117 @@ pub(super) fn merge_ranges(requested_ranges: &[Range<u64>], max_gap: u64) -> Vec
     }
 
     merged_ranges
+}
+
+/// Chooses the physical ranges predicted to finish fastest.
+///
+/// Without a usable transport estimate, this returns the normalized minimum-byte
+/// plan. With an estimate, plans within ten percent of the best predicted score
+/// prefer fewer transferred bytes so small estimate changes do not cause churn.
+pub(super) fn choose_range_plan(
+    requested_ranges: &[Range<u64>],
+    estimate: Option<TransportEstimate>,
+) -> Vec<Range<u64>> {
+    let candidates = candidate_range_plans(requested_ranges, MAX_CONCURRENT_RANGE_READS);
+    let Some(exact_plan) = candidates.first() else {
+        return Vec::new();
+    };
+    let Some(estimate) =
+        estimate.filter(|estimate| estimate.shared_throughput_bytes_per_second > 0)
+    else {
+        return exact_plan.clone();
+    };
+
+    let best_score = candidates
+        .iter()
+        .map(|plan| plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS))
+        .min()
+        .unwrap_or(0);
+    let competitive_score =
+        best_score.saturating_add(best_score.saturating_mul(DECISION_MARGIN_PERCENT) / 100);
+
+    candidates
+        .iter()
+        .filter(|plan| plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS) <= competitive_score)
+        .min_by_key(|plan| (planned_bytes(plan), plan.len()))
+        .cloned()
+        .unwrap_or_else(|| exact_plan.clone())
+}
+
+/// Builds only plans that reduce the number of request waves.
+///
+/// Each lower-wave candidate merges the smallest gaps required to reach that
+/// wave count. Plans that add bytes without removing a wave are omitted.
+fn candidate_range_plans(
+    requested_ranges: &[Range<u64>],
+    max_concurrent_reads: usize,
+) -> Vec<Vec<Range<u64>>> {
+    let exact_plan = merge_ranges(requested_ranges, 0);
+    if exact_plan.is_empty() {
+        return vec![exact_plan];
+    }
+
+    let max_concurrent_reads = max_concurrent_reads.max(1);
+    let exact_waves = request_waves(exact_plan.len(), max_concurrent_reads);
+    let mut candidates = vec![exact_plan.clone()];
+    let mut gaps = exact_plan
+        .windows(2)
+        .enumerate()
+        .map(|(index, ranges)| (ranges[1].start - ranges[0].end, index))
+        .collect::<Vec<_>>();
+    gaps.sort_unstable();
+
+    for target_waves in (1..exact_waves).rev() {
+        let target_count = target_waves * max_concurrent_reads;
+        let mut merge_gap = vec![false; exact_plan.len() - 1];
+        for (_, index) in gaps.iter().take(exact_plan.len() - target_count) {
+            merge_gap[*index] = true;
+        }
+
+        let mut plan = Vec::with_capacity(target_count);
+        let mut current_range = exact_plan[0].clone();
+        for (index, next_range) in exact_plan.iter().enumerate().skip(1) {
+            if merge_gap[index - 1] {
+                current_range.end = next_range.end;
+            } else {
+                plan.push(current_range);
+                current_range = next_range.clone();
+            }
+        }
+        plan.push(current_range);
+        candidates.push(plan);
+    }
+
+    candidates
+}
+
+/// Returns the bytes covered by a physical range plan.
+fn planned_bytes(plan: &[Range<u64>]) -> u128 {
+    plan.iter()
+        .map(|range| u128::from(range.end - range.start))
+        .sum()
+}
+
+/// Returns how many rounds of requests a plan needs at the given concurrency.
+fn request_waves(request_count: usize, max_concurrent_reads: usize) -> usize {
+    request_count.div_ceil(max_concurrent_reads.max(1))
+}
+
+/// Scores a plan as transferred bytes plus one bandwidth-delay cost per request wave.
+fn plan_score(
+    plan: &[Range<u64>],
+    estimate: TransportEstimate,
+    max_concurrent_reads: usize,
+) -> u128 {
+    let bandwidth_delay_bytes = estimate
+        .request_latency
+        .as_nanos()
+        .saturating_mul(u128::from(estimate.shared_throughput_bytes_per_second))
+        / 1_000_000_000;
+    planned_bytes(plan).saturating_add(
+        (request_waves(plan.len(), max_concurrent_reads) as u128)
+            .saturating_mul(bandwidth_delay_bytes),
+    )
 }
 
 /// Executes an already chosen physical plan and returns one result for each requested range.
@@ -80,11 +201,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::convert::Infallible;
+    use std::{convert::Infallible, time::Duration};
 
     use bytes::Bytes;
 
-    use super::{execute_range_plan, merge_ranges};
+    use super::{
+        TransportEstimate, candidate_range_plans, choose_range_plan, execute_range_plan,
+        merge_ranges, planned_bytes,
+    };
 
     #[test]
     fn merges_unsorted_overlapping_adjacent_and_nearby_ranges() {
@@ -96,6 +220,62 @@ mod tests {
             vec![0..8, 10..12, 15..18, 20..25]
         );
         assert!(merge_ranges(&[], 2).is_empty());
+    }
+
+    #[test]
+    fn candidates_merge_only_the_smallest_gaps_needed_to_remove_a_wave() {
+        let requested_ranges = spaced_ranges(&[9, 8, 7, 6, 5, 4, 3, 2, 1, 20]);
+        let candidates = candidate_range_plans(&requested_ranges, 5);
+
+        assert_eq!(
+            candidates.iter().map(Vec::len).collect::<Vec<_>>(),
+            vec![11, 10, 5]
+        );
+        let exact_bytes = planned_bytes(&candidates[0]);
+        assert_eq!(planned_bytes(&candidates[1]), exact_bytes + 1);
+        assert_eq!(planned_bytes(&candidates[2]), exact_bytes + 21);
+    }
+
+    #[test]
+    fn transport_cost_and_margin_choose_stable_wave_boundary_plans() {
+        let requested_ranges = spaced_ranges(&[900; 10]);
+        let low_bandwidth = TransportEstimate {
+            request_latency: Duration::from_millis(100),
+            shared_throughput_bytes_per_second: 1_000,
+        };
+        let near_boundary = TransportEstimate {
+            request_latency: Duration::from_secs(1),
+            shared_throughput_bytes_per_second: 1_000,
+        };
+        let high_bandwidth = TransportEstimate {
+            request_latency: Duration::from_millis(100),
+            shared_throughput_bytes_per_second: 1_000_000_000,
+        };
+
+        assert_eq!(choose_range_plan(&requested_ranges, None).len(), 11);
+        assert_eq!(
+            choose_range_plan(&requested_ranges, Some(low_bandwidth)).len(),
+            11
+        );
+        assert_eq!(
+            choose_range_plan(&requested_ranges, Some(near_boundary)).len(),
+            11
+        );
+        assert_eq!(
+            choose_range_plan(&requested_ranges, Some(high_bandwidth)).len(),
+            10
+        );
+    }
+
+    fn spaced_ranges(gaps: &[u64]) -> Vec<std::ops::Range<u64>> {
+        let mut start = 0;
+        let mut ranges = Vec::with_capacity(gaps.len() + 1);
+        for gap in gaps {
+            ranges.push(start..start + 100);
+            start += 100 + gap;
+        }
+        ranges.push(start..start + 100);
+        ranges
     }
 
     #[tokio::test]

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -19,6 +19,31 @@ pub(super) struct TransportEstimate {
     pub(super) shared_throughput_bytes_per_second: u64,
 }
 
+/// Why the automatic planner selected its physical range plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RangePlanDecision {
+    /// No usable transport estimate was available, so only safety bounds guided the plan.
+    ColdStart,
+    /// A usable transport estimate favored the normalized minimum-byte plan.
+    Exact,
+    /// A usable transport estimate favored including gaps to reduce physical requests.
+    Merged,
+}
+
+/// The exact request summary and physical ranges selected by the automatic planner.
+pub(super) struct ChosenRangePlan {
+    /// Number of ranges in the normalized minimum-byte plan.
+    pub(super) exact_range_count: usize,
+    /// Bytes covered by the normalized minimum-byte plan.
+    pub(super) exact_bytes: u128,
+    /// Physical ranges to read.
+    pub(super) physical_ranges: Vec<Range<u64>>,
+    /// Bytes covered by the physical ranges.
+    pub(super) planned_bytes: u128,
+    /// Reason the physical plan was selected.
+    pub(super) decision: RangePlanDecision,
+}
+
 /// Combines overlapping ranges and ranges separated by at most `max_gap` bytes.
 ///
 /// The returned ranges are sorted, non-overlapping physical reads. Keeping this
@@ -57,43 +82,67 @@ pub(super) fn merge_ranges(requested_ranges: &[Range<u64>], max_gap: u64) -> Vec
 
 /// Chooses the physical ranges predicted to finish fastest.
 ///
-/// Without a usable transport estimate, this returns the normalized minimum-byte
-/// plan. With an estimate, plans within ten percent of the best predicted score
-/// prefer fewer transferred bytes so small estimate changes do not cause churn.
-/// If the exact plan exceeds 64 requests, the cold plan uses at most 64 requests
-/// when that merge transfers no more than four times the exact bytes. Otherwise,
-/// it keeps the exact plan and relies on the execution concurrency bound.
+/// With an estimate, plans within ten percent of the best predicted score prefer
+/// fewer transferred bytes so small estimate changes do not cause churn. Without
+/// an estimate, this keeps the normalized minimum-byte plan unless it exceeds 64
+/// requests and a plan of at most 64 requests transfers no more than four times
+/// the exact bytes. Otherwise, execution keeps the exact plan and relies on its
+/// concurrency bound.
 pub(super) fn choose_range_plan(
     requested_ranges: &[Range<u64>],
     estimate: Option<TransportEstimate>,
-) -> Vec<Range<u64>> {
+) -> ChosenRangePlan {
     let candidates = candidate_range_plans(requested_ranges, MAX_CONCURRENT_RANGE_READS);
     let Some(exact_plan) = candidates.first() else {
-        return Vec::new();
+        return ChosenRangePlan {
+            exact_range_count: 0,
+            exact_bytes: 0,
+            physical_ranges: Vec::new(),
+            planned_bytes: 0,
+            decision: RangePlanDecision::ColdStart,
+        };
     };
+    let exact_range_count = exact_plan.len();
+    let exact_bytes = range_bytes(exact_plan);
     let candidate_start =
         usize::from(exact_plan.len() > MAX_RANGE_READ_REQUESTS && candidates.len() > 1);
     let eligible_candidates = &candidates[candidate_start..];
-    let Some(estimate) =
-        estimate.filter(|estimate| estimate.shared_throughput_bytes_per_second > 0)
-    else {
-        return eligible_candidates[0].clone();
-    };
+    let (physical_ranges, decision) =
+        match estimate.filter(|estimate| estimate.shared_throughput_bytes_per_second > 0) {
+            None => (eligible_candidates[0].clone(), RangePlanDecision::ColdStart),
+            Some(estimate) => {
+                let best_score = eligible_candidates
+                    .iter()
+                    .map(|plan| plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS))
+                    .min()
+                    .unwrap_or(0);
+                let competitive_score = best_score
+                    .saturating_add(best_score.saturating_mul(DECISION_MARGIN_PERCENT) / 100);
+                let plan = eligible_candidates
+                    .iter()
+                    .filter(|plan| {
+                        plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS) <= competitive_score
+                    })
+                    .min_by_key(|plan| (range_bytes(plan), plan.len()))
+                    .cloned()
+                    .unwrap_or_else(|| exact_plan.clone());
+                let decision = if plan == *exact_plan {
+                    RangePlanDecision::Exact
+                } else {
+                    RangePlanDecision::Merged
+                };
+                (plan, decision)
+            }
+        };
+    let planned_bytes = range_bytes(&physical_ranges);
 
-    let best_score = eligible_candidates
-        .iter()
-        .map(|plan| plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS))
-        .min()
-        .unwrap_or(0);
-    let competitive_score =
-        best_score.saturating_add(best_score.saturating_mul(DECISION_MARGIN_PERCENT) / 100);
-
-    eligible_candidates
-        .iter()
-        .filter(|plan| plan_score(plan, estimate, MAX_CONCURRENT_RANGE_READS) <= competitive_score)
-        .min_by_key(|plan| (planned_bytes(plan), plan.len()))
-        .cloned()
-        .unwrap_or_else(|| exact_plan.clone())
+    ChosenRangePlan {
+        exact_range_count,
+        exact_bytes,
+        physical_ranges,
+        planned_bytes,
+        decision,
+    }
 }
 
 /// Builds only plans that reduce the number of request waves.
@@ -113,7 +162,7 @@ fn candidate_range_plans(
     let max_concurrent_reads = max_concurrent_reads.max(1);
     let exact_waves = request_waves(exact_plan.len(), max_concurrent_reads);
     let mut candidates = vec![exact_plan.clone()];
-    let max_planned_bytes = planned_bytes(&exact_plan).saturating_mul(MAX_BYTE_AMPLIFICATION);
+    let max_planned_bytes = range_bytes(&exact_plan).saturating_mul(MAX_BYTE_AMPLIFICATION);
     let mut gaps = exact_plan
         .windows(2)
         .enumerate()
@@ -142,7 +191,7 @@ fn candidate_range_plans(
             }
         }
         plan.push(current_range);
-        if planned_bytes(&plan) > max_planned_bytes {
+        if range_bytes(&plan) > max_planned_bytes {
             break;
         }
         candidates.push(plan);
@@ -152,7 +201,7 @@ fn candidate_range_plans(
 }
 
 /// Returns the bytes covered by a physical range plan.
-fn planned_bytes(plan: &[Range<u64>]) -> u128 {
+pub(super) fn range_bytes(plan: &[Range<u64>]) -> u128 {
     plan.iter()
         .map(|range| u128::from(range.end - range.start))
         .sum()
@@ -174,7 +223,7 @@ fn plan_score(
         .as_nanos()
         .saturating_mul(u128::from(estimate.shared_throughput_bytes_per_second))
         / 1_000_000_000;
-    planned_bytes(plan).saturating_add(
+    range_bytes(plan).saturating_add(
         (request_waves(plan.len(), max_concurrent_reads) as u128)
             .saturating_mul(bandwidth_delay_bytes),
     )
@@ -222,8 +271,8 @@ mod tests {
     use bytes::Bytes;
 
     use super::{
-        TransportEstimate, candidate_range_plans, choose_range_plan, execute_range_plan,
-        merge_ranges, planned_bytes,
+        RangePlanDecision, TransportEstimate, candidate_range_plans, choose_range_plan,
+        execute_range_plan, merge_ranges, range_bytes,
     };
 
     #[test]
@@ -247,9 +296,9 @@ mod tests {
             candidates.iter().map(Vec::len).collect::<Vec<_>>(),
             vec![11, 10, 5]
         );
-        let exact_bytes = planned_bytes(&candidates[0]);
-        assert_eq!(planned_bytes(&candidates[1]), exact_bytes + 1);
-        assert_eq!(planned_bytes(&candidates[2]), exact_bytes + 21);
+        let exact_bytes = range_bytes(&candidates[0]);
+        assert_eq!(range_bytes(&candidates[1]), exact_bytes + 1);
+        assert_eq!(range_bytes(&candidates[2]), exact_bytes + 21);
     }
 
     #[test]
@@ -268,28 +317,38 @@ mod tests {
             shared_throughput_bytes_per_second: 1_000_000_000,
         };
 
-        assert_eq!(choose_range_plan(&requested_ranges, None).len(), 11);
+        let cold_plan = choose_range_plan(&requested_ranges, None);
+        assert_eq!(cold_plan.physical_ranges.len(), 11);
+        assert_eq!(cold_plan.decision, RangePlanDecision::ColdStart);
+        let exact_plan = choose_range_plan(&requested_ranges, Some(low_bandwidth));
+        assert_eq!(exact_plan.physical_ranges.len(), 11);
+        assert_eq!(exact_plan.decision, RangePlanDecision::Exact);
         assert_eq!(
-            choose_range_plan(&requested_ranges, Some(low_bandwidth)).len(),
+            choose_range_plan(&requested_ranges, Some(near_boundary))
+                .physical_ranges
+                .len(),
             11
         );
-        assert_eq!(
-            choose_range_plan(&requested_ranges, Some(near_boundary)).len(),
-            11
-        );
-        assert_eq!(
-            choose_range_plan(&requested_ranges, Some(high_bandwidth)).len(),
-            10
-        );
+        let merged_plan = choose_range_plan(&requested_ranges, Some(high_bandwidth));
+        assert_eq!(merged_plan.physical_ranges.len(), 10);
+        assert_eq!(merged_plan.decision, RangePlanDecision::Merged);
     }
 
     #[test]
     fn cold_plan_limits_requests_without_exceeding_byte_amplification() {
         let dense_ranges = spaced_ranges(&[1; 99]);
-        assert_eq!(choose_range_plan(&dense_ranges, None).len(), 60);
+        assert_eq!(
+            choose_range_plan(&dense_ranges, None).physical_ranges.len(),
+            60
+        );
 
         let sparse_ranges = spaced_ranges(&[1_000_000; 99]);
-        assert_eq!(choose_range_plan(&sparse_ranges, None).len(), 100);
+        assert_eq!(
+            choose_range_plan(&sparse_ranges, None)
+                .physical_ranges
+                .len(),
+            100
+        );
         assert_eq!(candidate_range_plans(&sparse_ranges, 10).len(), 1);
     }
 

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -272,7 +272,7 @@ mod tests {
 
     use super::{
         RangePlanDecision, TransportEstimate, candidate_range_plans, choose_range_plan,
-        execute_range_plan, merge_ranges, range_bytes,
+        execute_range_plan, merge_ranges, plan_score, range_bytes,
     };
 
     #[test]
@@ -332,6 +332,20 @@ mod tests {
         let merged_plan = choose_range_plan(&requested_ranges, Some(high_bandwidth));
         assert_eq!(merged_plan.physical_ranges.len(), 10);
         assert_eq!(merged_plan.decision, RangePlanDecision::Merged);
+    }
+
+    #[test]
+    fn concurrency_changes_the_request_wave_cost() {
+        let candidates = candidate_range_plans(&spaced_ranges(&[900; 10]), 10);
+        let exact_plan = &candidates[0];
+        let merged_plan = &candidates[1];
+        let estimate = TransportEstimate {
+            request_latency: Duration::from_secs(1),
+            shared_throughput_bytes_per_second: 1_000,
+        };
+
+        assert!(plan_score(exact_plan, estimate, 10) > plan_score(merged_plan, estimate, 10));
+        assert!(plan_score(exact_plan, estimate, 11) < plan_score(merged_plan, estimate, 11));
     }
 
     #[test]

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -1,0 +1,125 @@
+//! Planning and execution helpers for Parquet byte-range reads.
+
+use std::{future::Future, ops::Range};
+
+use bytes::Bytes;
+use futures_util::{StreamExt, TryStreamExt, stream};
+
+const MAX_CONCURRENT_RANGE_READS: usize = 10;
+
+/// Combines overlapping ranges and ranges separated by at most `max_gap` bytes.
+///
+/// The returned ranges are sorted, non-overlapping physical reads. Keeping this
+/// step separate lets the caller choose a plan before any object-store I/O starts.
+pub(super) fn merge_ranges(requested_ranges: &[Range<u64>], max_gap: u64) -> Vec<Range<u64>> {
+    if requested_ranges.is_empty() {
+        return Vec::new();
+    }
+
+    let mut requested_ranges = requested_ranges.to_vec();
+    requested_ranges.sort_unstable_by_key(|range| range.start);
+
+    let mut merged_ranges = Vec::with_capacity(requested_ranges.len());
+    let mut start_index = 0;
+    let mut end_index = 1;
+
+    while start_index != requested_ranges.len() {
+        let mut range_end = requested_ranges[start_index].end;
+        while end_index != requested_ranges.len()
+            && requested_ranges[end_index]
+                .start
+                .checked_sub(range_end)
+                .is_none_or(|gap| gap <= max_gap)
+        {
+            range_end = range_end.max(requested_ranges[end_index].end);
+            end_index += 1;
+        }
+
+        merged_ranges.push(requested_ranges[start_index].start..range_end);
+        start_index = end_index;
+        end_index += 1;
+    }
+
+    merged_ranges
+}
+
+/// Executes an already chosen physical plan and returns one result for each requested range.
+///
+/// Physical reads run with the same concurrency bound as the previous object-store
+/// helper. Results are sliced back into the caller's original order, including duplicate
+/// and overlapping requests.
+pub(super) async fn execute_range_plan<F, E, Fut>(
+    requested_ranges: &[Range<u64>],
+    physical_ranges: &[Range<u64>],
+    read: F,
+) -> Result<Vec<Bytes>, E>
+where
+    F: Send + FnMut(Range<u64>) -> Fut,
+    E: Send,
+    Fut: Future<Output = Result<Bytes, E>> + Send,
+{
+    let bytes: Vec<_> = stream::iter(physical_ranges.iter().cloned())
+        .map(read)
+        .buffered(MAX_CONCURRENT_RANGE_READS)
+        .try_collect()
+        .await?;
+
+    Ok(requested_ranges
+        .iter()
+        .map(|requested_range| {
+            let physical_index =
+                physical_ranges.partition_point(|range| range.start <= requested_range.start) - 1;
+            let physical_range = &physical_ranges[physical_index];
+            let physical_bytes = &bytes[physical_index];
+            let start = (requested_range.start - physical_range.start) as usize;
+            let end = (requested_range.end - physical_range.start) as usize;
+            physical_bytes.slice(start..end.min(physical_bytes.len()))
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use bytes::Bytes;
+
+    use super::{execute_range_plan, merge_ranges};
+
+    #[test]
+    fn merges_unsorted_overlapping_adjacent_and_nearby_ranges() {
+        let requested_ranges = [20..25, 0..4, 4..8, 15..18, 10..12, 2..6];
+
+        assert_eq!(merge_ranges(&requested_ranges, 2), vec![0..12, 15..25]);
+        assert_eq!(
+            merge_ranges(&requested_ranges, 0),
+            vec![0..8, 10..12, 15..18, 20..25]
+        );
+        assert!(merge_ranges(&[], 2).is_empty());
+    }
+
+    #[tokio::test]
+    async fn restores_unsorted_overlapping_duplicate_and_empty_requests() -> Result<(), Infallible>
+    {
+        let requested_ranges = [10..14, 0..4, 2..6, 10..14, 6..6];
+        let physical_ranges = merge_ranges(&requested_ranges, 0);
+        let data = Bytes::from_static(b"0123456789abcdef");
+
+        let results =
+            execute_range_plan(&requested_ranges, &physical_ranges, |range| {
+                let data = data.clone();
+                async move {
+                    Ok::<Bytes, Infallible>(data.slice(range.start as usize..range.end as usize))
+                }
+            })
+            .await?;
+
+        assert_eq!(physical_ranges, vec![0..6, 10..14]);
+        assert_eq!(results[0].as_ref(), b"abcd");
+        assert_eq!(results[1].as_ref(), b"0123");
+        assert_eq!(results[2].as_ref(), b"2345");
+        assert_eq!(results[3].as_ref(), b"abcd");
+        assert!(results[4].is_empty());
+        Ok(())
+    }
+}

--- a/src/reader/metrics.rs
+++ b/src/reader/metrics.rs
@@ -49,6 +49,22 @@ pub struct DeltaScanMetricsSnapshot {
     pub deletion_vector_failures: u64,
     /// Deletion-vector coordinate operations rejected by safety checks.
     pub deletion_vector_coordinate_rejections: u64,
+    /// Normalized exact Parquet ranges requested through direct multi-range calls.
+    pub parquet_data_file_ranges_requested: Option<u64>,
+    /// Bytes in those normalized exact Parquet ranges.
+    pub parquet_data_file_range_bytes_requested: Option<u64>,
+    /// Physical range requests selected by the automatic planner.
+    pub parquet_data_file_range_requests_planned: Option<u64>,
+    /// Bytes covered by those automatically planned physical range requests.
+    pub parquet_data_file_range_bytes_planned: Option<u64>,
+    /// Automatic range plans selected without a usable transport estimate.
+    pub parquet_data_file_cold_start_range_plans: Option<u64>,
+    /// Automatic range plans where an estimate favored the normalized exact ranges.
+    pub parquet_data_file_exact_range_plans: Option<u64>,
+    /// Automatic range plans where an estimate favored merging gaps between exact ranges.
+    pub parquet_data_file_merged_range_plans: Option<u64>,
+    /// Multi-range calls delegated to the store's own implementation.
+    pub parquet_data_file_store_delegated_range_calls: Option<u64>,
     /// Direct Parquet ranged GET operations, or `None` for another backend.
     pub parquet_data_file_range_get_operations: Option<u64>,
     /// Direct Parquet full GET operations, or `None` for another backend.
@@ -92,6 +108,14 @@ struct DeltaScanMetricsInner {
     deletion_vector_rows_deleted: AtomicU64,
     deletion_vector_failures: AtomicU64,
     deletion_vector_coordinate_rejections: AtomicU64,
+    parquet_data_file_ranges_requested: AtomicU64,
+    parquet_data_file_range_bytes_requested: AtomicU64,
+    parquet_data_file_range_requests_planned: AtomicU64,
+    parquet_data_file_range_bytes_planned: AtomicU64,
+    parquet_data_file_cold_start_range_plans: AtomicU64,
+    parquet_data_file_exact_range_plans: AtomicU64,
+    parquet_data_file_merged_range_plans: AtomicU64,
+    parquet_data_file_store_delegated_range_calls: AtomicU64,
     parquet_data_file_range_get_operations: AtomicU64,
     parquet_data_file_full_get_operations: AtomicU64,
     parquet_data_file_bytes_received: AtomicU64,
@@ -134,6 +158,14 @@ impl DeltaScanMetrics {
                 deletion_vector_rows_deleted: AtomicU64::new(0),
                 deletion_vector_failures: AtomicU64::new(0),
                 deletion_vector_coordinate_rejections: AtomicU64::new(0),
+                parquet_data_file_ranges_requested: AtomicU64::new(0),
+                parquet_data_file_range_bytes_requested: AtomicU64::new(0),
+                parquet_data_file_range_requests_planned: AtomicU64::new(0),
+                parquet_data_file_range_bytes_planned: AtomicU64::new(0),
+                parquet_data_file_cold_start_range_plans: AtomicU64::new(0),
+                parquet_data_file_exact_range_plans: AtomicU64::new(0),
+                parquet_data_file_merged_range_plans: AtomicU64::new(0),
+                parquet_data_file_store_delegated_range_calls: AtomicU64::new(0),
                 parquet_data_file_range_get_operations: AtomicU64::new(0),
                 parquet_data_file_full_get_operations: AtomicU64::new(0),
                 parquet_data_file_bytes_received: AtomicU64::new(0),
@@ -166,6 +198,22 @@ impl DeltaScanMetrics {
             deletion_vector_coordinate_rejections: load(
                 &inner.deletion_vector_coordinate_rejections,
             ),
+            parquet_data_file_ranges_requested: self
+                .parquet_metric(&inner.parquet_data_file_ranges_requested),
+            parquet_data_file_range_bytes_requested: self
+                .parquet_metric(&inner.parquet_data_file_range_bytes_requested),
+            parquet_data_file_range_requests_planned: self
+                .parquet_metric(&inner.parquet_data_file_range_requests_planned),
+            parquet_data_file_range_bytes_planned: self
+                .parquet_metric(&inner.parquet_data_file_range_bytes_planned),
+            parquet_data_file_cold_start_range_plans: self
+                .parquet_metric(&inner.parquet_data_file_cold_start_range_plans),
+            parquet_data_file_exact_range_plans: self
+                .parquet_metric(&inner.parquet_data_file_exact_range_plans),
+            parquet_data_file_merged_range_plans: self
+                .parquet_metric(&inner.parquet_data_file_merged_range_plans),
+            parquet_data_file_store_delegated_range_calls: self
+                .parquet_metric(&inner.parquet_data_file_store_delegated_range_calls),
             parquet_data_file_range_get_operations: self
                 .parquet_metric(&inner.parquet_data_file_range_get_operations),
             parquet_data_file_full_get_operations: self
@@ -248,6 +296,48 @@ impl DeltaScanMetrics {
         saturating_fetch_add(&self.inner.deletion_vector_coordinate_rejections, 1);
     }
 
+    pub(crate) fn record_parquet_data_file_ranges_requested(
+        &self,
+        range_count: usize,
+        bytes: u128,
+    ) {
+        saturating_fetch_add(
+            &self.inner.parquet_data_file_ranges_requested,
+            usize_to_u64_saturating(range_count),
+        );
+        saturating_fetch_add(
+            &self.inner.parquet_data_file_range_bytes_requested,
+            u128_to_u64_saturating(bytes),
+        );
+    }
+
+    pub(crate) fn record_parquet_data_file_range_plan(&self, request_count: usize, bytes: u128) {
+        saturating_fetch_add(
+            &self.inner.parquet_data_file_range_requests_planned,
+            usize_to_u64_saturating(request_count),
+        );
+        saturating_fetch_add(
+            &self.inner.parquet_data_file_range_bytes_planned,
+            u128_to_u64_saturating(bytes),
+        );
+    }
+
+    pub(crate) fn record_parquet_data_file_cold_start_range_plan(&self) {
+        saturating_fetch_add(&self.inner.parquet_data_file_cold_start_range_plans, 1);
+    }
+
+    pub(crate) fn record_parquet_data_file_exact_range_plan(&self) {
+        saturating_fetch_add(&self.inner.parquet_data_file_exact_range_plans, 1);
+    }
+
+    pub(crate) fn record_parquet_data_file_merged_range_plan(&self) {
+        saturating_fetch_add(&self.inner.parquet_data_file_merged_range_plans, 1);
+    }
+
+    pub(crate) fn record_parquet_data_file_store_delegated_range_call(&self) {
+        saturating_fetch_add(&self.inner.parquet_data_file_store_delegated_range_calls, 1);
+    }
+
     pub(crate) fn record_parquet_data_file_range_get_operation(&self) {
         saturating_fetch_add(&self.inner.parquet_data_file_range_get_operations, 1);
     }
@@ -280,6 +370,10 @@ pub(crate) fn saturating_fetch_add(counter: &AtomicU64, value: u64) {
 }
 
 fn usize_to_u64_saturating(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn u128_to_u64_saturating(value: u128) -> u64 {
     u64::try_from(value).unwrap_or(u64::MAX)
 }
 
@@ -323,12 +417,31 @@ mod tests {
         assert_eq!(direct.deletion_vector_rows_deleted, 0);
         assert_eq!(direct.deletion_vector_failures, 0);
         assert_eq!(direct.deletion_vector_coordinate_rejections, 0);
+        assert_eq!(direct.parquet_data_file_ranges_requested, Some(0));
+        assert_eq!(direct.parquet_data_file_range_bytes_requested, Some(0));
+        assert_eq!(direct.parquet_data_file_range_requests_planned, Some(0));
+        assert_eq!(direct.parquet_data_file_range_bytes_planned, Some(0));
+        assert_eq!(direct.parquet_data_file_cold_start_range_plans, Some(0));
+        assert_eq!(direct.parquet_data_file_exact_range_plans, Some(0));
+        assert_eq!(direct.parquet_data_file_merged_range_plans, Some(0));
+        assert_eq!(
+            direct.parquet_data_file_store_delegated_range_calls,
+            Some(0)
+        );
         assert_eq!(direct.parquet_data_file_range_get_operations, Some(0));
         assert_eq!(direct.parquet_data_file_full_get_operations, Some(0));
         assert_eq!(direct.parquet_data_file_bytes_received, Some(0));
         assert_eq!(direct.estimated_parquet_task_bytes_admitted, Some(0));
 
         let kernel = metrics(ParquetReaderBackend::DeltaKernel).snapshot();
+        assert_eq!(kernel.parquet_data_file_ranges_requested, None);
+        assert_eq!(kernel.parquet_data_file_range_bytes_requested, None);
+        assert_eq!(kernel.parquet_data_file_range_requests_planned, None);
+        assert_eq!(kernel.parquet_data_file_range_bytes_planned, None);
+        assert_eq!(kernel.parquet_data_file_cold_start_range_plans, None);
+        assert_eq!(kernel.parquet_data_file_exact_range_plans, None);
+        assert_eq!(kernel.parquet_data_file_merged_range_plans, None);
+        assert_eq!(kernel.parquet_data_file_store_delegated_range_calls, None);
         assert_eq!(kernel.parquet_data_file_range_get_operations, None);
         assert_eq!(kernel.parquet_data_file_full_get_operations, None);
         assert_eq!(kernel.parquet_data_file_bytes_received, None);
@@ -359,6 +472,14 @@ mod tests {
             &metrics.inner.deletion_vector_rows_deleted,
             &metrics.inner.deletion_vector_failures,
             &metrics.inner.deletion_vector_coordinate_rejections,
+            &metrics.inner.parquet_data_file_ranges_requested,
+            &metrics.inner.parquet_data_file_range_bytes_requested,
+            &metrics.inner.parquet_data_file_range_requests_planned,
+            &metrics.inner.parquet_data_file_range_bytes_planned,
+            &metrics.inner.parquet_data_file_cold_start_range_plans,
+            &metrics.inner.parquet_data_file_exact_range_plans,
+            &metrics.inner.parquet_data_file_merged_range_plans,
+            &metrics.inner.parquet_data_file_store_delegated_range_calls,
             &metrics.inner.parquet_data_file_range_get_operations,
             &metrics.inner.parquet_data_file_full_get_operations,
             &metrics.inner.parquet_data_file_bytes_received,
@@ -381,10 +502,21 @@ mod tests {
         assert_eq!(snapshot.deletion_vector_rows_deleted, 9);
         assert_eq!(snapshot.deletion_vector_failures, 10);
         assert_eq!(snapshot.deletion_vector_coordinate_rejections, 11);
-        assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(12));
-        assert_eq!(snapshot.parquet_data_file_full_get_operations, Some(13));
-        assert_eq!(snapshot.parquet_data_file_bytes_received, Some(14));
-        assert_eq!(snapshot.estimated_parquet_task_bytes_admitted, Some(15));
+        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(12));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(13));
+        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(14));
+        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(15));
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(16));
+        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(17));
+        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(18));
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_calls,
+            Some(19)
+        );
+        assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(20));
+        assert_eq!(snapshot.parquet_data_file_full_get_operations, Some(21));
+        assert_eq!(snapshot.parquet_data_file_bytes_received, Some(22));
+        assert_eq!(snapshot.estimated_parquet_task_bytes_admitted, Some(23));
     }
 
     #[test]

--- a/src/reader/metrics.rs
+++ b/src/reader/metrics.rs
@@ -50,21 +50,21 @@ pub struct DeltaScanMetricsSnapshot {
     /// Deletion-vector coordinate operations rejected by safety checks.
     pub deletion_vector_coordinate_rejections: u64,
     /// Normalized exact Parquet ranges requested through direct multi-range calls.
-    pub parquet_data_file_ranges_requested: Option<u64>,
+    pub parquet_data_file_exact_ranges_requested: Option<u64>,
     /// Bytes in those normalized exact Parquet ranges.
-    pub parquet_data_file_range_bytes_requested: Option<u64>,
+    pub parquet_data_file_exact_range_bytes_requested: Option<u64>,
     /// Physical range requests selected by the automatic planner.
-    pub parquet_data_file_range_requests_planned: Option<u64>,
+    pub parquet_data_file_physical_range_requests_planned: Option<u64>,
     /// Bytes covered by those automatically planned physical range requests.
-    pub parquet_data_file_range_bytes_planned: Option<u64>,
+    pub parquet_data_file_physical_range_bytes_planned: Option<u64>,
     /// Automatic range plans selected without a usable transport estimate.
     pub parquet_data_file_cold_start_range_plans: Option<u64>,
     /// Automatic range plans where an estimate favored the normalized exact ranges.
-    pub parquet_data_file_exact_range_plans: Option<u64>,
+    pub parquet_data_file_cost_based_exact_range_plans: Option<u64>,
     /// Automatic range plans where an estimate favored merging gaps between exact ranges.
-    pub parquet_data_file_merged_range_plans: Option<u64>,
-    /// Multi-range calls delegated to the store's own implementation.
-    pub parquet_data_file_store_delegated_range_calls: Option<u64>,
+    pub parquet_data_file_cost_based_merged_range_plans: Option<u64>,
+    /// Range-planning decisions delegated to the store's own implementation.
+    pub parquet_data_file_store_delegated_range_plans: Option<u64>,
     /// Direct Parquet ranged GET operations, or `None` for another backend.
     pub parquet_data_file_range_get_operations: Option<u64>,
     /// Direct Parquet full GET operations, or `None` for another backend.
@@ -108,14 +108,14 @@ struct DeltaScanMetricsInner {
     deletion_vector_rows_deleted: AtomicU64,
     deletion_vector_failures: AtomicU64,
     deletion_vector_coordinate_rejections: AtomicU64,
-    parquet_data_file_ranges_requested: AtomicU64,
-    parquet_data_file_range_bytes_requested: AtomicU64,
-    parquet_data_file_range_requests_planned: AtomicU64,
-    parquet_data_file_range_bytes_planned: AtomicU64,
+    parquet_data_file_exact_ranges_requested: AtomicU64,
+    parquet_data_file_exact_range_bytes_requested: AtomicU64,
+    parquet_data_file_physical_range_requests_planned: AtomicU64,
+    parquet_data_file_physical_range_bytes_planned: AtomicU64,
     parquet_data_file_cold_start_range_plans: AtomicU64,
-    parquet_data_file_exact_range_plans: AtomicU64,
-    parquet_data_file_merged_range_plans: AtomicU64,
-    parquet_data_file_store_delegated_range_calls: AtomicU64,
+    parquet_data_file_cost_based_exact_range_plans: AtomicU64,
+    parquet_data_file_cost_based_merged_range_plans: AtomicU64,
+    parquet_data_file_store_delegated_range_plans: AtomicU64,
     parquet_data_file_range_get_operations: AtomicU64,
     parquet_data_file_full_get_operations: AtomicU64,
     parquet_data_file_bytes_received: AtomicU64,
@@ -158,14 +158,14 @@ impl DeltaScanMetrics {
                 deletion_vector_rows_deleted: AtomicU64::new(0),
                 deletion_vector_failures: AtomicU64::new(0),
                 deletion_vector_coordinate_rejections: AtomicU64::new(0),
-                parquet_data_file_ranges_requested: AtomicU64::new(0),
-                parquet_data_file_range_bytes_requested: AtomicU64::new(0),
-                parquet_data_file_range_requests_planned: AtomicU64::new(0),
-                parquet_data_file_range_bytes_planned: AtomicU64::new(0),
+                parquet_data_file_exact_ranges_requested: AtomicU64::new(0),
+                parquet_data_file_exact_range_bytes_requested: AtomicU64::new(0),
+                parquet_data_file_physical_range_requests_planned: AtomicU64::new(0),
+                parquet_data_file_physical_range_bytes_planned: AtomicU64::new(0),
                 parquet_data_file_cold_start_range_plans: AtomicU64::new(0),
-                parquet_data_file_exact_range_plans: AtomicU64::new(0),
-                parquet_data_file_merged_range_plans: AtomicU64::new(0),
-                parquet_data_file_store_delegated_range_calls: AtomicU64::new(0),
+                parquet_data_file_cost_based_exact_range_plans: AtomicU64::new(0),
+                parquet_data_file_cost_based_merged_range_plans: AtomicU64::new(0),
+                parquet_data_file_store_delegated_range_plans: AtomicU64::new(0),
                 parquet_data_file_range_get_operations: AtomicU64::new(0),
                 parquet_data_file_full_get_operations: AtomicU64::new(0),
                 parquet_data_file_bytes_received: AtomicU64::new(0),
@@ -198,22 +198,22 @@ impl DeltaScanMetrics {
             deletion_vector_coordinate_rejections: load(
                 &inner.deletion_vector_coordinate_rejections,
             ),
-            parquet_data_file_ranges_requested: self
-                .parquet_metric(&inner.parquet_data_file_ranges_requested),
-            parquet_data_file_range_bytes_requested: self
-                .parquet_metric(&inner.parquet_data_file_range_bytes_requested),
-            parquet_data_file_range_requests_planned: self
-                .parquet_metric(&inner.parquet_data_file_range_requests_planned),
-            parquet_data_file_range_bytes_planned: self
-                .parquet_metric(&inner.parquet_data_file_range_bytes_planned),
+            parquet_data_file_exact_ranges_requested: self
+                .parquet_metric(&inner.parquet_data_file_exact_ranges_requested),
+            parquet_data_file_exact_range_bytes_requested: self
+                .parquet_metric(&inner.parquet_data_file_exact_range_bytes_requested),
+            parquet_data_file_physical_range_requests_planned: self
+                .parquet_metric(&inner.parquet_data_file_physical_range_requests_planned),
+            parquet_data_file_physical_range_bytes_planned: self
+                .parquet_metric(&inner.parquet_data_file_physical_range_bytes_planned),
             parquet_data_file_cold_start_range_plans: self
                 .parquet_metric(&inner.parquet_data_file_cold_start_range_plans),
-            parquet_data_file_exact_range_plans: self
-                .parquet_metric(&inner.parquet_data_file_exact_range_plans),
-            parquet_data_file_merged_range_plans: self
-                .parquet_metric(&inner.parquet_data_file_merged_range_plans),
-            parquet_data_file_store_delegated_range_calls: self
-                .parquet_metric(&inner.parquet_data_file_store_delegated_range_calls),
+            parquet_data_file_cost_based_exact_range_plans: self
+                .parquet_metric(&inner.parquet_data_file_cost_based_exact_range_plans),
+            parquet_data_file_cost_based_merged_range_plans: self
+                .parquet_metric(&inner.parquet_data_file_cost_based_merged_range_plans),
+            parquet_data_file_store_delegated_range_plans: self
+                .parquet_metric(&inner.parquet_data_file_store_delegated_range_plans),
             parquet_data_file_range_get_operations: self
                 .parquet_metric(&inner.parquet_data_file_range_get_operations),
             parquet_data_file_full_get_operations: self
@@ -296,28 +296,32 @@ impl DeltaScanMetrics {
         saturating_fetch_add(&self.inner.deletion_vector_coordinate_rejections, 1);
     }
 
-    pub(crate) fn record_parquet_data_file_ranges_requested(
+    pub(crate) fn record_parquet_data_file_exact_ranges_requested(
         &self,
         range_count: usize,
         bytes: u128,
     ) {
         saturating_fetch_add(
-            &self.inner.parquet_data_file_ranges_requested,
+            &self.inner.parquet_data_file_exact_ranges_requested,
             usize_to_u64_saturating(range_count),
         );
         saturating_fetch_add(
-            &self.inner.parquet_data_file_range_bytes_requested,
+            &self.inner.parquet_data_file_exact_range_bytes_requested,
             u128_to_u64_saturating(bytes),
         );
     }
 
-    pub(crate) fn record_parquet_data_file_range_plan(&self, request_count: usize, bytes: u128) {
+    pub(crate) fn record_parquet_data_file_physical_range_plan(
+        &self,
+        request_count: usize,
+        bytes: u128,
+    ) {
         saturating_fetch_add(
-            &self.inner.parquet_data_file_range_requests_planned,
+            &self.inner.parquet_data_file_physical_range_requests_planned,
             usize_to_u64_saturating(request_count),
         );
         saturating_fetch_add(
-            &self.inner.parquet_data_file_range_bytes_planned,
+            &self.inner.parquet_data_file_physical_range_bytes_planned,
             u128_to_u64_saturating(bytes),
         );
     }
@@ -326,16 +330,22 @@ impl DeltaScanMetrics {
         saturating_fetch_add(&self.inner.parquet_data_file_cold_start_range_plans, 1);
     }
 
-    pub(crate) fn record_parquet_data_file_exact_range_plan(&self) {
-        saturating_fetch_add(&self.inner.parquet_data_file_exact_range_plans, 1);
+    pub(crate) fn record_parquet_data_file_cost_based_exact_range_plan(&self) {
+        saturating_fetch_add(
+            &self.inner.parquet_data_file_cost_based_exact_range_plans,
+            1,
+        );
     }
 
-    pub(crate) fn record_parquet_data_file_merged_range_plan(&self) {
-        saturating_fetch_add(&self.inner.parquet_data_file_merged_range_plans, 1);
+    pub(crate) fn record_parquet_data_file_cost_based_merged_range_plan(&self) {
+        saturating_fetch_add(
+            &self.inner.parquet_data_file_cost_based_merged_range_plans,
+            1,
+        );
     }
 
-    pub(crate) fn record_parquet_data_file_store_delegated_range_call(&self) {
-        saturating_fetch_add(&self.inner.parquet_data_file_store_delegated_range_calls, 1);
+    pub(crate) fn record_parquet_data_file_store_delegated_range_plan(&self) {
+        saturating_fetch_add(&self.inner.parquet_data_file_store_delegated_range_plans, 1);
     }
 
     pub(crate) fn record_parquet_data_file_range_get_operation(&self) {
@@ -417,15 +427,30 @@ mod tests {
         assert_eq!(direct.deletion_vector_rows_deleted, 0);
         assert_eq!(direct.deletion_vector_failures, 0);
         assert_eq!(direct.deletion_vector_coordinate_rejections, 0);
-        assert_eq!(direct.parquet_data_file_ranges_requested, Some(0));
-        assert_eq!(direct.parquet_data_file_range_bytes_requested, Some(0));
-        assert_eq!(direct.parquet_data_file_range_requests_planned, Some(0));
-        assert_eq!(direct.parquet_data_file_range_bytes_planned, Some(0));
-        assert_eq!(direct.parquet_data_file_cold_start_range_plans, Some(0));
-        assert_eq!(direct.parquet_data_file_exact_range_plans, Some(0));
-        assert_eq!(direct.parquet_data_file_merged_range_plans, Some(0));
+        assert_eq!(direct.parquet_data_file_exact_ranges_requested, Some(0));
         assert_eq!(
-            direct.parquet_data_file_store_delegated_range_calls,
+            direct.parquet_data_file_exact_range_bytes_requested,
+            Some(0)
+        );
+        assert_eq!(
+            direct.parquet_data_file_physical_range_requests_planned,
+            Some(0)
+        );
+        assert_eq!(
+            direct.parquet_data_file_physical_range_bytes_planned,
+            Some(0)
+        );
+        assert_eq!(direct.parquet_data_file_cold_start_range_plans, Some(0));
+        assert_eq!(
+            direct.parquet_data_file_cost_based_exact_range_plans,
+            Some(0)
+        );
+        assert_eq!(
+            direct.parquet_data_file_cost_based_merged_range_plans,
+            Some(0)
+        );
+        assert_eq!(
+            direct.parquet_data_file_store_delegated_range_plans,
             Some(0)
         );
         assert_eq!(direct.parquet_data_file_range_get_operations, Some(0));
@@ -434,14 +459,17 @@ mod tests {
         assert_eq!(direct.estimated_parquet_task_bytes_admitted, Some(0));
 
         let kernel = metrics(ParquetReaderBackend::DeltaKernel).snapshot();
-        assert_eq!(kernel.parquet_data_file_ranges_requested, None);
-        assert_eq!(kernel.parquet_data_file_range_bytes_requested, None);
-        assert_eq!(kernel.parquet_data_file_range_requests_planned, None);
-        assert_eq!(kernel.parquet_data_file_range_bytes_planned, None);
+        assert_eq!(kernel.parquet_data_file_exact_ranges_requested, None);
+        assert_eq!(kernel.parquet_data_file_exact_range_bytes_requested, None);
+        assert_eq!(
+            kernel.parquet_data_file_physical_range_requests_planned,
+            None
+        );
+        assert_eq!(kernel.parquet_data_file_physical_range_bytes_planned, None);
         assert_eq!(kernel.parquet_data_file_cold_start_range_plans, None);
-        assert_eq!(kernel.parquet_data_file_exact_range_plans, None);
-        assert_eq!(kernel.parquet_data_file_merged_range_plans, None);
-        assert_eq!(kernel.parquet_data_file_store_delegated_range_calls, None);
+        assert_eq!(kernel.parquet_data_file_cost_based_exact_range_plans, None);
+        assert_eq!(kernel.parquet_data_file_cost_based_merged_range_plans, None);
+        assert_eq!(kernel.parquet_data_file_store_delegated_range_plans, None);
         assert_eq!(kernel.parquet_data_file_range_get_operations, None);
         assert_eq!(kernel.parquet_data_file_full_get_operations, None);
         assert_eq!(kernel.parquet_data_file_bytes_received, None);
@@ -472,14 +500,18 @@ mod tests {
             &metrics.inner.deletion_vector_rows_deleted,
             &metrics.inner.deletion_vector_failures,
             &metrics.inner.deletion_vector_coordinate_rejections,
-            &metrics.inner.parquet_data_file_ranges_requested,
-            &metrics.inner.parquet_data_file_range_bytes_requested,
-            &metrics.inner.parquet_data_file_range_requests_planned,
-            &metrics.inner.parquet_data_file_range_bytes_planned,
+            &metrics.inner.parquet_data_file_exact_ranges_requested,
+            &metrics.inner.parquet_data_file_exact_range_bytes_requested,
+            &metrics
+                .inner
+                .parquet_data_file_physical_range_requests_planned,
+            &metrics.inner.parquet_data_file_physical_range_bytes_planned,
             &metrics.inner.parquet_data_file_cold_start_range_plans,
-            &metrics.inner.parquet_data_file_exact_range_plans,
-            &metrics.inner.parquet_data_file_merged_range_plans,
-            &metrics.inner.parquet_data_file_store_delegated_range_calls,
+            &metrics.inner.parquet_data_file_cost_based_exact_range_plans,
+            &metrics
+                .inner
+                .parquet_data_file_cost_based_merged_range_plans,
+            &metrics.inner.parquet_data_file_store_delegated_range_plans,
             &metrics.inner.parquet_data_file_range_get_operations,
             &metrics.inner.parquet_data_file_full_get_operations,
             &metrics.inner.parquet_data_file_bytes_received,
@@ -502,15 +534,30 @@ mod tests {
         assert_eq!(snapshot.deletion_vector_rows_deleted, 9);
         assert_eq!(snapshot.deletion_vector_failures, 10);
         assert_eq!(snapshot.deletion_vector_coordinate_rejections, 11);
-        assert_eq!(snapshot.parquet_data_file_ranges_requested, Some(12));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_requested, Some(13));
-        assert_eq!(snapshot.parquet_data_file_range_requests_planned, Some(14));
-        assert_eq!(snapshot.parquet_data_file_range_bytes_planned, Some(15));
-        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(16));
-        assert_eq!(snapshot.parquet_data_file_exact_range_plans, Some(17));
-        assert_eq!(snapshot.parquet_data_file_merged_range_plans, Some(18));
+        assert_eq!(snapshot.parquet_data_file_exact_ranges_requested, Some(12));
         assert_eq!(
-            snapshot.parquet_data_file_store_delegated_range_calls,
+            snapshot.parquet_data_file_exact_range_bytes_requested,
+            Some(13)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_requests_planned,
+            Some(14)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_physical_range_bytes_planned,
+            Some(15)
+        );
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(16));
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_exact_range_plans,
+            Some(17)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_cost_based_merged_range_plans,
+            Some(18)
+        );
+        assert_eq!(
+            snapshot.parquet_data_file_store_delegated_range_plans,
             Some(19)
         );
         assert_eq!(snapshot.parquet_data_file_range_get_operations, Some(20));

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -27,6 +27,14 @@ fn configuration_and_error_contract_is_public() -> Result<(), DeltaReaderError> 
         let _: u64 = snapshot.scheduler_batches_emitted;
         let _: u64 = snapshot.scheduler_rows_emitted;
         let _: u64 = snapshot.deletion_vector_coordinate_rejections;
+        let _: Option<u64> = snapshot.parquet_data_file_ranges_requested;
+        let _: Option<u64> = snapshot.parquet_data_file_range_bytes_requested;
+        let _: Option<u64> = snapshot.parquet_data_file_range_requests_planned;
+        let _: Option<u64> = snapshot.parquet_data_file_range_bytes_planned;
+        let _: Option<u64> = snapshot.parquet_data_file_cold_start_range_plans;
+        let _: Option<u64> = snapshot.parquet_data_file_exact_range_plans;
+        let _: Option<u64> = snapshot.parquet_data_file_merged_range_plans;
+        let _: Option<u64> = snapshot.parquet_data_file_store_delegated_range_calls;
         let _: Option<u64> = snapshot.estimated_parquet_task_bytes_admitted;
     }
     let _ = snapshot;

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -27,14 +27,14 @@ fn configuration_and_error_contract_is_public() -> Result<(), DeltaReaderError> 
         let _: u64 = snapshot.scheduler_batches_emitted;
         let _: u64 = snapshot.scheduler_rows_emitted;
         let _: u64 = snapshot.deletion_vector_coordinate_rejections;
-        let _: Option<u64> = snapshot.parquet_data_file_ranges_requested;
-        let _: Option<u64> = snapshot.parquet_data_file_range_bytes_requested;
-        let _: Option<u64> = snapshot.parquet_data_file_range_requests_planned;
-        let _: Option<u64> = snapshot.parquet_data_file_range_bytes_planned;
+        let _: Option<u64> = snapshot.parquet_data_file_exact_ranges_requested;
+        let _: Option<u64> = snapshot.parquet_data_file_exact_range_bytes_requested;
+        let _: Option<u64> = snapshot.parquet_data_file_physical_range_requests_planned;
+        let _: Option<u64> = snapshot.parquet_data_file_physical_range_bytes_planned;
         let _: Option<u64> = snapshot.parquet_data_file_cold_start_range_plans;
-        let _: Option<u64> = snapshot.parquet_data_file_exact_range_plans;
-        let _: Option<u64> = snapshot.parquet_data_file_merged_range_plans;
-        let _: Option<u64> = snapshot.parquet_data_file_store_delegated_range_calls;
+        let _: Option<u64> = snapshot.parquet_data_file_cost_based_exact_range_plans;
+        let _: Option<u64> = snapshot.parquet_data_file_cost_based_merged_range_plans;
+        let _: Option<u64> = snapshot.parquet_data_file_store_delegated_range_plans;
         let _: Option<u64> = snapshot.estimated_parquet_task_bytes_admitted;
     }
     let _ = snapshot;


### PR DESCRIPTION
## Summary

- choose exact or merged Parquet byte ranges from recent request latency and shared throughput
- preserve native multi-range behavior for local, in-memory, and custom stores
- expose exact, planned, received, and decision metrics using bounded, cancellation-safe observations

## Validation

- `cargo test --locked`
- `cargo test --locked --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `cargo package --locked`
- `python -m zensical build --strict -f docs/mkdocs.yml`

Part of #64