### PR TITLE
feat: add debug diagnostics for automatic Parquet range-plan decisions

### DIFF
--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -20,13 +20,18 @@ use tracing::Instrument;
 use url::Url;
 
 use super::range_planning::{
-    ChosenRangePlan, RangePlanDecision, TransportEstimate, choose_range_plan, execute_range_plan,
-    merge_ranges, range_bytes,
+    ChosenRangePlan, RangePlanDecision, TransportEstimate, bandwidth_delay_bytes,
+    choose_range_plan, execute_range_plan, merge_ranges, range_bytes, request_waves,
 };
-use crate::{DeltaScanMetrics, reader::ParquetRangeReadPolicy};
+use crate::{
+    DeltaScanMetrics,
+    reader::{ParquetRangeReadPolicy, options::MAX_CONCURRENT_PARQUET_RANGE_READS},
+};
 
 const TRANSPORT_SAMPLE_WINDOW: usize = 9;
 const MIN_TRANSPORT_SAMPLES: usize = 3;
+const RANGE_PLANNING_DIAGNOSTIC_TARGET: &str =
+    "delta_arrow_reader::diagnostics::parquet_range_planning";
 
 pub(crate) struct MeteredParquetObjectStore {
     inner: Arc<dyn ObjectStore>,
@@ -145,7 +150,7 @@ impl MeteredParquetObjectStore {
     }
 
     /// Returns robust latency and shared-throughput estimates after enough plans have completed.
-    fn current_transport_estimate(&self) -> Option<TransportEstimate> {
+    fn current_transport_estimate(&self) -> (usize, Option<TransportEstimate>) {
         self.range_read_estimator.current_transport_estimate()
     }
 
@@ -190,9 +195,9 @@ impl MeteredParquetObjectStore {
         location: &Path,
         requested_ranges: &[Range<u64>],
         physical_ranges: &[Range<u64>],
-    ) -> Result<Vec<Bytes>> {
-        let plan_started = Instant::now();
+    ) -> Result<(Vec<Bytes>, Duration)> {
         let completed_reads = Arc::new(Mutex::new(Vec::with_capacity(physical_ranges.len())));
+        let plan_started = Instant::now();
         let results = execute_range_plan(requested_ranges, physical_ranges, |range| {
             let completed_reads = Arc::clone(&completed_reads);
             async move {
@@ -205,26 +210,28 @@ impl MeteredParquetObjectStore {
             }
         })
         .await?;
+        let plan_time = plan_started.elapsed();
         self.record_completed_range_reads(
             &completed_reads
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
         );
         self.metrics
-            .record_parquet_range_successful_plan_time(plan_started.elapsed());
-        Ok(results)
+            .record_parquet_range_successful_plan_time(plan_time);
+        Ok((results, plan_time))
     }
 }
 
 impl ParquetRangeReadEstimator {
-    /// Returns median latency and throughput after the shared window has enough samples.
-    fn current_transport_estimate(&self) -> Option<TransportEstimate> {
+    /// Returns the sample count and median estimate from the same locked view of the window.
+    fn current_transport_estimate(&self) -> (usize, Option<TransportEstimate>) {
         let samples = self
             .transport_samples
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let sample_count = samples.len();
         if samples.len() < MIN_TRANSPORT_SAMPLES {
-            return None;
+            return (sample_count, None);
         }
 
         let mut latencies = samples
@@ -238,10 +245,13 @@ impl ParquetRangeReadEstimator {
         latencies.sort_unstable();
         throughputs.sort_unstable();
         let middle = samples.len() / 2;
-        Some(TransportEstimate {
-            request_latency: latencies[middle],
-            shared_throughput_bytes_per_second: throughputs[middle],
-        })
+        (
+            sample_count,
+            Some(TransportEstimate {
+                request_latency: latencies[middle],
+                shared_throughput_bytes_per_second: throughputs[middle],
+            }),
+        )
     }
 
     /// Adds one completed-plan sample and discards the oldest sample when the window is full.
@@ -255,6 +265,50 @@ impl ParquetRangeReadEstimator {
         }
         samples.push_back(sample);
     }
+}
+
+/// Emits the inputs and outcome of one successfully completed automatic range plan.
+fn trace_completed_automatic_range_plan(
+    plan: &ChosenRangePlan,
+    transport_sample_count: usize,
+    observed_plan_time: Duration,
+) {
+    let estimate = plan.transport_estimate;
+    tracing::debug!(
+        target: RANGE_PLANNING_DIAGNOSTIC_TARGET,
+        event = "automatic_parquet_range_plan_completed",
+        transport_sample_count = u64::try_from(transport_sample_count).unwrap_or(u64::MAX),
+        estimated_request_latency_micros = estimate.map(|value| value.request_latency.as_micros()),
+        estimated_shared_throughput_bytes_per_second =
+            estimate.map(|value| value.shared_throughput_bytes_per_second),
+        estimated_bandwidth_delay_bytes = estimate.map(bandwidth_delay_bytes),
+        exact_range_count = u64::try_from(plan.exact_range_count).unwrap_or(u64::MAX),
+        exact_bytes = plan.exact_bytes,
+        exact_request_waves = u64::try_from(request_waves(
+            plan.exact_range_count,
+            MAX_CONCURRENT_PARQUET_RANGE_READS,
+        ))
+        .unwrap_or(u64::MAX),
+        baseline_range_count = u64::try_from(plan.baseline_range_count).unwrap_or(u64::MAX),
+        baseline_bytes = plan.baseline_bytes,
+        baseline_request_waves = u64::try_from(request_waves(
+            plan.baseline_range_count,
+            MAX_CONCURRENT_PARQUET_RANGE_READS,
+        ))
+        .unwrap_or(u64::MAX),
+        selected_range_count = u64::try_from(plan.physical_ranges.len()).unwrap_or(u64::MAX),
+        selected_bytes = plan.planned_bytes,
+        selected_request_waves = u64::try_from(request_waves(
+            plan.physical_ranges.len(),
+            MAX_CONCURRENT_PARQUET_RANGE_READS,
+        ))
+        .unwrap_or(u64::MAX),
+        baseline_predicted_score = plan.baseline_predicted_score,
+        selected_predicted_score = plan.selected_predicted_score,
+        observed_selected_plan_micros = observed_plan_time.as_micros(),
+        decision = plan.decision.as_str(),
+        "Automatic Parquet range plan completed"
+    );
 }
 
 /// Summarizes one fully completed physical plan without double-counting concurrent delivery time.
@@ -413,14 +467,24 @@ impl ObjectStore for MeteredParquetObjectStore {
                     physical_ranges.len(),
                     range_bytes(&physical_ranges),
                 );
-                self.read_physical_ranges(location, ranges, &physical_ranges)
-                    .await
+                let (results, _) = self
+                    .read_physical_ranges(location, ranges, &physical_ranges)
+                    .await?;
+                Ok(results)
             }
             MultiRangeReadStrategy::ChooseAutomatically => {
-                let plan = choose_range_plan(ranges, self.current_transport_estimate());
+                let (transport_sample_count, estimate) = self.current_transport_estimate();
+                let plan = choose_range_plan(ranges, estimate);
                 self.record_chosen_range_plan_metrics(&plan);
-                self.read_physical_ranges(location, ranges, &plan.physical_ranges)
-                    .await
+                let (results, observed_plan_time) = self
+                    .read_physical_ranges(location, ranges, &plan.physical_ranges)
+                    .await?;
+                trace_completed_automatic_range_plan(
+                    &plan,
+                    transport_sample_count,
+                    observed_plan_time,
+                );
+                Ok(results)
             }
         }
     }
