### PR TITLE
fix: keep scan metric snapshots extensible

### DIFF
--- a/src/reader/datafusion/execution.rs
+++ b/src/reader/datafusion/execution.rs
@@ -93,7 +93,11 @@ impl IntraFileRepartitioning {
     }
 }
 
-/// Immutable point-in-time DataFusion scan metrics.
+/// Immutable point-in-time copy of one DataFusion scan's metrics.
+///
+/// A snapshot taken while the scan is running may contain partial progress. It does not change
+/// after creation; call [`ScanMetrics::snapshot`] again to observe later progress.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScanMetricsSnapshot {
     /// Delta reader planning and execution metrics.

--- a/src/reader/metrics.rs
+++ b/src/reader/metrics.rs
@@ -23,7 +23,11 @@ pub struct ParquetRangePlanningDiagnosticSnapshot {
     pub successful_plan_time_micros: u64,
 }
 
-/// Immutable point-in-time metrics for one Delta scan.
+/// Immutable point-in-time copy of one Delta scan's metrics.
+///
+/// A snapshot taken while the scan is running may contain partial progress. It does not change
+/// after creation; call [`DeltaScanMetrics::snapshot`] again to observe later progress.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeltaScanMetricsSnapshot {
     /// Delta snapshot version selected for the scan.


### PR DESCRIPTION
## Summary

- mark the core and DataFusion scan metric snapshots as non-exhaustive
- document that snapshots may contain partial progress and do not update after creation
- allow future metric fields to be added without breaking external struct construction again

This remains part of the current 0.5.0 breaking release because applying non-exhaustive is itself an API change. Future field additions will remain compatible.

## Validation

- cargo fmt --all -- --check
- cargo test --test public_api --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps