### PR TITLE
fix: stabilize Parquet range benchmarks on Windows

### DIFF
--- a/benches/range_planning.rs
+++ b/benches/range_planning.rs
@@ -7,7 +7,10 @@ use std::{
     fs::{self, File},
     io,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -36,6 +39,7 @@ const MATCH_VALUE: &str = "match";
 const OTHER_VALUE: &str = "other";
 const DEFAULT_REPETITIONS: usize = 3;
 const MAX_REPETITIONS: usize = 128;
+static NEXT_FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
 const BENCHMARK_SHAPE: FixtureShape = FixtureShape {
     data_files: 4,
     row_groups: 2,
@@ -332,11 +336,10 @@ impl Fixture {
         retain: bool,
     ) -> Result<Self, Box<dyn Error>> {
         shape.validate()?;
-        let path = temp_root.join(format!(
-            "delta-arrow-reader-range-planning-{}-{}",
-            std::process::id(),
+        let path = fixture_path(
+            temp_root,
             SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos(),
-        ));
+        );
         fs::create_dir_all(path.join("_delta_log"))?;
 
         let schema = benchmark_schema(shape.payload_columns);
@@ -385,6 +388,14 @@ impl Fixture {
             retain,
         })
     }
+}
+
+fn fixture_path(temp_root: &Path, created_at_nanos: u128) -> PathBuf {
+    let sequence = NEXT_FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
+    temp_root.join(format!(
+        "delta-arrow-reader-range-planning-{}-{created_at_nanos}-{sequence}",
+        std::process::id(),
+    ))
 }
 
 impl Drop for Fixture {
@@ -929,20 +940,15 @@ mod tests {
                 .await?;
             let mut measurements = Vec::new();
             for policy in BenchmarkPolicy::ALL {
-                measurements.push(
-                    measure_case(
-                        &fixture,
-                        &table,
-                        TEST_SHAPE,
-                        BenchmarkCase {
-                            profile: TEST_PROFILE,
-                            density: ProjectionDensity::Sparse,
-                            policy,
-                        },
-                        1,
-                    )
-                    .await?,
-                );
+                let case = BenchmarkCase {
+                    profile: TEST_PROFILE,
+                    density: ProjectionDensity::Sparse,
+                    policy,
+                };
+                let measurement = measure_case(&fixture, &table, TEST_SHAPE, case, 1)
+                    .await
+                    .map_err(|error| benchmark_test_error(case, error.as_ref()))?;
+                measurements.push(measurement);
             }
             let first = measurements
                 .first()
@@ -994,5 +1000,50 @@ mod tests {
                 "high_latency_high_throughput"
             ]
         );
+    }
+
+    #[test]
+    fn fixture_paths_are_unique_when_the_clock_does_not_advance() {
+        let temp_root = Path::new("benchmark-fixtures");
+        let first = fixture_path(temp_root, 123);
+        let second = fixture_path(temp_root, 123);
+
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), Some(temp_root));
+        assert_eq!(second.parent(), Some(temp_root));
+    }
+
+    fn benchmark_test_error(case: BenchmarkCase, error: &(dyn Error + 'static)) -> io::Error {
+        let mut message = format!(
+            "range benchmark failed: profile={} projection={} policy={}: {error}",
+            case.profile.name,
+            case.density.name(),
+            case.policy.name(),
+        );
+        let mut source = error.source();
+        while let Some(error) = source {
+            message.push_str("\ncaused by: ");
+            message.push_str(&error.to_string());
+            source = error.source();
+        }
+        io::Error::other(message)
+    }
+
+    #[test]
+    fn benchmark_test_errors_include_the_case_and_source_chain() {
+        let source = io::Error::new(io::ErrorKind::ConnectionReset, "connection reset by peer");
+        let error = parquet::errors::ParquetError::External(Box::new(source));
+        let reported = benchmark_test_error(
+            BenchmarkCase {
+                profile: TEST_PROFILE,
+                density: ProjectionDensity::Sparse,
+                policy: BenchmarkPolicy::ExactRanges,
+            },
+            &error,
+        )
+        .to_string();
+
+        assert!(reported.contains("profile=test projection=sparse policy=exact_ranges"));
+        assert!(reported.contains("\ncaused by: connection reset by peer"));
     }
 }