@@ -506,13 +570,14 @@ fn meter_get_result(result: GetResult, metrics: DeltaScanMetrics) -> GetResult {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::BTreeMap,
         fmt,
         fs::File,
         io,
         ops::Range,
         path::PathBuf,
         sync::{
-            Arc, Mutex,
+            Arc, Mutex, Once,
             atomic::{AtomicU64, Ordering},
         },
         time::{Duration, Instant},
@@ -530,11 +595,110 @@ mod tests {
         path::Path,
         throttle::{ThrottleConfig, ThrottledStore},
     };
+    use tracing::{
+        Event, Level, Metadata, Subscriber,
+        field::{Field as TracingField, Visit},
+        span::{Attributes as TracingAttributes, Id, Record},
+        subscriber::{Interest, with_default},
+    };
 
     use super::{
         ChosenRangePlan, CompletedRangeRead, MeteredParquetObjectStore, MultiRangeReadStrategy,
-        ParquetRangeReadEstimator, RangePlanDecision, TransportEstimate,
+        ParquetRangeReadEstimator, RANGE_PLANNING_DIAGNOSTIC_TARGET, RangePlanDecision,
+        TransportEstimate,
     };
+
+    static TRACING_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static TRACING_TEST_GLOBAL_SUBSCRIBER: Once = Once::new();
+
+    #[derive(Clone, Default)]
+    struct EventFields(Arc<Mutex<Vec<BTreeMap<String, String>>>>);
+
+    impl Subscriber for EventFields {
+        fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+            if metadata.target() == RANGE_PLANNING_DIAGNOSTIC_TARGET
+                && *metadata.level() == Level::DEBUG
+            {
+                Interest::always()
+            } else {
+                Interest::sometimes()
+            }
+        }
+
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.target() == RANGE_PLANNING_DIAGNOSTIC_TARGET
+                && *metadata.level() == Level::DEBUG
+        }
+
+        fn new_span(&self, _attributes: &TracingAttributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            let mut fields = event
+                .metadata()
+                .fields()
+                .iter()
+                .map(|field| (field.name().to_owned(), "<empty>".to_owned()))
+                .collect();
+            event.record(&mut FieldVisitor(&mut fields));
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(fields);
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    struct FieldVisitor<'fields>(&'fields mut BTreeMap<String, String>);
+
+    impl Visit for FieldVisitor<'_> {
+        fn record_debug(&mut self, field: &TracingField, value: &dyn fmt::Debug) {
+            self.0.insert(field.name().to_owned(), format!("{value:?}"));
+        }
+
+        fn record_str(&mut self, field: &TracingField, value: &str) {
+            self.0.insert(field.name().to_owned(), value.to_owned());
+        }
+
+        fn record_u64(&mut self, field: &TracingField, value: u64) {
+            self.0.insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_u128(&mut self, field: &TracingField, value: u128) {
+            self.0.insert(field.name().to_owned(), value.to_string());
+        }
+    }
+
+    fn capture_range_planning_events<T>(
+        run: impl FnOnce() -> T,
+    ) -> (T, Vec<BTreeMap<String, String>>) {
+        let _lock = TRACING_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = EventFields(Arc::clone(&events));
+        TRACING_TEST_GLOBAL_SUBSCRIBER.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(EventFields::default());
+        });
+        let result = with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
+            run()
+        });
+        tracing::callsite::rebuild_interest_cache();
+        let captured = events
+            .lock()
+            .map(|events| events.clone())
+            .unwrap_or_default();
+        (result, captured)
+    }
     use crate::{
         DeltaScanMetrics, ParquetReaderBackend,
         reader::{ParquetRangeReadPolicy, metrics::DeltaScanMetricsConfig},
@@ -582,6 +746,78 @@ mod tests {
             )
             .await?;
         Ok(MeteredParquetObjectStore::new(inner, metrics, strategy))
+    }
+
+    #[test]
+    fn cold_start_completion_reports_plan_shape_without_an_estimate()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let (result, events) = capture_range_planning_events(|| {
+            runtime.block_on(async {
+                memory_store(direct_metrics())
+                    .await?
+                    .get_ranges(&Path::from("data.parquet"), &[0..4, 8..12])
+                    .await
+            })
+        });
+        result?;
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(
+            event.get("event").map(String::as_str),
+            Some("automatic_parquet_range_plan_completed")
+        );
+        assert_eq!(
+            event.get("transport_sample_count").map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            event
+                .get("estimated_request_latency_micros")
+                .map(String::as_str),
+            Some("<empty>")
+        );
+        assert_eq!(
+            event.get("exact_range_count").map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(event.get("exact_bytes").map(String::as_str), Some("8"));
+        assert_eq!(
+            event.get("exact_request_waves").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            event.get("baseline_range_count").map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(event.get("baseline_bytes").map(String::as_str), Some("8"));
+        assert_eq!(
+            event.get("selected_range_count").map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(event.get("selected_bytes").map(String::as_str), Some("8"));
+        assert_eq!(
+            event.get("baseline_predicted_score").map(String::as_str),
+            Some("<empty>")
+        );
+        assert_eq!(
+            event.get("selected_predicted_score").map(String::as_str),
+            Some("<empty>")
+        );
+        assert_eq!(
+            event.get("decision").map(String::as_str),
+            Some("cold_start")
+        );
+        assert_ne!(
+            event
+                .get("observed_selected_plan_micros")
+                .map(String::as_str),
+            Some("<empty>")
+        );
+        Ok(())
     }
 
     #[test]
@@ -848,8 +1084,13 @@ mod tests {
             store.record_chosen_range_plan_metrics(&ChosenRangePlan {
                 exact_range_count: 3,
                 exact_bytes: 6,
+                baseline_range_count: 3,
+                baseline_bytes: 6,
                 physical_ranges,
                 planned_bytes,
+                transport_estimate: None,
+                baseline_predicted_score: None,
+                selected_predicted_score: None,
                 decision,
             });
         }
@@ -905,9 +1146,9 @@ mod tests {
 
         first.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
         first.record_completed_range_reads(&[completed_read(started, 20, 2_000)]);
-        assert_eq!(first.current_transport_estimate(), None);
+        assert_eq!(first.current_transport_estimate(), (2, None));
         second.record_completed_range_reads(&[completed_read(started, 30, 3_000)]);
-        assert!(second.current_transport_estimate().is_some());
+        assert!(second.current_transport_estimate().1.is_some());
 
         let warm_metrics = direct_metrics();
         let warm = MeteredParquetObjectStore::new(
@@ -967,15 +1208,18 @@ mod tests {
                 bytes_received,
             )]);
         }
-        assert_eq!(store.current_transport_estimate(), None);
+        assert_eq!(store.current_transport_estimate(), (2, None));
 
         store.record_completed_range_reads(&[completed_read(started, 20, 5_000)]);
         assert_eq!(
             store.current_transport_estimate(),
-            Some(TransportEstimate {
-                request_latency: Duration::from_millis(20),
-                shared_throughput_bytes_per_second: 5_000,
-            })
+            (
+                3,
+                Some(TransportEstimate {
+                    request_latency: Duration::from_millis(20),
+                    shared_throughput_bytes_per_second: 5_000,
+                })
+            )
         );
 
         for latency_millis in 1..=12 {
@@ -984,6 +1228,7 @@ mod tests {
         assert_eq!(
             store
                 .current_transport_estimate()
+                .1
                 .map(|estimate| estimate.request_latency),
             Some(Duration::from_millis(8))
         );
@@ -1007,6 +1252,7 @@ mod tests {
         assert_eq!(
             store
                 .current_transport_estimate()
+                .1
                 .map(|estimate| estimate.shared_throughput_bytes_per_second),
             Some(1_000)
         );
@@ -1041,7 +1287,7 @@ mod tests {
             assert_eq!(results[0].as_ref(), b"0123");
             assert_eq!(results[1].as_ref(), b"89ab");
         }
-        assert!(store.current_transport_estimate().is_some());
+        assert!(store.current_transport_estimate().1.is_some());
 
         let failed_metrics = direct_metrics();
         let failed_store = MeteredParquetObjectStore::new(
@@ -1059,7 +1305,7 @@ mod tests {
                 .await
                 .is_err()
         );
-        assert_eq!(failed_store.current_transport_estimate(), None);
+        assert_eq!(failed_store.current_transport_estimate(), (2, None));
         let snapshot = failed_metrics.snapshot();
         assert_eq!(snapshot.parquet_data_file_exact_ranges_requested, Some(2));
         assert_eq!(
@@ -1117,7 +1363,7 @@ mod tests {
 
         task.abort();
         assert!(task.await.is_err_and(|error| error.is_cancelled()));
-        assert_eq!(store.current_transport_estimate(), None);
+        assert_eq!(store.current_transport_estimate(), (2, None));
         Ok(())
     }
 
@@ -1148,7 +1394,7 @@ mod tests {
             .expect_err("truncated range unexpectedly succeeded");
         assert!(error.to_string().contains("unexpected length"));
         assert_eq!(metrics.snapshot().parquet_data_file_bytes_received, Some(3));
-        assert_eq!(store.current_transport_estimate(), None);
+        assert_eq!(store.current_transport_estimate(), (2, None));
         Ok(())
     }
 

--- a/src/reader/backend/direct_parquet/metered_object_store.rs
+++ b/src/reader/backend/direct_parquet/metered_object_store.rs
@@ -149,7 +149,7 @@ impl MeteredParquetObjectStore {
         Ok((bytes, completed_read))
     }
 
-    /// Returns robust latency and shared-throughput estimates after enough plans have completed.
+    /// Returns the sample count and robust estimate from the same estimator view.
     fn current_transport_estimate(&self) -> (usize, Option<TransportEstimate>) {
         self.range_read_estimator.current_transport_estimate()
     }
@@ -196,8 +196,8 @@ impl MeteredParquetObjectStore {
         requested_ranges: &[Range<u64>],
         physical_ranges: &[Range<u64>],
     ) -> Result<(Vec<Bytes>, Duration)> {
-        let completed_reads = Arc::new(Mutex::new(Vec::with_capacity(physical_ranges.len())));
         let plan_started = Instant::now();
+        let completed_reads = Arc::new(Mutex::new(Vec::with_capacity(physical_ranges.len())));
         let results = execute_range_plan(requested_ranges, physical_ranges, |range| {
             let completed_reads = Arc::clone(&completed_reads);
             async move {
@@ -210,15 +210,15 @@ impl MeteredParquetObjectStore {
             }
         })
         .await?;
-        let plan_time = plan_started.elapsed();
+        let observed_plan_time = plan_started.elapsed();
         self.record_completed_range_reads(
             &completed_reads
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
         );
         self.metrics
-            .record_parquet_range_successful_plan_time(plan_time);
-        Ok((results, plan_time))
+            .record_parquet_range_successful_plan_time(plan_started.elapsed());
+        Ok((results, observed_plan_time))
     }
 }
 
@@ -303,8 +303,8 @@ fn trace_completed_automatic_range_plan(
             MAX_CONCURRENT_PARQUET_RANGE_READS,
         ))
         .unwrap_or(u64::MAX),
-        baseline_predicted_score = plan.baseline_predicted_score,
-        selected_predicted_score = plan.selected_predicted_score,
+        baseline_predicted_cost_bytes = plan.baseline_predicted_cost_bytes,
+        selected_predicted_cost_bytes = plan.selected_predicted_cost_bytes,
         observed_selected_plan_micros = observed_plan_time.as_micros(),
         decision = plan.decision.as_str(),
         "Automatic Parquet range plan completed"
@@ -607,6 +607,10 @@ mod tests {
         ParquetRangeReadEstimator, RANGE_PLANNING_DIAGNOSTIC_TARGET, RangePlanDecision,
         TransportEstimate,
     };
+    use crate::{
+        DeltaScanMetrics, ParquetReaderBackend,
+        reader::{ParquetRangeReadPolicy, metrics::DeltaScanMetricsConfig},
+    };
 
     static TRACING_TEST_LOCK: Mutex<()> = Mutex::new(());
     static TRACING_TEST_GLOBAL_SUBSCRIBER: Once = Once::new();
@@ -699,10 +703,19 @@ mod tests {
             .unwrap_or_default();
         (result, captured)
     }
-    use crate::{
-        DeltaScanMetrics, ParquetReaderBackend,
-        reader::{ParquetRangeReadPolicy, metrics::DeltaScanMetricsConfig},
-    };
+
+    fn event_field<'event>(
+        event: &'event BTreeMap<String, String>,
+        field: &str,
+    ) -> Option<&'event str> {
+        event.get(field).map(String::as_str)
+    }
+
+    fn assert_event_fields(event: &BTreeMap<String, String>, expected_fields: &[(&str, &str)]) {
+        for (field, expected) in expected_fields {
+            assert_eq!(event_field(event, field), Some(*expected), "{field}");
+        }
+    }
 
     fn direct_metrics() -> DeltaScanMetrics {
         DeltaScanMetrics::new(DeltaScanMetricsConfig {
@@ -766,57 +779,130 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         let event = &events[0];
-        assert_eq!(
-            event.get("event").map(String::as_str),
-            Some("automatic_parquet_range_plan_completed")
-        );
-        assert_eq!(
-            event.get("transport_sample_count").map(String::as_str),
-            Some("0")
-        );
-        assert_eq!(
-            event
-                .get("estimated_request_latency_micros")
-                .map(String::as_str),
-            Some("<empty>")
-        );
-        assert_eq!(
-            event.get("exact_range_count").map(String::as_str),
-            Some("2")
-        );
-        assert_eq!(event.get("exact_bytes").map(String::as_str), Some("8"));
-        assert_eq!(
-            event.get("exact_request_waves").map(String::as_str),
-            Some("1")
-        );
-        assert_eq!(
-            event.get("baseline_range_count").map(String::as_str),
-            Some("2")
-        );
-        assert_eq!(event.get("baseline_bytes").map(String::as_str), Some("8"));
-        assert_eq!(
-            event.get("selected_range_count").map(String::as_str),
-            Some("2")
-        );
-        assert_eq!(event.get("selected_bytes").map(String::as_str), Some("8"));
-        assert_eq!(
-            event.get("baseline_predicted_score").map(String::as_str),
-            Some("<empty>")
-        );
-        assert_eq!(
-            event.get("selected_predicted_score").map(String::as_str),
-            Some("<empty>")
-        );
-        assert_eq!(
-            event.get("decision").map(String::as_str),
-            Some("cold_start")
+        assert_event_fields(
+            event,
+            &[
+                ("event", "automatic_parquet_range_plan_completed"),
+                ("transport_sample_count", "0"),
+                ("estimated_request_latency_micros", "<empty>"),
+                ("estimated_shared_throughput_bytes_per_second", "<empty>"),
+                ("estimated_bandwidth_delay_bytes", "<empty>"),
+                ("exact_range_count", "2"),
+                ("exact_bytes", "8"),
+                ("exact_request_waves", "1"),
+                ("baseline_range_count", "2"),
+                ("baseline_bytes", "8"),
+                ("baseline_request_waves", "1"),
+                ("selected_range_count", "2"),
+                ("selected_bytes", "8"),
+                ("selected_request_waves", "1"),
+                ("baseline_predicted_cost_bytes", "<empty>"),
+                ("selected_predicted_cost_bytes", "<empty>"),
+                ("decision", "cold_start"),
+            ],
         );
         assert_ne!(
-            event
-                .get("observed_selected_plan_micros")
-                .map(String::as_str),
+            event_field(event, "observed_selected_plan_micros"),
             Some("<empty>")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn warmed_completions_report_the_estimate_and_exact_candidate_scores()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let location =
+            Path::from("private-bucket/credential-secret/schema-secret/predicate-secret.parquet");
+        let requested_ranges = (0..=10)
+            .map(|index| {
+                let start = index * 1_000;
+                start..start + 100
+            })
+            .collect::<Vec<_>>();
+
+        for (throughput, expected_fields) in [
+            (
+                1_000,
+                [
+                    ("estimated_shared_throughput_bytes_per_second", "1000"),
+                    ("estimated_bandwidth_delay_bytes", "100"),
+                    ("selected_range_count", "11"),
+                    ("selected_bytes", "1100"),
+                    ("selected_request_waves", "2"),
+                    ("baseline_predicted_cost_bytes", "1300"),
+                    ("selected_predicted_cost_bytes", "1300"),
+                    ("decision", "cost_based_exact"),
+                ],
+            ),
+            (
+                1_000_000_000,
+                [
+                    ("estimated_shared_throughput_bytes_per_second", "1000000000"),
+                    ("estimated_bandwidth_delay_bytes", "100000000"),
+                    ("selected_range_count", "10"),
+                    ("selected_bytes", "2000"),
+                    ("selected_request_waves", "1"),
+                    ("baseline_predicted_cost_bytes", "200001100"),
+                    ("selected_predicted_cost_bytes", "100002000"),
+                    ("decision", "cost_based_merged"),
+                ],
+            ),
+        ] {
+            let (result, events) = capture_range_planning_events(|| {
+                runtime.block_on(async {
+                    let inner = Arc::new(InMemory::new());
+                    inner
+                        .put(&location, PutPayload::from(vec![0_u8; 10_100]))
+                        .await?;
+                    let store = MeteredParquetObjectStore::new(
+                        inner,
+                        direct_metrics(),
+                        MultiRangeReadStrategy::ChooseAutomatically,
+                    );
+                    let started = Instant::now();
+                    for _ in 0..3 {
+                        store.record_completed_range_reads(&[completed_read(
+                            started, 100, throughput,
+                        )]);
+                    }
+                    store.get_ranges(&location, &requested_ranges).await
+                })
+            });
+            assert!(result?.iter().all(|bytes| bytes.len() == 100));
+            assert_eq!(events.len(), 1);
+            let event = &events[0];
+            assert_event_fields(
+                event,
+                &[
+                    ("transport_sample_count", "3"),
+                    ("estimated_request_latency_micros", "100000"),
+                    ("exact_range_count", "11"),
+                    ("exact_bytes", "1100"),
+                    ("exact_request_waves", "2"),
+                    ("baseline_range_count", "11"),
+                    ("baseline_bytes", "1100"),
+                    ("baseline_request_waves", "2"),
+                ],
+            );
+            assert_event_fields(event, &expected_fields);
+            assert_ne!(
+                event_field(event, "observed_selected_plan_micros"),
+                Some("<empty>")
+            );
+
+            let diagnostic = format!("{event:?}");
+            for private_value in [
+                "private-bucket",
+                "credential-secret",
+                "schema-secret",
+                "predicate-secret",
+            ] {
+                assert!(!diagnostic.contains(private_value));
+            }
+        }
         Ok(())
     }
 
@@ -1089,8 +1175,8 @@ mod tests {
                 physical_ranges,
                 planned_bytes,
                 transport_estimate: None,
-                baseline_predicted_score: None,
-                selected_predicted_score: None,
+                baseline_predicted_cost_bytes: None,
+                selected_predicted_cost_bytes: None,
                 decision,
             });
         }
@@ -1324,46 +1410,85 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn cancelled_partial_automatic_plan_does_not_update_transport_estimates()
-    -> std::result::Result<(), Box<dyn std::error::Error>> {
-        let first = PutPayload::from_static(b"abc")
-            .into_iter()
-            .next()
-            .ok_or_else(missing_chunk)?;
-        let payload = stream::iter([Ok(first)])
-            .chain(stream::pending::<Result<Bytes>>())
-            .boxed();
-        let metrics = direct_metrics();
-        let store = Arc::new(MeteredParquetObjectStore::new(
-            Arc::new(ScriptedGetStore::new(test_get_result(
-                GetResultPayload::Stream(payload),
-                0..8,
-            ))),
-            metrics.clone(),
-            MultiRangeReadStrategy::ChooseAutomatically,
-        ));
-        let started = Instant::now();
-        for _ in 0..2 {
-            store.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
-        }
-
-        let task_store = Arc::clone(&store);
-        let task = tokio::spawn(async move {
-            task_store
-                .get_ranges(&Path::from("data.parquet"), &[0..4, 4..8])
-                .await
+    #[test]
+    fn failed_automatic_plan_emits_no_completion_and_adds_no_sample() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let ((result, estimate), events) = capture_range_planning_events(|| {
+            runtime.block_on(async {
+                let store = MeteredParquetObjectStore::new(
+                    Arc::new(InMemory::new()),
+                    direct_metrics(),
+                    MultiRangeReadStrategy::ChooseAutomatically,
+                );
+                let started = Instant::now();
+                for _ in 0..2 {
+                    store.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
+                }
+                let result = store
+                    .get_ranges(&Path::from("private-missing.parquet"), &[0..4, 8..12])
+                    .await;
+                (result, store.current_transport_estimate())
+            })
         });
-        tokio::time::timeout(Duration::from_secs(5), async {
-            while metrics.snapshot().parquet_data_file_bytes_received != Some(3) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await?;
 
-        task.abort();
-        assert!(task.await.is_err_and(|error| error.is_cancelled()));
-        assert_eq!(store.current_transport_estimate(), (2, None));
+        assert!(result.is_err());
+        assert_eq!(estimate, (2, None));
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn cancelled_partial_automatic_plan_emits_no_completion_and_adds_no_sample()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let (result, events) = capture_range_planning_events(|| {
+            runtime.block_on(async {
+                let first = PutPayload::from_static(b"abc")
+                    .into_iter()
+                    .next()
+                    .ok_or_else(missing_chunk)?;
+                let payload = stream::iter([Ok(first)])
+                    .chain(stream::pending::<Result<Bytes>>())
+                    .boxed();
+                let metrics = direct_metrics();
+                let store = Arc::new(MeteredParquetObjectStore::new(
+                    Arc::new(ScriptedGetStore::new(test_get_result(
+                        GetResultPayload::Stream(payload),
+                        0..8,
+                    ))),
+                    metrics.clone(),
+                    MultiRangeReadStrategy::ChooseAutomatically,
+                ));
+                let started = Instant::now();
+                for _ in 0..2 {
+                    store.record_completed_range_reads(&[completed_read(started, 10, 1_000)]);
+                }
+
+                let task_store = Arc::clone(&store);
+                let task = tokio::spawn(async move {
+                    task_store
+                        .get_ranges(&Path::from("data.parquet"), &[0..4, 4..8])
+                        .await
+                });
+                tokio::time::timeout(Duration::from_secs(5), async {
+                    while metrics.snapshot().parquet_data_file_bytes_received != Some(3) {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await?;
+
+                task.abort();
+                assert!(task.await.is_err_and(|error| error.is_cancelled()));
+                assert_eq!(store.current_transport_estimate(), (2, None));
+                Ok::<_, Box<dyn std::error::Error>>(())
+            })
+        });
+        result?;
+        assert!(events.is_empty());
         Ok(())
     }
 

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -31,16 +31,36 @@ pub(super) enum RangePlanDecision {
     CostBasedMerged,
 }
 
+impl RangePlanDecision {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::ColdStart => "cold_start",
+            Self::CostBasedExact => "cost_based_exact",
+            Self::CostBasedMerged => "cost_based_merged",
+        }
+    }
+}
+
 /// The exact request summary and physical ranges selected by the automatic planner.
 pub(super) struct ChosenRangePlan {
     /// Number of ranges in the normalized minimum-byte plan.
     pub(super) exact_range_count: usize,
     /// Bytes covered by the normalized minimum-byte plan.
     pub(super) exact_bytes: u128,
+    /// Number of ranges in the plan used when no transport estimate is available.
+    pub(super) baseline_range_count: usize,
+    /// Bytes covered by the plan used when no transport estimate is available.
+    pub(super) baseline_bytes: u128,
     /// Physical ranges to read.
     pub(super) physical_ranges: Vec<Range<u64>>,
     /// Bytes covered by the physical ranges.
     pub(super) planned_bytes: u128,
+    /// Transport conditions used to compare the eligible plans.
+    pub(super) transport_estimate: Option<TransportEstimate>,
+    /// Predicted cost of the cold-start baseline, in byte-equivalent units.
+    pub(super) baseline_predicted_score: Option<u128>,
+    /// Predicted cost of the selected plan, in byte-equivalent units.
+    pub(super) selected_predicted_score: Option<u128>,
     /// Reason the physical plan was selected.
     pub(super) decision: RangePlanDecision,
 }
@@ -98,8 +118,13 @@ pub(super) fn choose_range_plan(
         return ChosenRangePlan {
             exact_range_count: 0,
             exact_bytes: 0,
+            baseline_range_count: 0,
+            baseline_bytes: 0,
             physical_ranges: Vec::new(),
             planned_bytes: 0,
+            transport_estimate: None,
+            baseline_predicted_score: None,
+            selected_predicted_score: None,
             decision: RangePlanDecision::ColdStart,
         };
     };
@@ -108,41 +133,59 @@ pub(super) fn choose_range_plan(
     let candidate_start =
         usize::from(exact_plan.len() > MAX_RANGE_READ_REQUESTS && candidates.len() > 1);
     let eligible_candidates = &candidates[candidate_start..];
-    let (physical_ranges, decision) =
-        match estimate.filter(|estimate| estimate.shared_throughput_bytes_per_second > 0) {
-            None => (eligible_candidates[0].clone(), RangePlanDecision::ColdStart),
-            Some(estimate) => {
-                let best_score = eligible_candidates
-                    .iter()
-                    .map(|plan| plan_score(plan, estimate, MAX_CONCURRENT_PARQUET_RANGE_READS))
-                    .min()
-                    .unwrap_or(0);
-                let competitive_score = best_score
-                    .saturating_add(best_score.saturating_mul(DECISION_MARGIN_PERCENT) / 100);
-                let plan = eligible_candidates
-                    .iter()
-                    .filter(|plan| {
-                        plan_score(plan, estimate, MAX_CONCURRENT_PARQUET_RANGE_READS)
-                            <= competitive_score
-                    })
-                    .min_by_key(|plan| (range_bytes(plan), plan.len()))
-                    .cloned()
-                    .unwrap_or_else(|| exact_plan.clone());
-                let decision = if plan == *exact_plan {
-                    RangePlanDecision::CostBasedExact
-                } else {
-                    RangePlanDecision::CostBasedMerged
-                };
-                (plan, decision)
-            }
-        };
+    let baseline_plan = &eligible_candidates[0];
+    let baseline_range_count = baseline_plan.len();
+    let baseline_bytes = range_bytes(baseline_plan);
+    let transport_estimate =
+        estimate.filter(|estimate| estimate.shared_throughput_bytes_per_second > 0);
+    let (physical_ranges, decision) = match transport_estimate {
+        None => (eligible_candidates[0].clone(), RangePlanDecision::ColdStart),
+        Some(estimate) => {
+            let best_score = eligible_candidates
+                .iter()
+                .map(|plan| plan_score(plan, estimate, MAX_CONCURRENT_PARQUET_RANGE_READS))
+                .min()
+                .unwrap_or(0);
+            let competitive_score =
+                best_score.saturating_add(best_score.saturating_mul(DECISION_MARGIN_PERCENT) / 100);
+            let plan = eligible_candidates
+                .iter()
+                .filter(|plan| {
+                    plan_score(plan, estimate, MAX_CONCURRENT_PARQUET_RANGE_READS)
+                        <= competitive_score
+                })
+                .min_by_key(|plan| (range_bytes(plan), plan.len()))
+                .cloned()
+                .unwrap_or_else(|| exact_plan.clone());
+            let decision = if plan == *exact_plan {
+                RangePlanDecision::CostBasedExact
+            } else {
+                RangePlanDecision::CostBasedMerged
+            };
+            (plan, decision)
+        }
+    };
     let planned_bytes = range_bytes(&physical_ranges);
+    let baseline_predicted_score = transport_estimate
+        .map(|estimate| plan_score(baseline_plan, estimate, MAX_CONCURRENT_PARQUET_RANGE_READS));
+    let selected_predicted_score = transport_estimate.map(|estimate| {
+        plan_score(
+            &physical_ranges,
+            estimate,
+            MAX_CONCURRENT_PARQUET_RANGE_READS,
+        )
+    });
 
     ChosenRangePlan {
         exact_range_count,
         exact_bytes,
+        baseline_range_count,
+        baseline_bytes,
         physical_ranges,
         planned_bytes,
+        transport_estimate,
+        baseline_predicted_score,
+        selected_predicted_score,
         decision,
     }
 }
@@ -210,7 +253,7 @@ pub(super) fn range_bytes(plan: &[Range<u64>]) -> u128 {
 }
 
 /// Returns how many rounds of requests a plan needs at the given concurrency.
-fn request_waves(request_count: usize, max_concurrent_reads: usize) -> usize {
+pub(super) fn request_waves(request_count: usize, max_concurrent_reads: usize) -> usize {
     request_count.div_ceil(max_concurrent_reads.max(1))
 }
 
@@ -220,15 +263,20 @@ fn plan_score(
     estimate: TransportEstimate,
     max_concurrent_reads: usize,
 ) -> u128 {
-    let bandwidth_delay_bytes = estimate
-        .request_latency
-        .as_nanos()
-        .saturating_mul(u128::from(estimate.shared_throughput_bytes_per_second))
-        / 1_000_000_000;
+    let bandwidth_delay_bytes = bandwidth_delay_bytes(estimate);
     range_bytes(plan).saturating_add(
         (request_waves(plan.len(), max_concurrent_reads) as u128)
             .saturating_mul(bandwidth_delay_bytes),
     )
+}
+
+/// Returns the bytes transferable during one typical request-latency interval.
+pub(super) fn bandwidth_delay_bytes(estimate: TransportEstimate) -> u128 {
+    estimate
+        .request_latency
+        .as_nanos()
+        .saturating_mul(u128::from(estimate.shared_throughput_bytes_per_second))
+        / 1_000_000_000
 }
 
 /// Executes an already chosen physical plan and returns one result for each requested range.
@@ -273,8 +321,8 @@ mod tests {
     use bytes::Bytes;
 
     use super::{
-        RangePlanDecision, TransportEstimate, candidate_range_plans, choose_range_plan,
-        execute_range_plan, merge_ranges, plan_score, range_bytes,
+        RangePlanDecision, TransportEstimate, bandwidth_delay_bytes, candidate_range_plans,
+        choose_range_plan, execute_range_plan, merge_ranges, plan_score, range_bytes,
     };
 
     #[test]
@@ -322,9 +370,21 @@ mod tests {
         let cold_plan = choose_range_plan(&requested_ranges, None);
         assert_eq!(cold_plan.physical_ranges.len(), 11);
         assert_eq!(cold_plan.decision, RangePlanDecision::ColdStart);
+        assert_eq!(cold_plan.transport_estimate, None);
+        assert_eq!(cold_plan.baseline_predicted_score, None);
+        assert_eq!(cold_plan.selected_predicted_score, None);
         let exact_plan = choose_range_plan(&requested_ranges, Some(low_bandwidth));
         assert_eq!(exact_plan.physical_ranges.len(), 11);
         assert_eq!(exact_plan.decision, RangePlanDecision::CostBasedExact);
+        assert_eq!(exact_plan.transport_estimate, Some(low_bandwidth));
+        assert_eq!(
+            exact_plan.baseline_predicted_score,
+            Some(plan_score(&exact_plan.physical_ranges, low_bandwidth, 10))
+        );
+        assert_eq!(
+            exact_plan.selected_predicted_score,
+            exact_plan.baseline_predicted_score
+        );
         assert_eq!(
             choose_range_plan(&requested_ranges, Some(near_boundary))
                 .physical_ranges
@@ -334,6 +394,16 @@ mod tests {
         let merged_plan = choose_range_plan(&requested_ranges, Some(high_bandwidth));
         assert_eq!(merged_plan.physical_ranges.len(), 10);
         assert_eq!(merged_plan.decision, RangePlanDecision::CostBasedMerged);
+        assert_eq!(merged_plan.baseline_range_count, 11);
+        assert_eq!(merged_plan.baseline_bytes, 1_100);
+        assert_eq!(
+            merged_plan.baseline_predicted_score,
+            Some(1_100 + 2 * bandwidth_delay_bytes(high_bandwidth))
+        );
+        assert_eq!(
+            merged_plan.selected_predicted_score,
+            Some(2_000 + bandwidth_delay_bytes(high_bandwidth))
+        );
     }
 
     #[test]

--- a/src/reader/backend/direct_parquet/range_planning.rs
+++ b/src/reader/backend/direct_parquet/range_planning.rs
@@ -58,9 +58,9 @@ pub(super) struct ChosenRangePlan {
     /// Transport conditions used to compare the eligible plans.
     pub(super) transport_estimate: Option<TransportEstimate>,
     /// Predicted cost of the cold-start baseline, in byte-equivalent units.
-    pub(super) baseline_predicted_score: Option<u128>,
+    pub(super) baseline_predicted_cost_bytes: Option<u128>,
     /// Predicted cost of the selected plan, in byte-equivalent units.
-    pub(super) selected_predicted_score: Option<u128>,
+    pub(super) selected_predicted_cost_bytes: Option<u128>,
     /// Reason the physical plan was selected.
     pub(super) decision: RangePlanDecision,
 }
@@ -123,8 +123,8 @@ pub(super) fn choose_range_plan(
             physical_ranges: Vec::new(),
             planned_bytes: 0,
             transport_estimate: None,
-            baseline_predicted_score: None,
-            selected_predicted_score: None,
+            baseline_predicted_cost_bytes: None,
+            selected_predicted_cost_bytes: None,
             decision: RangePlanDecision::ColdStart,
         };
     };
@@ -166,9 +166,9 @@ pub(super) fn choose_range_plan(
         }
     };
     let planned_bytes = range_bytes(&physical_ranges);
-    let baseline_predicted_score = transport_estimate
+    let baseline_predicted_cost_bytes = transport_estimate
         .map(|estimate| plan_score(baseline_plan, estimate, MAX_CONCURRENT_PARQUET_RANGE_READS));
-    let selected_predicted_score = transport_estimate.map(|estimate| {
+    let selected_predicted_cost_bytes = transport_estimate.map(|estimate| {
         plan_score(
             &physical_ranges,
             estimate,
@@ -184,8 +184,8 @@ pub(super) fn choose_range_plan(
         physical_ranges,
         planned_bytes,
         transport_estimate,
-        baseline_predicted_score,
-        selected_predicted_score,
+        baseline_predicted_cost_bytes,
+        selected_predicted_cost_bytes,
         decision,
     }
 }
@@ -371,19 +371,19 @@ mod tests {
         assert_eq!(cold_plan.physical_ranges.len(), 11);
         assert_eq!(cold_plan.decision, RangePlanDecision::ColdStart);
         assert_eq!(cold_plan.transport_estimate, None);
-        assert_eq!(cold_plan.baseline_predicted_score, None);
-        assert_eq!(cold_plan.selected_predicted_score, None);
+        assert_eq!(cold_plan.baseline_predicted_cost_bytes, None);
+        assert_eq!(cold_plan.selected_predicted_cost_bytes, None);
         let exact_plan = choose_range_plan(&requested_ranges, Some(low_bandwidth));
         assert_eq!(exact_plan.physical_ranges.len(), 11);
         assert_eq!(exact_plan.decision, RangePlanDecision::CostBasedExact);
         assert_eq!(exact_plan.transport_estimate, Some(low_bandwidth));
         assert_eq!(
-            exact_plan.baseline_predicted_score,
+            exact_plan.baseline_predicted_cost_bytes,
             Some(plan_score(&exact_plan.physical_ranges, low_bandwidth, 10))
         );
         assert_eq!(
-            exact_plan.selected_predicted_score,
-            exact_plan.baseline_predicted_score
+            exact_plan.selected_predicted_cost_bytes,
+            exact_plan.baseline_predicted_cost_bytes
         );
         assert_eq!(
             choose_range_plan(&requested_ranges, Some(near_boundary))
@@ -397,11 +397,11 @@ mod tests {
         assert_eq!(merged_plan.baseline_range_count, 11);
         assert_eq!(merged_plan.baseline_bytes, 1_100);
         assert_eq!(
-            merged_plan.baseline_predicted_score,
+            merged_plan.baseline_predicted_cost_bytes,
             Some(1_100 + 2 * bandwidth_delay_bytes(high_bandwidth))
         );
         assert_eq!(
-            merged_plan.selected_predicted_score,
+            merged_plan.selected_predicted_cost_bytes,
             Some(2_000 + bandwidth_delay_bytes(high_bandwidth))
         );
     }


### PR DESCRIPTION
## Summary

- emit one structured debug completion event for each successful automatic Parquet range plan
- report the estimator sample count, transport estimate, bandwidth-delay value, plan shapes, and exact byte-equivalent costs used by the decision
- keep failed and cancelled plans, object paths, credentials, schema details, and predicates out of successful diagnostics

## Verification

- cargo test --locked
- cargo test --locked --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
- cargo fmt --all -- --check

Closes #74