### PR TITLE
fix: preserve adaptive Parquet range learning across DataFusion scans

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -697,6 +697,7 @@ pub(crate) fn direct_parquet_executor(
         plan,
         output_batch_size_rows,
         row_predicate,
+        Arc::default(),
         None,
     )
 }

--- a/src/reader/backend/direct_parquet.rs
+++ b/src/reader/backend/direct_parquet.rs
@@ -32,6 +32,7 @@ use parquet::schema::types::SchemaDescriptor;
 use snafu::{IntoError, ResultExt};
 use tokio::sync::OnceCell;
 
+pub(crate) use self::metered_object_store::ParquetRangeReadEstimator;
 use self::{
     metered_object_store::{MeteredParquetObjectStore, MultiRangeReadStrategy},
     row_group_pruning::pruned_row_groups,
@@ -139,15 +140,19 @@ impl DirectParquetReader {
         engine_context: Arc<DeltaKernelEngineContext>,
         execution_options: DeltaScanExecutionOptions,
         metrics: DeltaScanMetrics,
+        range_read_estimator: Arc<ParquetRangeReadEstimator>,
     ) -> Self {
-        let store = Arc::new(MeteredParquetObjectStore::new(
-            engine_context.object_store(),
-            metrics.clone(),
-            MultiRangeReadStrategy::for_policy(
-                execution_options.parquet_range_read_policy(),
-                engine_context.table_url(),
-            ),
-        ));
+        let store = Arc::new(
+            MeteredParquetObjectStore::new(
+                engine_context.object_store(),
+                metrics.clone(),
+                MultiRangeReadStrategy::for_policy(
+                    execution_options.parquet_range_read_policy(),
+                    engine_context.table_url(),
+                ),
+            )
+            .with_range_read_estimator(range_read_estimator),
+        );
         Self {
             engine_context,
             store,
@@ -628,12 +633,14 @@ pub(crate) fn direct_parquet_file_executor(
     plan: &Arc<DeltaScanPlan>,
     output_batch_size_rows: Option<usize>,
     row_predicate: Option<DeltaKernelPredicate>,
+    range_read_estimator: Arc<ParquetRangeReadEstimator>,
     metadata_cache: Option<Arc<RangedParquetMetadataCache>>,
 ) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
     let reader = DirectParquetReader::new(
         Arc::clone(&plan.engine_context),
         plan.execution_options,
         plan.metrics.clone(),
+        range_read_estimator,
     );
     let reader = Arc::new(match metadata_cache {
         Some(cache) => reader.with_metadata_cache(cache),
@@ -1192,7 +1199,12 @@ mod tests {
             table_url,
             &DeltaStorageOptions::default(),
         )?);
-        Ok(DirectParquetReader::new(engine_context, options, metrics))
+        Ok(DirectParquetReader::new(
+            engine_context,
+            options,
+            metrics,
+            Arc::default(),
+        ))
     }
 
     pub(super) fn task(
@@ -1578,7 +1590,8 @@ mod tests {
         row_predicate: Option<DeltaKernelPredicate>,
     ) -> Result<Vec<RecordBatch>, DeltaReaderError> {
         let scheduler = DeltaScanScheduler::new(Arc::clone(&plan));
-        let executor = direct_parquet_file_executor(&plan, Some(2), row_predicate, None);
+        let executor =
+            direct_parquet_file_executor(&plan, Some(2), row_predicate, Arc::default(), None);
         let mut batches = Vec::new();
         for partition in 0..plan.partitions.len() {
             let mut stream = scheduler.partition_stream(
@@ -1644,6 +1657,7 @@ mod tests {
             Arc::clone(&plan.engine_context),
             plan.execution_options,
             plan.metrics.clone(),
+            Arc::default(),
         );
         let object = reader.resolve_parquet_object(&task)?;
         let inner = Arc::new(InMemory::new());
@@ -1772,6 +1786,7 @@ mod tests {
             engine_context,
             DeltaScanExecutionOptions::new(),
             metrics.clone(),
+            Arc::default(),
         );
         let tracked_store = GatedObjectStore::ungated(Arc::clone(&store));
         reader.store = Arc::new(MeteredParquetObjectStore::new(
@@ -2084,6 +2099,7 @@ mod tests {
             Arc::clone(&plan.engine_context),
             plan.execution_options,
             plan.metrics.clone(),
+            Arc::default(),
         ));
         let limiter = one_file_limiter(plan.execution_options)?;
         let partition = limiter.partition(0)?;

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -102,6 +102,15 @@ impl MeteredParquetObjectStore {
         }
     }
 
+    /// Reuses transport measurements collected by other readers in the same store context.
+    pub(crate) fn with_range_read_estimator(
+        mut self,
+        range_read_estimator: Arc<ParquetRangeReadEstimator>,
+    ) -> Self {
+        self.range_read_estimator = range_read_estimator;
+        self
+    }
+
     /// Reads one physical range and measures request latency separately from payload delivery.
     async fn read_range_with_timing(
         &self,
@@ -880,18 +889,18 @@ mod tests {
             )
             .await?;
         let estimator = Arc::new(ParquetRangeReadEstimator::default());
-        let mut first = MeteredParquetObjectStore::new(
+        let first = MeteredParquetObjectStore::new(
             inner.clone(),
             direct_metrics(),
             MultiRangeReadStrategy::ChooseAutomatically,
-        );
-        first.range_read_estimator = Arc::clone(&estimator);
-        let mut second = MeteredParquetObjectStore::new(
+        )
+        .with_range_read_estimator(Arc::clone(&estimator));
+        let second = MeteredParquetObjectStore::new(
             inner.clone(),
             direct_metrics(),
             MultiRangeReadStrategy::ChooseAutomatically,
-        );
-        second.range_read_estimator = Arc::clone(&estimator);
+        )
+        .with_range_read_estimator(Arc::clone(&estimator));
         let started = Instant::now();
 
         first.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
@@ -901,12 +910,12 @@ mod tests {
         assert!(second.current_transport_estimate().is_some());
 
         let warm_metrics = direct_metrics();
-        let mut warm = MeteredParquetObjectStore::new(
+        let warm = MeteredParquetObjectStore::new(
             inner.clone(),
             warm_metrics.clone(),
             MultiRangeReadStrategy::ChooseAutomatically,
-        );
-        warm.range_read_estimator = estimator;
+        )
+        .with_range_read_estimator(estimator);
         let ranges = [0..4, 8..12];
         let warm_bytes = warm
             .get_ranges(&Path::from("data.parquet"), &ranges)

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -32,6 +32,15 @@ pub(crate) struct MeteredParquetObjectStore {
     inner: Arc<dyn ObjectStore>,
     metrics: DeltaScanMetrics,
     multi_range_read_strategy: MultiRangeReadStrategy,
+    range_read_estimator: Arc<ParquetRangeReadEstimator>,
+}
+
+/// Recent transport measurements shared by Parquet readers in one store context.
+///
+/// The estimator retains only latency and throughput samples. It does not retain object paths,
+/// credentials, table identifiers, or query text.
+#[derive(Default)]
+pub(crate) struct ParquetRangeReadEstimator {
     transport_samples: Mutex<VecDeque<TransportEstimate>>,
 }
 
@@ -89,7 +98,7 @@ impl MeteredParquetObjectStore {
             inner,
             metrics,
             multi_range_read_strategy,
-            transport_samples: Mutex::new(VecDeque::with_capacity(TRANSPORT_SAMPLE_WINDOW)),
+            range_read_estimator: Arc::new(ParquetRangeReadEstimator::default()),
         }
     }
 
@@ -128,29 +137,7 @@ impl MeteredParquetObjectStore {
 
     /// Returns robust latency and shared-throughput estimates after enough plans have completed.
     fn current_transport_estimate(&self) -> Option<TransportEstimate> {
-        let samples = self
-            .transport_samples
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if samples.len() < MIN_TRANSPORT_SAMPLES {
-            return None;
-        }
-
-        let mut latencies = samples
-            .iter()
-            .map(|sample| sample.request_latency)
-            .collect::<Vec<_>>();
-        let mut throughputs = samples
-            .iter()
-            .map(|sample| sample.shared_throughput_bytes_per_second)
-            .collect::<Vec<_>>();
-        latencies.sort_unstable();
-        throughputs.sort_unstable();
-        let middle = samples.len() / 2;
-        Some(TransportEstimate {
-            request_latency: latencies[middle],
-            shared_throughput_bytes_per_second: throughputs[middle],
-        })
+        self.range_read_estimator.current_transport_estimate()
     }
 
     /// Adds one sample after every physical range in a chosen plan finishes successfully.
@@ -161,15 +148,7 @@ impl MeteredParquetObjectStore {
         let Some(sample) = transport_sample(completed_reads) else {
             return;
         };
-
-        let mut samples = self
-            .transport_samples
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if samples.len() == TRANSPORT_SAMPLE_WINDOW {
-            samples.pop_front();
-        }
-        samples.push_back(sample);
+        self.range_read_estimator.record(sample);
     }
 
     /// Records the exact request and chosen physical plan before its reads start.
@@ -225,6 +204,47 @@ impl MeteredParquetObjectStore {
         self.metrics
             .record_parquet_range_successful_plan_time(plan_started.elapsed());
         Ok(results)
+    }
+}
+
+impl ParquetRangeReadEstimator {
+    /// Returns median latency and throughput after the shared window has enough samples.
+    fn current_transport_estimate(&self) -> Option<TransportEstimate> {
+        let samples = self
+            .transport_samples
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if samples.len() < MIN_TRANSPORT_SAMPLES {
+            return None;
+        }
+
+        let mut latencies = samples
+            .iter()
+            .map(|sample| sample.request_latency)
+            .collect::<Vec<_>>();
+        let mut throughputs = samples
+            .iter()
+            .map(|sample| sample.shared_throughput_bytes_per_second)
+            .collect::<Vec<_>>();
+        latencies.sort_unstable();
+        throughputs.sort_unstable();
+        let middle = samples.len() / 2;
+        Some(TransportEstimate {
+            request_latency: latencies[middle],
+            shared_throughput_bytes_per_second: throughputs[middle],
+        })
+    }
+
+    /// Adds one completed-plan sample and discards the oldest sample when the window is full.
+    fn record(&self, sample: TransportEstimate) {
+        let mut samples = self
+            .transport_samples
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if samples.len() == TRANSPORT_SAMPLE_WINDOW {
+            samples.pop_front();
+        }
+        samples.push_back(sample);
     }
 }
 
@@ -504,7 +524,7 @@ mod tests {
 
     use super::{
         ChosenRangePlan, CompletedRangeRead, MeteredParquetObjectStore, MultiRangeReadStrategy,
-        RangePlanDecision, TransportEstimate,
+        ParquetRangeReadEstimator, RangePlanDecision, TransportEstimate,
     };
     use crate::{
         DeltaScanMetrics, ParquetReaderBackend,
@@ -848,6 +868,78 @@ mod tests {
             snapshot.parquet_data_file_cost_based_merged_range_plans,
             Some(1)
         );
+    }
+
+    #[tokio::test]
+    async fn separate_stores_share_only_an_explicitly_reused_estimator() -> Result<()> {
+        let inner = Arc::new(InMemory::new());
+        inner
+            .put(
+                &Path::from("data.parquet"),
+                PutPayload::from_static(b"0123456789abcdef"),
+            )
+            .await?;
+        let estimator = Arc::new(ParquetRangeReadEstimator::default());
+        let mut first = MeteredParquetObjectStore::new(
+            inner.clone(),
+            direct_metrics(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        first.range_read_estimator = Arc::clone(&estimator);
+        let mut second = MeteredParquetObjectStore::new(
+            inner.clone(),
+            direct_metrics(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        second.range_read_estimator = Arc::clone(&estimator);
+        let started = Instant::now();
+
+        first.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
+        first.record_completed_range_reads(&[completed_read(started, 20, 2_000)]);
+        assert_eq!(first.current_transport_estimate(), None);
+        second.record_completed_range_reads(&[completed_read(started, 30, 3_000)]);
+        assert!(second.current_transport_estimate().is_some());
+
+        let warm_metrics = direct_metrics();
+        let mut warm = MeteredParquetObjectStore::new(
+            inner.clone(),
+            warm_metrics.clone(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        warm.range_read_estimator = estimator;
+        let ranges = [0..4, 8..12];
+        let warm_bytes = warm
+            .get_ranges(&Path::from("data.parquet"), &ranges)
+            .await?;
+        let snapshot = warm_metrics.snapshot();
+        assert_eq!(snapshot.parquet_data_file_cold_start_range_plans, Some(0));
+        assert_eq!(
+            snapshot
+                .parquet_data_file_cost_based_exact_range_plans
+                .unwrap_or_default()
+                + snapshot
+                    .parquet_data_file_cost_based_merged_range_plans
+                    .unwrap_or_default(),
+            1
+        );
+
+        let cold_metrics = direct_metrics();
+        let cold = MeteredParquetObjectStore::new(
+            inner,
+            cold_metrics.clone(),
+            MultiRangeReadStrategy::ChooseAutomatically,
+        );
+        let cold_bytes = cold
+            .get_ranges(&Path::from("data.parquet"), &ranges)
+            .await?;
+        assert_eq!(cold_bytes, warm_bytes);
+        assert_eq!(
+            cold_metrics
+                .snapshot()
+                .parquet_data_file_cold_start_range_plans,
+            Some(1)
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/reader/datafusion.rs
+++ b/src/reader/datafusion.rs
@@ -30,8 +30,11 @@ use self::{
 use crate::{
     DeltaReaderError, DeltaScanExecutionOptions, DeltaTable, ParquetReaderBackend,
     delta::kernel::kernel_pruning_predicate,
-    reader::planning::{DeltaScanPartitionTargetOptions, build_physical_row_predicate, plan_scan},
-    reader::transform::schema_with_view_types,
+    reader::{
+        backend::direct_parquet::ParquetRangeReadEstimator,
+        planning::{DeltaScanPartitionTargetOptions, build_physical_row_predicate, plan_scan},
+        transform::schema_with_view_types,
+    },
 };
 
 const TRACING_TARGET: &str = "delta_arrow_reader::datafusion";
@@ -89,6 +92,7 @@ pub struct DeltaTableProvider {
     schema: SchemaRef,
     options: ScanOptions,
     registration_name: Option<String>,
+    range_read_estimator: Arc<ParquetRangeReadEstimator>,
 }
 
 impl DeltaTableProvider {
@@ -119,6 +123,7 @@ impl DeltaTableProvider {
             schema,
             options,
             registration_name,
+            range_read_estimator: Arc::default(),
         })
     }
 
@@ -231,6 +236,7 @@ impl DeltaTableProvider {
                 reader_plan,
                 datafusion_plan,
                 exact_row_predicate,
+                Arc::clone(&self.range_read_estimator),
                 self.registration_name.clone(),
                 self.options.use_arrow_view_types,
                 self.options.intra_file_repartitioning,

--- a/src/reader/datafusion/execution.rs
+++ b/src/reader/datafusion/execution.rs
@@ -58,7 +58,7 @@ use super::{
 };
 
 use crate::reader::backend::direct_parquet::{
-    RangedParquetMetadataCache, direct_parquet_file_executor,
+    ParquetRangeReadEstimator, RangedParquetMetadataCache, direct_parquet_file_executor,
 };
 use crate::{
     DeltaReaderError, DeltaScanMetrics, DeltaScanMetricsSnapshot, ParquetReaderBackend,
@@ -309,6 +309,7 @@ pub(crate) fn create_datafusion_execution_plan(
     reader_plan: DeltaScanPlan,
     datafusion_plan: DataFusionScanPlan,
     exact_row_predicate: Option<DeltaKernelPredicate>,
+    range_read_estimator: Arc<ParquetRangeReadEstimator>,
     registration_name: Option<String>,
     use_arrow_view_types: bool,
     intra_file_repartitioning: IntraFileRepartitioning,
@@ -317,6 +318,7 @@ pub(crate) fn create_datafusion_execution_plan(
         reader_plan,
         datafusion_plan,
         exact_row_predicate,
+        range_read_estimator,
         registration_name,
         use_arrow_view_types,
         intra_file_repartitioning,
@@ -334,6 +336,7 @@ struct DeltaScanExec {
     limiter: Arc<ScanReadLimiter>,
     dynamic_filters: Arc<[RetainedDynamicFilter]>,
     intra_file_repartitioning: IntraFileRepartitioning,
+    range_read_estimator: Arc<ParquetRangeReadEstimator>,
     parquet_metadata_cache: Option<Arc<RangedParquetMetadataCache>>,
 }
 
@@ -343,6 +346,7 @@ impl DeltaScanExec {
         reader_plan: DeltaScanPlan,
         datafusion_plan: DataFusionScanPlan,
         exact_row_predicate: Option<DeltaKernelPredicate>,
+        range_read_estimator: Arc<ParquetRangeReadEstimator>,
         registration_name: Option<String>,
         use_arrow_view_types: bool,
         intra_file_repartitioning: IntraFileRepartitioning,
@@ -371,6 +375,7 @@ impl DeltaScanExec {
             limiter,
             dynamic_filters: Arc::from([]),
             intra_file_repartitioning,
+            range_read_estimator,
             parquet_metadata_cache: None,
         }
     }
@@ -641,6 +646,7 @@ impl ExecutionPlan for DeltaScanExec {
                 &self.reader_plan,
                 Some(configured_batch_size_rows),
                 self.exact_row_predicate.clone(),
+                Arc::clone(&self.range_read_estimator),
                 self.parquet_metadata_cache.clone(),
             ),
             ParquetReaderBackend::DeltaKernel => delta_kernel_executor(&self.reader_plan),
@@ -851,7 +857,10 @@ mod tests {
     use crate::{
         DeltaScanExecutionOptions, DeltaTable, DeltaTableBuilder,
         delta::kernel::kernel_pruning_predicate,
-        reader::datafusion::planning::{FilterCapabilities, plan_datafusion_scan},
+        reader::datafusion::{
+            DeltaTableProvider, ScanOptions,
+            planning::{FilterCapabilities, plan_datafusion_scan},
+        },
         reader::planning::{
             DeltaScanPartitionTargetOptions, build_physical_row_predicate, plan_scan,
         },
@@ -1078,6 +1087,7 @@ mod tests {
             reader_plan,
             datafusion_plan,
             exact_row_predicate,
+            Arc::default(),
             registration_name,
             true,
             intra_file_repartitioning,
@@ -1086,6 +1096,51 @@ mod tests {
 
     fn session(batch_size: usize) -> SessionContext {
         SessionContext::new_with_config(SessionConfig::new().with_batch_size(batch_size))
+    }
+
+    #[tokio::test]
+    async fn provider_reuses_one_range_read_estimator_across_physical_plans() -> TestResult {
+        let fixture = TestTable::partitioned("shared-range-read-estimator")?;
+        let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
+        let provider = DeltaTableProvider::try_new(table.clone(), ScanOptions::default())?;
+        let separate_provider = DeltaTableProvider::try_new(table, ScanOptions::default())?;
+        let context = SessionContext::new();
+
+        let first = provider.plan(&context.state(), None, &[])?.0;
+        let second = provider.plan(&context.state(), None, &[])?.0;
+        let separate = separate_provider.plan(&context.state(), None, &[])?.0;
+        let first = first
+            .as_ref()
+            .downcast_ref::<DeltaScanExec>()
+            .ok_or("first plan was not DeltaScanExec")?;
+        let second = second
+            .as_ref()
+            .downcast_ref::<DeltaScanExec>()
+            .ok_or("second plan was not DeltaScanExec")?;
+        let separate = separate
+            .as_ref()
+            .downcast_ref::<DeltaScanExec>()
+            .ok_or("separate provider plan was not DeltaScanExec")?;
+        let repartitioned =
+            first.with_repartitioned_partitions(first.reader_plan.partitions.clone());
+        let repartitioned = repartitioned
+            .as_ref()
+            .downcast_ref::<DeltaScanExec>()
+            .ok_or("repartitioned plan was not DeltaScanExec")?;
+
+        assert!(Arc::ptr_eq(
+            &first.range_read_estimator,
+            &second.range_read_estimator
+        ));
+        assert!(Arc::ptr_eq(
+            &first.range_read_estimator,
+            &repartitioned.range_read_estimator
+        ));
+        assert!(!Arc::ptr_eq(
+            &first.range_read_estimator,
+            &separate.range_read_estimator
+        ));
+        Ok(())
     }
 
     fn sized_file_task(path: &str, size: Option<u64>) -> DeltaScanFileTask {


### PR DESCRIPTION
## Summary

- share the bounded Parquet transport estimator across execution partitions and fresh physical plans from one DataFusion provider
- keep independently created providers isolated and preserve the streaming reader lifecycle
- add regression coverage for aggregate warming, provider plan reuse, repartitioned plans, and independent cold starts

## Verification

- cargo test --locked
- cargo test --locked --features datafusion
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
- cargo package --locked

Closes #71