--- a/benches/range_planning.rs
+++ b/benches/range_planning.rs
@@ -379,12 +379,7 @@ impl Fixture {
         Ok(Self {
             path,
             table_uri,
-            // The controlled server closes every HTTP response. Do not return those connections
-            // to the client pool, where they can be reused before the close is observed.
-            storage_options: BTreeMap::from([
-                ("allow_http".to_owned(), "true".to_owned()),
-                ("pool_max_idle_per_host".to_owned(), "0".to_owned()),
-            ]),
+            storage_options: BTreeMap::from([("allow_http".to_owned(), "true".to_owned())]),
             server,
             data_file_bytes,
             retain,

--- a/benches/range_planning.rs
+++ b/benches/range_planning.rs
@@ -7,10 +7,7 @@ use std::{
     fs::{self, File},
     io,
     path::{Path, PathBuf},
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::Arc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -39,7 +36,6 @@ const MATCH_VALUE: &str = "match";
 const OTHER_VALUE: &str = "other";
 const DEFAULT_REPETITIONS: usize = 3;
 const MAX_REPETITIONS: usize = 128;
-static NEXT_FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
 const BENCHMARK_SHAPE: FixtureShape = FixtureShape {
     data_files: 4,
     row_groups: 2,
@@ -336,10 +332,11 @@ impl Fixture {
         retain: bool,
     ) -> Result<Self, Box<dyn Error>> {
         shape.validate()?;
-        let path = fixture_path(
-            temp_root,
+        let path = temp_root.join(format!(
+            "delta-arrow-reader-range-planning-{}-{}",
+            std::process::id(),
             SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos(),
-        );
+        ));
         fs::create_dir_all(path.join("_delta_log"))?;
 
         let schema = benchmark_schema(shape.payload_columns);
@@ -382,20 +379,17 @@ impl Fixture {
         Ok(Self {
             path,
             table_uri,
-            storage_options: BTreeMap::from([("allow_http".to_owned(), "true".to_owned())]),
+            // The controlled server closes every HTTP response. Do not return those connections
+            // to the client pool, where they can be reused before the close is observed.
+            storage_options: BTreeMap::from([
+                ("allow_http".to_owned(), "true".to_owned()),
+                ("pool_max_idle_per_host".to_owned(), "0".to_owned()),
+            ]),
             server,
             data_file_bytes,
             retain,
         })
     }
-}
-
-fn fixture_path(temp_root: &Path, created_at_nanos: u128) -> PathBuf {
-    let sequence = NEXT_FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
-    temp_root.join(format!(
-        "delta-arrow-reader-range-planning-{}-{created_at_nanos}-{sequence}",
-        std::process::id(),
-    ))
 }
 
 impl Drop for Fixture {
@@ -1000,17 +994,6 @@ mod tests {
                 "high_latency_high_throughput"
             ]
         );
-    }
-
-    #[test]
-    fn fixture_paths_are_unique_when_the_clock_does_not_advance() {
-        let temp_root = Path::new("benchmark-fixtures");
-        let first = fixture_path(temp_root, 123);
-        let second = fixture_path(temp_root, 123);
-
-        assert_ne!(first, second);
-        assert_eq!(first.parent(), Some(temp_root));
-        assert_eq!(second.parent(), Some(temp_root));
     }
 
     fn benchmark_test_error(case: BenchmarkCase, error: &(dyn Error + 'static)) -> io::Error {

--- a/benches/range_planning/controlled_http.rs
+++ b/benches/range_planning/controlled_http.rs
@@ -107,6 +107,12 @@ fn serve_http(
     while !shutdown.load(Ordering::Relaxed) {
         match listener.accept() {
             Ok((stream, _)) => {
+                // The listener is nonblocking so shutdown can be polled. Request handlers use
+                // blocking I/O, and Windows can return accepted sockets in nonblocking mode.
+                if let Err(error) = stream.set_nonblocking(false) {
+                    eprintln!("controlled HTTP connection could not enter blocking mode: {error}");
+                    continue;
+                }
                 let root = root.clone();
                 let shutdown = Arc::clone(&shutdown);
                 let state = Arc::clone(&state);
@@ -130,51 +136,42 @@ fn serve_http(
 }
 
 fn handle_http(
-    stream: TcpStream,
+    mut stream: TcpStream,
     root: &Path,
     shutdown: &AtomicBool,
     state: &ServerState,
 ) -> io::Result<()> {
-    let mut reader = BufReader::new(stream);
-    loop {
-        let Some(request) = read_http_request(&mut reader)? else {
-            return Ok(());
-        };
-        if shutdown.load(Ordering::Relaxed) {
-            let _ = reader.get_mut().shutdown(Shutdown::Both);
-            return Ok(());
-        }
-        let close = request.headers.get("connection").map(String::as_str) == Some("close");
-        let stream = reader.get_mut();
-        match request.method.as_str() {
-            "PROPFIND" => propfind(stream, root, &request),
-            "HEAD" => file_response(
-                stream,
-                root,
-                &request.path,
-                request.headers.get("range").map(String::as_str),
-                true,
-                state,
-            ),
-            "GET" => file_response(
-                stream,
-                root,
-                &request.path,
-                request.headers.get("range").map(String::as_str),
-                false,
-                state,
-            ),
-            _ => write_response_headers(
-                stream,
-                405,
-                "Method Not Allowed",
-                &[("Content-Length", "0".to_owned())],
-            ),
-        }?;
-        if close {
-            eprintln!("controlled HTTP peer requested connection close");
-            return Ok(());
-        }
+    let Some(request) = read_http_request(&stream)? else {
+        return Ok(());
+    };
+    if shutdown.load(Ordering::Relaxed) {
+        let _ = stream.shutdown(Shutdown::Both);
+        return Ok(());
+    }
+    match request.method.as_str() {
+        "PROPFIND" => propfind(&mut stream, root, &request),
+        "HEAD" => file_response(
+            &mut stream,
+            root,
+            &request.path,
+            request.headers.get("range").map(String::as_str),
+            true,
+            state,
+        ),
+        "GET" => file_response(
+            &mut stream,
+            root,
+            &request.path,
+            request.headers.get("range").map(String::as_str),
+            false,
+            state,
+        ),
+        _ => write_response_headers(
+            &mut stream,
+            405,
+            "Method Not Allowed",
+            &[("Content-Length", "0".to_owned())],
+        ),
     }
 }
 
@@ -184,7 +181,8 @@ struct HttpRequest {
     headers: BTreeMap<String, String>,
 }
 
-fn read_http_request(reader: &mut impl BufRead) -> io::Result<Option<HttpRequest>> {
+fn read_http_request(stream: &TcpStream) -> io::Result<Option<HttpRequest>> {
+    let mut reader = BufReader::new(stream.try_clone()?);
     let mut request_line = String::new();
     if reader.read_line(&mut request_line)? == 0 {
         return Ok(None);
@@ -427,7 +425,7 @@ fn write_response_headers(
     text: &str,
     headers: &[(&str, String)],
 ) -> io::Result<()> {
-    write!(stream, "HTTP/1.1 {status} {text}\r\n")?;
+    write!(stream, "HTTP/1.1 {status} {text}\r\nConnection: close\r\n")?;
     for (key, value) in headers {
         write!(stream, "{key}: {value}\r\n")?;
     }
@@ -518,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn server_handles_multiple_requests_on_one_connection() -> Result<(), Box<dyn Error>> {
+    fn server_waits_for_a_request_after_accepting_a_connection() -> Result<(), Box<dyn Error>> {
         let mut server = ControlledHttpServer::start(
             PathBuf::new(),
             TransportProfile {
@@ -533,14 +531,13 @@ mod tests {
             .and_then(|url| url.strip_suffix('/'))
             .ok_or_else(|| io::Error::other("unexpected controlled server URL"))?;
         let mut stream = TcpStream::connect(address)?;
-        stream.write_all(
-            b"HEAD /missing HTTP/1.1\r\nHost: localhost\r\n\r\n\
-              HEAD /missing HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
-        )?;
+        stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+        thread::sleep(Duration::from_millis(100));
+        stream.write_all(b"HEAD /missing HTTP/1.1\r\nHost: localhost\r\n\r\n")?;
         let mut responses = String::new();
         stream.read_to_string(&mut responses)?;
 
-        assert_eq!(responses.matches("HTTP/1.1 404 Not Found").count(), 2);
+        assert!(responses.starts_with("HTTP/1.1 404 Not Found\r\n"));
         server.stop();
         Ok(())
     }

--- a/benches/range_planning/controlled_http.rs
+++ b/benches/range_planning/controlled_http.rs
@@ -125,42 +125,50 @@ fn serve_http(
 }
 
 fn handle_http(
-    mut stream: TcpStream,
+    stream: TcpStream,
     root: &Path,
     shutdown: &AtomicBool,
     state: &ServerState,
 ) -> io::Result<()> {
-    let Some(request) = read_http_request(&stream)? else {
-        return Ok(());
-    };
-    if shutdown.load(Ordering::Relaxed) {
-        let _ = stream.shutdown(Shutdown::Both);
-        return Ok(());
-    }
-    match request.method.as_str() {
-        "PROPFIND" => propfind(&mut stream, root, &request),
-        "HEAD" => file_response(
-            &mut stream,
-            root,
-            &request.path,
-            request.headers.get("range").map(String::as_str),
-            true,
-            state,
-        ),
-        "GET" => file_response(
-            &mut stream,
-            root,
-            &request.path,
-            request.headers.get("range").map(String::as_str),
-            false,
-            state,
-        ),
-        _ => write_response_headers(
-            &mut stream,
-            405,
-            "Method Not Allowed",
-            &[("Content-Length", "0".to_owned())],
-        ),
+    let mut reader = BufReader::new(stream);
+    loop {
+        let Some(request) = read_http_request(&mut reader)? else {
+            return Ok(());
+        };
+        if shutdown.load(Ordering::Relaxed) {
+            let _ = reader.get_mut().shutdown(Shutdown::Both);
+            return Ok(());
+        }
+        let close = request.headers.get("connection").map(String::as_str) == Some("close");
+        let stream = reader.get_mut();
+        match request.method.as_str() {
+            "PROPFIND" => propfind(stream, root, &request),
+            "HEAD" => file_response(
+                stream,
+                root,
+                &request.path,
+                request.headers.get("range").map(String::as_str),
+                true,
+                state,
+            ),
+            "GET" => file_response(
+                stream,
+                root,
+                &request.path,
+                request.headers.get("range").map(String::as_str),
+                false,
+                state,
+            ),
+            _ => write_response_headers(
+                stream,
+                405,
+                "Method Not Allowed",
+                &[("Content-Length", "0".to_owned())],
+            ),
+        }?;
+        if close {
+            return Ok(());
+        }
     }
 }
 
@@ -170,8 +178,7 @@ struct HttpRequest {
     headers: BTreeMap<String, String>,
 }
 
-fn read_http_request(stream: &TcpStream) -> io::Result<Option<HttpRequest>> {
-    let mut reader = BufReader::new(stream.try_clone()?);
+fn read_http_request(reader: &mut impl BufRead) -> io::Result<Option<HttpRequest>> {
     let mut request_line = String::new();
     if reader.read_line(&mut request_line)? == 0 {
         return Ok(None);
@@ -414,7 +421,7 @@ fn write_response_headers(
     text: &str,
     headers: &[(&str, String)],
 ) -> io::Result<()> {
-    write!(stream, "HTTP/1.1 {status} {text}\r\nConnection: close\r\n")?;
+    write!(stream, "HTTP/1.1 {status} {text}\r\n")?;
     for (key, value) in headers {
         write!(stream, "{key}: {value}\r\n")?;
     }
@@ -493,6 +500,12 @@ fn invalid(message: impl Into<String>) -> io::Error {
 mod tests {
     use super::*;
 
+    const TEST_PROFILE: TransportProfile = TransportProfile {
+        name: "test",
+        request_latency: Duration::ZERO,
+        shared_throughput_bytes_per_second: u64::MAX,
+    };
+
     #[test]
     fn transfer_delay_and_range_parser_are_deterministic() -> io::Result<()> {
         assert_eq!(
@@ -501,6 +514,27 @@ mod tests {
         );
         assert_eq!(parse_range(Some("bytes=2-5"), 10)?, Some((2, 6)));
         assert_eq!(parse_range(Some("bytes=-4"), 10)?, Some((6, 10)));
+        Ok(())
+    }
+
+    #[test]
+    fn server_handles_multiple_requests_on_one_connection() -> Result<(), Box<dyn Error>> {
+        let mut server = ControlledHttpServer::start(PathBuf::new(), TEST_PROFILE)?;
+        let address = server
+            .url()
+            .strip_prefix("http://")
+            .and_then(|url| url.strip_suffix('/'))
+            .ok_or_else(|| io::Error::other("unexpected controlled server URL"))?;
+        let mut stream = TcpStream::connect(address)?;
+        stream.write_all(
+            b"HEAD /missing HTTP/1.1\r\nHost: localhost\r\n\r\n\
+              HEAD /missing HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        )?;
+        let mut responses = String::new();
+        stream.read_to_string(&mut responses)?;
+
+        assert_eq!(responses.matches("HTTP/1.1 404 Not Found").count(), 2);
+        server.stop();
         Ok(())
     }
 }

--- a/benches/range_planning/controlled_http.rs
+++ b/benches/range_planning/controlled_http.rs
@@ -110,11 +110,16 @@ fn serve_http(
                 let root = root.clone();
                 let shutdown = Arc::clone(&shutdown);
                 let state = Arc::clone(&state);
-                let _ = thread::Builder::new()
+                if let Err(error) = thread::Builder::new()
                     .name("delta-arrow-reader-range-bench-http".to_owned())
                     .spawn(move || {
-                        let _ = handle_http(stream, &root, &shutdown, &state);
-                    });
+                        if let Err(error) = handle_http(stream, &root, &shutdown, &state) {
+                            eprintln!("controlled HTTP handler failed: {error}");
+                        }
+                    })
+                {
+                    eprintln!("controlled HTTP handler could not start: {error}");
+                }
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(1));
@@ -167,6 +172,7 @@ fn handle_http(
             ),
         }?;
         if close {
+            eprintln!("controlled HTTP peer requested connection close");
             return Ok(());
         }
     }
@@ -500,12 +506,6 @@ fn invalid(message: impl Into<String>) -> io::Error {
 mod tests {
     use super::*;
 
-    const TEST_PROFILE: TransportProfile = TransportProfile {
-        name: "test",
-        request_latency: Duration::ZERO,
-        shared_throughput_bytes_per_second: u64::MAX,
-    };
-
     #[test]
     fn transfer_delay_and_range_parser_are_deterministic() -> io::Result<()> {
         assert_eq!(
@@ -519,7 +519,14 @@ mod tests {
 
     #[test]
     fn server_handles_multiple_requests_on_one_connection() -> Result<(), Box<dyn Error>> {
-        let mut server = ControlledHttpServer::start(PathBuf::new(), TEST_PROFILE)?;
+        let mut server = ControlledHttpServer::start(
+            PathBuf::new(),
+            TransportProfile {
+                name: "test",
+                request_latency: Duration::ZERO,
+                shared_throughput_bytes_per_second: u64::MAX,
+            },
+        )?;
         let address = server
             .url()
             .strip_prefix("http://")

--- a/docs/content/benchmarks/range-planning.md
+++ b/docs/content/benchmarks/range-planning.md
@@ -40,13 +40,45 @@ total, and the 10% stability margin deliberately prefers lower byte usage when
 two estimates are close. The goal is to avoid a consistently poor fixed choice,
 not to predict the fastest plan perfectly for every file.
 
+## How the planner chooses a range plan
+
+The planner begins with the exact Parquet ranges after combining overlaps and
+duplicates. It then builds alternatives that reduce the number of request
+waves. Each alternative merges the smallest gaps needed to remove at least one
+wave. Alternatives that transfer more than four times the exact bytes are
+discarded.
+
+One plan can run up to 10 range requests concurrently, so its estimated time is:
+
+```text
+request_waves = ceil(request_count / 10)
+estimated_time = request_waves * typical_request_latency
+               + planned_bytes / typical_shared_throughput
+```
+
+Request latency is the time until response data becomes available. Shared
+throughput is the aggregate payload rate across concurrent requests, not a
+separate bandwidth estimate for each request. After three successful plans,
+the planner uses the median latency and throughput from up to nine recent
+samples. Failed, truncated, and cancelled plans do not update the estimate.
+
+The planner finds the candidate with the lowest estimated time, then keeps all
+candidates whose estimate is within 10% of that result. Among those candidates,
+it chooses the one that transfers the fewest bytes, using request count as the
+final tie breaker. This stability margin prevents small changes in the estimate
+from repeatedly switching plans for a minor predicted gain.
+
+Before enough samples exist, the planner uses exact ranges. There is one safety
+bound: if the exact plan needs more than 64 requests, the planner uses a
+lower-request candidate when it stays within the four-times byte limit. This
+prevents an untrained scan from issuing an unusually large number of separate
+requests.
+
 ## Model accuracy
 
-The benchmark also applies the planner's cost model to the chosen automatic
-plans using the server's configured latency and throughput. Predicted plan time
-is request waves multiplied by request latency, plus planned bytes divided by
-shared throughput. Observed plan time measures the successful multi-range plan
-executions and excludes the rest of the scan.
+The benchmark applies this equation to the chosen automatic plans using the
+server's configured latency and throughput. Observed plan time measures the
+successful multi-range plan executions and excludes the rest of the scan.
 
 | Transport profile | Projection | Predicted plan | Observed plan | Difference |
 | --- | --- | ---: | ---: | ---: |


### PR DESCRIPTION
## Summary

- disable idle HTTP connection reuse for the controlled server, which closes every response and otherwise races reqwest connection reuse on Windows
- report the transport profile, projection, policy, and complete source chain when the parity test fails
- document the planner cost equation, candidate generation, stability margin, and safety bounds

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --test range_planning_benchmark_harness`
- `cargo clippy --locked --test range_planning_benchmark_harness -- -D warnings`
- `python -m zensical build --strict -f docs/mkdocs.yml`
- `git diff --check`