### PR TITLE
feat: add opt-in Parquet metadata preparation for faster repeated queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ test = false
 
 [features]
 datafusion = ["dep:datafusion"]
+experimental-parquet-metadata-preparation = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 [[bench]]
 name = "reader"
 harness = false
-required-features = ["datafusion"]
+required-features = ["datafusion", "experimental-parquet-metadata-preparation"]
 test = false
 
 [[bench]]

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -17,7 +17,8 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use delta_arrow_reader::{
-    DeltaScanExecutionOptions, DeltaStorageOptions, DeltaTableBuilder, ParquetReaderBackend,
+    DeltaScanExecutionOptions, DeltaStorageOptions, DeltaTableBuilder,
+    ParquetMetadataPreparationLimits, ParquetMetadataPreparationReport, ParquetReaderBackend,
     datafusion::{ScanMetricsSnapshot, ScanOptions, collect_scan_metrics, register_table},
 };
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
@@ -29,7 +30,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 
 const MIB: u64 = 1024 * 1024;
-const BENCHMARK_SCHEMA_VERSION: u32 = 31;
+const BENCHMARK_SCHEMA_VERSION: u32 = 32;
 const DEFAULT_REPETITIONS: usize = 3;
 const DEFAULT_QUERIES_PER_TABLE: usize = 1;
 const MAX_REPETITIONS: usize = 128;
@@ -40,7 +41,7 @@ const PROTOCOL_JSON: &str = r#"{"protocol":{"minReaderVersion":1,"minWriterVersi
 const DELETION_VECTOR_PROTOCOL_JSON: &str = r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["deletionVectors"],"writerFeatures":["deletionVectors"]}}"#;
 const RELATIVE_DV_ID: &str = "vBn[lx{q8@P<9BNH/isA";
 const RELATIVE_DV_FILE: &str = "deletion_vector_61d16c75-6994-46b7-a15b-8b538852e50e.bin";
-const EXPECTED_FIXTURE_FINGERPRINTS: [(&str, &str); 4] = [
+const EXPECTED_FIXTURE_FINGERPRINTS: [(&str, &str); 5] = [
     ("provider_few_larger_files", "fnv1a64:a3f6509701b2a6fc"),
     ("provider_many_small_files", "fnv1a64:05a1a9efa301e8be"),
     ("provider_many_unequal_files", "fnv1a64:e29235befe1d61e3"),
@@ -48,9 +49,10 @@ const EXPECTED_FIXTURE_FINGERPRINTS: [(&str, &str); 4] = [
         "provider_few_larger_files_sparse_dv",
         "fnv1a64:e1509da31486f25a",
     ),
+    ("provider_4096_tiny_files", "fnv1a64:25e64f77ded44bc9"),
 ];
 
-const CSV_HEADER: [&str; 87] = [
+const CSV_HEADER: [&str; 96] = [
     "benchmark_schema_version",
     "benchmark_mode",
     "host_os",
@@ -63,6 +65,7 @@ const CSV_HEADER: [&str; 87] = [
     "query_case",
     "parquet_backend",
     "scan_metadata_mode",
+    "parquet_metadata_mode",
     "scheduling_mode",
     "scan_target_partitions",
     "max_concurrent_file_reads_per_scan",
@@ -108,6 +111,14 @@ const CSV_HEADER: [&str; 87] = [
     "table_initialization_micros_p50",
     "table_initialization_micros_p95",
     "table_initialization_micros_p99",
+    "parquet_metadata_preparation_micros_p50",
+    "parquet_metadata_preparation_micros_p95",
+    "parquet_metadata_preparation_micros_p99",
+    "prepared_parquet_metadata_file_count_p50",
+    "prepared_parquet_metadata_memory_bytes_p50",
+    "parquet_metadata_preparation_range_get_operations_p50",
+    "parquet_metadata_preparation_full_get_operations_p50",
+    "parquet_metadata_preparation_bytes_received_p50",
     "session_total_micros_p50",
     "session_total_micros_p95",
     "session_total_micros_p99",
@@ -149,6 +160,7 @@ struct Config {
     query: Query,
     backend: ParquetReaderBackend,
     scan_metadata_mode: ScanMetadataMode,
+    parquet_metadata_mode: ParquetMetadataMode,
     queries_per_table: usize,
     repetitions: usize,
     metadata_size_hint_bytes: Option<usize>,
@@ -161,6 +173,12 @@ struct Config {
 enum ScanMetadataMode {
     Lazy,
     Eager,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParquetMetadataMode {
+    OnDemand,
+    Prepared,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -177,6 +195,7 @@ enum Workload {
     ManySmall,
     ManyUnequal,
     FewLargerSparseDv,
+    FourThousandTinyFiles,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -238,6 +257,7 @@ struct QueryMeasurement {
 #[derive(Debug)]
 struct RepetitionMeasurement {
     table_initialization_micros: u64,
+    parquet_metadata_preparation: Option<ParquetMetadataPreparationMeasurement>,
     session_total_micros: u64,
     #[cfg(test)]
     #[allow(dead_code)]
@@ -246,6 +266,12 @@ struct RepetitionMeasurement {
     #[allow(dead_code)]
     table_registration_count: usize,
     query_measurements: Vec<QueryMeasurement>,
+}
+
+#[derive(Debug)]
+struct ParquetMetadataPreparationMeasurement {
+    micros: u64,
+    prepared: ParquetMetadataPreparationReport,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -270,8 +296,19 @@ struct Summary {
     peak_rss: Option<u64>,
     peak_rss_delta: Option<u64>,
     table_initialization: Percentiles,
+    parquet_metadata_preparation: ParquetMetadataPreparationSummary,
     session_total: Percentiles,
     read: ReadSummary,
+}
+
+#[derive(Debug)]
+struct ParquetMetadataPreparationSummary {
+    micros: Option<Percentiles>,
+    file_count: Option<u64>,
+    memory_bytes: Option<u64>,
+    range_gets: Option<u64>,
+    full_gets: Option<u64>,
+    bytes_received: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -336,6 +373,7 @@ impl Config {
             query: Query::FullRows,
             backend: ParquetReaderBackend::Direct,
             scan_metadata_mode: ScanMetadataMode::Lazy,
+            parquet_metadata_mode: ParquetMetadataMode::OnDemand,
             queries_per_table: DEFAULT_QUERIES_PER_TABLE,
             repetitions: DEFAULT_REPETITIONS,
             metadata_size_hint_bytes: Some(65_536),
@@ -378,6 +416,10 @@ impl Config {
                 "--provider-exec-scan-metadata-mode" => {
                     config.scan_metadata_mode =
                         ScanMetadataMode::parse(&required_arg(&mut args, &argument)?)?
+                }
+                "--provider-exec-parquet-metadata-mode" => {
+                    config.parquet_metadata_mode =
+                        ParquetMetadataMode::parse(&required_arg(&mut args, &argument)?)?
                 }
                 "--provider-exec-queries-per-table" => {
                     config.queries_per_table = required_arg(&mut args, &argument)?.parse()?;
@@ -422,6 +464,20 @@ impl Config {
     }
 
     fn validate(&self) -> Result<(), Box<dyn Error>> {
+        if self.parquet_metadata_mode == ParquetMetadataMode::Prepared
+            && (self.backend != ParquetReaderBackend::Direct
+                || self.scan_metadata_mode != ScanMetadataMode::Eager)
+        {
+            return Err(invalid(
+                "prepared Parquet metadata requires the direct backend and eager scan metadata",
+            )
+            .into());
+        }
+        if matches!(self.workload, Workload::FourThousandTinyFiles)
+            && self.scan_metadata_mode != ScanMetadataMode::Eager
+        {
+            return Err(invalid("the 4,096-file workload requires eager scan metadata").into());
+        }
         let case = (
             self.workload,
             self.query,
@@ -450,7 +506,7 @@ impl Config {
                 Workload::ManyUnequal,
                 Query::FilterTailIds,
                 ParquetReaderBackend::Direct,
-                "local",
+                "local" | "s3_throttled",
                 Some(65_536),
                 None,
             ) | (
@@ -488,10 +544,17 @@ impl Config {
                 "s3_throttled",
                 Some(65_536),
                 None,
+            ) | (
+                Workload::FourThousandTinyFiles,
+                Query::ProjectId,
+                ParquetReaderBackend::Direct,
+                "local" | "s3_throttled",
+                Some(65_536),
+                None,
             )
         );
         if self.seed != 0 || !frozen {
-            return Err(invalid("configuration is not one of the 12 frozen cases").into());
+            return Err(invalid("configuration is not one of the 15 frozen cases").into());
         }
         Ok(())
     }
@@ -518,6 +581,23 @@ impl ScanMetadataMode {
         match self {
             Self::Lazy => "lazy",
             Self::Eager => "eager",
+        }
+    }
+}
+
+impl ParquetMetadataMode {
+    fn parse(value: &str) -> Result<Self, io::Error> {
+        match value.replace('-', "_").as_str() {
+            "on_demand" => Ok(Self::OnDemand),
+            "prepared" => Ok(Self::Prepared),
+            other => Err(invalid(format!("unknown Parquet metadata mode: {other}"))),
+        }
+    }
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::OnDemand => "on_demand",
+            Self::Prepared => "prepared",
         }
     }
 }
@@ -561,6 +641,7 @@ impl Workload {
             "provider_many_small_files" => Ok(Self::ManySmall),
             "provider_many_unequal_files" => Ok(Self::ManyUnequal),
             "provider_few_larger_files_sparse_dv" => Ok(Self::FewLargerSparseDv),
+            "provider_4096_tiny_files" => Ok(Self::FourThousandTinyFiles),
             other => Err(invalid(format!("unknown frozen workload: {other}"))),
         }
     }
@@ -571,6 +652,7 @@ impl Workload {
             Self::ManySmall => "provider_many_small_files",
             Self::ManyUnequal => "provider_many_unequal_files",
             Self::FewLargerSparseDv => "provider_few_larger_files_sparse_dv",
+            Self::FourThousandTinyFiles => "provider_4096_tiny_files",
         }
     }
 
@@ -587,6 +669,7 @@ impl Workload {
                     }
                 })
                 .collect(),
+            Self::FourThousandTinyFiles => vec![1; 4_096],
         };
         rows.into_iter()
             .enumerate()
@@ -600,7 +683,9 @@ impl Workload {
     const fn deleted_rows(self) -> &'static [u64] {
         match self {
             Self::FewLargerSparseDv => &[1, 4_096, 8_191],
-            _ => &[],
+            Self::FewLarger | Self::ManySmall | Self::ManyUnequal | Self::FourThousandTinyFiles => {
+                &[]
+            }
         }
     }
 }
@@ -1390,14 +1475,35 @@ async fn run_repetition(
     };
     let session_started = Instant::now();
     let table_initialization_started = session_started;
-    let table = match config.scan_metadata_mode {
-        ScanMetadataMode::Lazy => builder.load_table().await?,
-        ScanMetadataMode::Eager => builder.load_table_with_eager_scan_metadata().await?,
+    let table = match (config.scan_metadata_mode, config.parquet_metadata_mode) {
+        (ScanMetadataMode::Lazy, ParquetMetadataMode::OnDemand) => builder.load_table().await?,
+        (ScanMetadataMode::Eager, ParquetMetadataMode::OnDemand) => {
+            builder.load_table_with_eager_scan_metadata().await?
+        }
+        (ScanMetadataMode::Eager, ParquetMetadataMode::Prepared) => {
+            builder
+                .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                    max_files: fixture.file_count,
+                    max_retained_metadata_bytes: usize::MAX,
+                })
+                .await?
+        }
+        (ScanMetadataMode::Lazy, ParquetMetadataMode::Prepared) => {
+            return Err("prepared Parquet metadata requires eager scan metadata".into());
+        }
     };
     #[cfg(test)]
     let table_load_count = 1;
     let table_initialization_micros =
         saturating_u64(table_initialization_started.elapsed().as_micros());
+    let parquet_metadata_preparation =
+        table
+            .parquet_metadata_preparation_report()
+            .cloned()
+            .map(|prepared| ParquetMetadataPreparationMeasurement {
+                micros: saturating_u64(prepared.preparation_duration.as_micros()),
+                prepared,
+            });
     register_table(&context, "orders", table, scan_options)?;
     #[cfg(test)]
     let table_registration_count = 1;
@@ -1409,6 +1515,7 @@ async fn run_repetition(
     let session_total_micros = saturating_u64(session_started.elapsed().as_micros());
     Ok(RepetitionMeasurement {
         table_initialization_micros,
+        parquet_metadata_preparation,
         session_total_micros,
         #[cfg(test)]
         table_load_count,
@@ -1615,6 +1722,7 @@ fn summarize(repetitions: &[RepetitionMeasurement]) -> Summary {
                 .map(|repetition| repetition.table_initialization_micros)
                 .collect::<Vec<_>>(),
         ),
+        parquet_metadata_preparation: summarize_parquet_metadata_preparation(repetitions),
         session_total: percentiles(
             &repetitions
                 .iter()
@@ -1622,6 +1730,76 @@ fn summarize(repetitions: &[RepetitionMeasurement]) -> Summary {
                 .collect::<Vec<_>>(),
         ),
         read: summarize_read(&measurements),
+    }
+}
+
+fn summarize_parquet_metadata_preparation(
+    repetitions: &[RepetitionMeasurement],
+) -> ParquetMetadataPreparationSummary {
+    let Some(measurements) = repetitions
+        .iter()
+        .map(|repetition| repetition.parquet_metadata_preparation.as_ref())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return ParquetMetadataPreparationSummary {
+            micros: None,
+            file_count: None,
+            memory_bytes: None,
+            range_gets: None,
+            full_gets: None,
+            bytes_received: None,
+        };
+    };
+    ParquetMetadataPreparationSummary {
+        micros: Some(percentiles(
+            &measurements
+                .iter()
+                .map(|measurement| measurement.micros)
+                .collect::<Vec<_>>(),
+        )),
+        file_count: Some(percentile(
+            &measurements
+                .iter()
+                .map(|measurement| saturating_u64(measurement.prepared.files_prepared as u128))
+                .collect::<Vec<_>>(),
+            50,
+        )),
+        memory_bytes: Some(percentile(
+            &measurements
+                .iter()
+                .map(|measurement| {
+                    saturating_u64(measurement.prepared.estimated_retained_metadata_bytes as u128)
+                })
+                .collect::<Vec<_>>(),
+            50,
+        )),
+        range_gets: optional_percentile(
+            measurements.iter().map(|measurement| {
+                measurement
+                    .prepared
+                    .read_metrics
+                    .parquet_data_file_range_get_operations
+            }),
+            50,
+        ),
+        full_gets: optional_percentile(
+            measurements.iter().map(|measurement| {
+                measurement
+                    .prepared
+                    .read_metrics
+                    .parquet_data_file_full_get_operations
+            }),
+            50,
+        ),
+        bytes_received: optional_percentile(
+            measurements.iter().map(|measurement| {
+                measurement
+                    .prepared
+                    .read_metrics
+                    .parquet_data_file_bytes_received
+            }),
+            50,
+        ),
     }
 }
 
@@ -1747,6 +1925,7 @@ fn csv_row(
 ) -> Vec<String> {
     let summary = summarize(repetitions);
     let read = &summary.read;
+    let preparation = &summary.parquet_metadata_preparation;
     let row = vec![
         BENCHMARK_SCHEMA_VERSION.to_string(),
         "provider_exec".to_owned(),
@@ -1760,6 +1939,7 @@ fn csv_row(
         config.query.name().to_owned(),
         backend_name(config.backend).to_owned(),
         config.scan_metadata_mode.name().to_owned(),
+        config.parquet_metadata_mode.name().to_owned(),
         "prefetch_2_ap_target_scan_3x".to_owned(),
         target_partitions.to_string(),
         target_partitions.saturating_mul(3).max(1).to_string(),
@@ -1807,6 +1987,14 @@ fn csv_row(
         summary.table_initialization.p50.to_string(),
         summary.table_initialization.p95.to_string(),
         summary.table_initialization.p99.to_string(),
+        optional(preparation.micros.map(|micros| micros.p50)),
+        optional(preparation.micros.map(|micros| micros.p95)),
+        optional(preparation.micros.map(|micros| micros.p99)),
+        optional(preparation.file_count),
+        optional(preparation.memory_bytes),
+        optional(preparation.range_gets),
+        optional(preparation.full_gets),
+        optional(preparation.bytes_received),
         summary.session_total.p50.to_string(),
         summary.session_total.p95.to_string(),
         summary.session_total.p99.to_string(),
@@ -1934,6 +2122,7 @@ mod tests {
             query,
             backend,
             scan_metadata_mode: ScanMetadataMode::Lazy,
+            parquet_metadata_mode: ParquetMetadataMode::OnDemand,
             queries_per_table: DEFAULT_QUERIES_PER_TABLE,
             repetitions: 1,
             metadata_size_hint_bytes,
@@ -1951,7 +2140,7 @@ mod tests {
     }
 
     #[test]
-    fn frozen_matrix_contains_exactly_twelve_cases() -> TestResult {
+    fn frozen_matrix_contains_exactly_fifteen_cases() -> TestResult {
         let local = StorageProfile::local();
         let throttled = StorageProfile::throttled();
         let cases = [
@@ -2051,10 +2240,39 @@ mod tests {
                 Some(65_536),
                 None,
             ),
+            config(
+                Workload::FourThousandTinyFiles,
+                Query::ProjectId,
+                ParquetReaderBackend::Direct,
+                local,
+                Some(65_536),
+                None,
+            ),
+            config(
+                Workload::FourThousandTinyFiles,
+                Query::ProjectId,
+                ParquetReaderBackend::Direct,
+                throttled,
+                Some(65_536),
+                None,
+            ),
+            config(
+                Workload::ManyUnequal,
+                Query::FilterTailIds,
+                ParquetReaderBackend::Direct,
+                throttled,
+                Some(65_536),
+                None,
+            ),
         ];
-        assert_eq!(cases.len(), 12);
+        assert_eq!(cases.len(), 15);
         for mut case in cases {
-            for mode in [ScanMetadataMode::Lazy, ScanMetadataMode::Eager] {
+            let scan_metadata_modes = if matches!(case.workload, Workload::FourThousandTinyFiles) {
+                &[ScanMetadataMode::Eager][..]
+            } else {
+                &[ScanMetadataMode::Lazy, ScanMetadataMode::Eager][..]
+            };
+            for &mode in scan_metadata_modes {
                 case.scan_metadata_mode = mode;
                 case.validate()?;
             }
@@ -2068,6 +2286,19 @@ mod tests {
             None,
         );
         assert!(outside.validate().is_err());
+        let mut prepared = config(
+            Workload::FewLarger,
+            Query::FullRows,
+            ParquetReaderBackend::Direct,
+            local,
+            Some(65_536),
+            None,
+        );
+        prepared.scan_metadata_mode = ScanMetadataMode::Eager;
+        prepared.parquet_metadata_mode = ParquetMetadataMode::Prepared;
+        prepared.validate()?;
+        prepared.scan_metadata_mode = ScanMetadataMode::Lazy;
+        assert!(prepared.validate().is_err());
         Ok(())
     }
 
@@ -2089,6 +2320,8 @@ mod tests {
                 "direct_parquet",
                 "--provider-exec-scan-metadata-mode",
                 "eager",
+                "--provider-exec-parquet-metadata-mode",
+                "prepared",
                 "--provider-exec-queries-per-table",
                 "128",
                 "--provider-exec-scheduling-profile",
@@ -2113,6 +2346,7 @@ mod tests {
         assert_eq!(parsed.query.name(), "full_rows");
         assert!(matches!(parsed.backend, ParquetReaderBackend::Direct));
         assert_eq!(parsed.scan_metadata_mode, ScanMetadataMode::Eager);
+        assert_eq!(parsed.parquet_metadata_mode, ParquetMetadataMode::Prepared);
         assert_eq!(parsed.queries_per_table, 128);
         assert_eq!(parsed.repetitions, 5);
         assert_eq!(parsed.metadata_size_hint_bytes, Some(65_536));
@@ -2131,6 +2365,10 @@ mod tests {
         assert_eq!(defaults.query.name(), "full_rows");
         assert!(matches!(defaults.backend, ParquetReaderBackend::Direct));
         assert_eq!(defaults.scan_metadata_mode, ScanMetadataMode::Lazy);
+        assert_eq!(
+            defaults.parquet_metadata_mode,
+            ParquetMetadataMode::OnDemand
+        );
         assert_eq!(defaults.queries_per_table, DEFAULT_QUERIES_PER_TABLE);
         assert_eq!(defaults.repetitions, DEFAULT_REPETITIONS);
         assert_eq!(defaults.metadata_size_hint_bytes, Some(65_536));
@@ -2161,6 +2399,29 @@ mod tests {
                 .is_err()
         );
         assert!(Config::parse(["--provider-exec-scan-metadata-mode"].map(str::to_owned)).is_err());
+        assert_eq!(
+            Config::parse(
+                [
+                    "--provider-exec-scan-metadata-mode",
+                    "eager",
+                    "--provider-exec-parquet-metadata-mode",
+                    "prepared",
+                ]
+                .map(str::to_owned),
+            )?
+            .parquet_metadata_mode,
+            ParquetMetadataMode::Prepared
+        );
+        assert!(
+            Config::parse(["--provider-exec-parquet-metadata-mode", "prepared"].map(str::to_owned))
+                .is_err()
+        );
+        assert!(
+            Config::parse(
+                ["--provider-exec-parquet-metadata-mode", "automatic"].map(str::to_owned)
+            )
+            .is_err()
+        );
         for count in ["1", "128"] {
             assert_eq!(
                 Config::parse(["--provider-exec-queries-per-table", count].map(str::to_owned))?
@@ -2209,6 +2470,7 @@ mod tests {
             drop(fixture);
             assert!(!temporary_path.exists());
         }
+        assert_eq!(Workload::FourThousandTinyFiles.files().len(), 4_096);
         let retained = Fixture::create(
             &env::temp_dir(),
             Workload::FewLarger,
@@ -2274,7 +2536,7 @@ mod tests {
     }
 
     #[test]
-    fn one_registered_table_runs_three_fresh_queries_in_both_metadata_modes() -> TestResult {
+    fn one_registered_table_runs_three_queries_with_on_demand_or_prepared_metadata() -> TestResult {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()?;
@@ -2292,8 +2554,13 @@ mod tests {
                 Fixture::create(&env::temp_dir(), config.workload, config.storage, false)?;
             let expected_rows = expected_rows(config.workload, config.query, &fixture);
 
-            for mode in [ScanMetadataMode::Lazy, ScanMetadataMode::Eager] {
-                config.scan_metadata_mode = mode;
+            for (scan_metadata_mode, parquet_metadata_mode) in [
+                (ScanMetadataMode::Lazy, ParquetMetadataMode::OnDemand),
+                (ScanMetadataMode::Eager, ParquetMetadataMode::OnDemand),
+                (ScanMetadataMode::Eager, ParquetMetadataMode::Prepared),
+            ] {
+                config.scan_metadata_mode = scan_metadata_mode;
+                config.parquet_metadata_mode = parquet_metadata_mode;
                 let repetition = run_repetition(&config, &fixture, 4).await?;
                 let repetitions = [repetition];
                 let summary = summarize(&repetitions);
@@ -2303,6 +2570,26 @@ mod tests {
                 assert_eq!(repetitions[0].table_load_count, 1);
                 assert_eq!(repetitions[0].table_registration_count, 1);
                 assert_eq!(repetitions[0].query_measurements.len(), 3);
+                match parquet_metadata_mode {
+                    ParquetMetadataMode::OnDemand => {
+                        assert!(repetitions[0].parquet_metadata_preparation.is_none());
+                    }
+                    ParquetMetadataMode::Prepared => {
+                        let preparation = repetitions[0]
+                            .parquet_metadata_preparation
+                            .as_ref()
+                            .ok_or("prepared mode did not report metadata preparation")?;
+                        assert_eq!(preparation.prepared.files_prepared, fixture.file_count);
+                        assert!(preparation.prepared.estimated_retained_metadata_bytes > 0);
+                        assert!(
+                            preparation
+                                .prepared
+                                .read_metrics
+                                .parquet_data_file_range_get_operations
+                                .is_some_and(|operations| operations > 0)
+                        );
+                    }
+                }
                 assert!(
                     repetitions[0].session_total_micros
                         >= repetitions[0].table_initialization_micros
@@ -2342,6 +2629,7 @@ mod tests {
         let repetitions = [
             RepetitionMeasurement {
                 table_initialization_micros: 10,
+                parquet_metadata_preparation: None,
                 session_total_micros: 100,
                 table_load_count: 1,
                 table_registration_count: 1,
@@ -2349,6 +2637,7 @@ mod tests {
             },
             RepetitionMeasurement {
                 table_initialization_micros: 30,
+                parquet_metadata_preparation: None,
                 session_total_micros: 300,
                 table_load_count: 1,
                 table_registration_count: 1,
@@ -2387,15 +2676,24 @@ mod tests {
 
     #[test]
     fn csv_and_helpers_preserve_frozen_edge_behavior() -> TestResult {
-        assert_eq!(CSV_HEADER.len(), 87);
+        assert_eq!(CSV_HEADER.len(), 96);
         assert_eq!(CSV_HEADER[11], "scan_metadata_mode");
-        assert_eq!(CSV_HEADER[19], "queries_per_table");
+        assert_eq!(CSV_HEADER[12], "parquet_metadata_mode");
+        assert_eq!(CSV_HEADER[20], "queries_per_table");
         assert_eq!(
-            &CSV_HEADER[54..60],
+            &CSV_HEADER[55..69],
             [
                 "table_initialization_micros_p50",
                 "table_initialization_micros_p95",
                 "table_initialization_micros_p99",
+                "parquet_metadata_preparation_micros_p50",
+                "parquet_metadata_preparation_micros_p95",
+                "parquet_metadata_preparation_micros_p99",
+                "prepared_parquet_metadata_file_count_p50",
+                "prepared_parquet_metadata_memory_bytes_p50",
+                "parquet_metadata_preparation_range_get_operations_p50",
+                "parquet_metadata_preparation_full_get_operations_p50",
+                "parquet_metadata_preparation_bytes_received_p50",
                 "session_total_micros_p50",
                 "session_total_micros_p95",
                 "session_total_micros_p99",
@@ -2444,7 +2742,7 @@ mod tests {
             let summary = summarize(&repetitions);
             let row = csv_row(&config, &fixture, Some(4), 4, &repetitions);
             assert_eq!(row.len(), CSV_HEADER.len());
-            assert_eq!(row[0], "31");
+            assert_eq!(row[0], "32");
             assert_eq!(row[1], "provider_exec");
             assert_eq!(row[2], env::consts::OS);
             assert_eq!(row[3], env::consts::ARCH);
@@ -2456,57 +2754,59 @@ mod tests {
             assert_eq!(row[9], "project_id");
             assert_eq!(row[10], "delta_kernel");
             assert_eq!(row[11], "eager");
-            assert_eq!(row[12], "prefetch_2_ap_target_scan_3x");
-            assert_eq!(&row[13..18], ["4", "12", "3", "1", "2"]);
-            assert_eq!(row[18], "1");
-            assert_eq!(row[19], "3");
-            assert_eq!(row[20], "4");
-            assert_eq!(row[21], "32768");
-            assert_eq!(row[22], "819772");
-            assert_eq!(row[23], "4");
-            assert_eq!(row[24], "12");
-            assert_eq!(row[25], "3");
-            assert_eq!(row[26], "1");
-            assert_eq!(&row[27..31], ["4", "4", "32768", "819772"]);
-            assert_eq!(&row[31..35], ["4", "4", "4", "4"]);
-            assert!(row[35..43].iter().all(|value| value == "0"));
-            assert_eq!(row[43], "36");
-            assert_eq!(row[44], "32756");
-            assert_eq!(&row[45..50], ["4", "4", "12", "0", "0"]);
-            assert_eq!(row[50], "32756");
-            assert_eq!(row[51], "36");
-            assert_eq!(row[52], optional(summary.peak_rss));
-            assert_eq!(row[53], optional(summary.peak_rss_delta));
-            assert_eq!(row[54], summary.table_initialization.p50.to_string());
-            assert_eq!(row[55], summary.table_initialization.p95.to_string());
-            assert_eq!(row[56], summary.table_initialization.p99.to_string());
-            assert_eq!(row[57], summary.session_total.p50.to_string());
-            assert_eq!(row[58], summary.session_total.p95.to_string());
-            assert_eq!(row[59], summary.session_total.p99.to_string());
-            assert_eq!(row[60], summary.planning.p50.to_string());
-            assert_eq!(row[61], summary.planning.p95.to_string());
-            assert_eq!(row[62], summary.planning.p99.to_string());
-            assert_eq!(row[63], summary.first_batch.p50.to_string());
-            assert_eq!(row[64], summary.first_batch.p95.to_string());
-            assert_eq!(row[65], summary.first_batch.p99.to_string());
-            assert_eq!(row[66], summary.total.p50.to_string());
-            assert_eq!(row[67], summary.total.p95.to_string());
-            assert_eq!(row[68], summary.total.p99.to_string());
-            assert_eq!(row[69], summary.rows_per_second.p50.to_string());
-            assert_eq!(row[70], summary.rows_per_second.p95.to_string());
-            assert_eq!(row[71], summary.rows_per_second.p99.to_string());
-            assert_eq!(row[72], summary.batch_latency.p50.to_string());
-            assert_eq!(row[73], summary.batch_latency.p95.to_string());
-            assert_eq!(row[74], summary.batch_latency.p99.to_string());
-            assert_eq!(row[75], summary.min_total.to_string());
-            assert_eq!(row[76], summary.max_total.to_string());
-            assert_eq!(row[77], "0");
-            assert_eq!(row[78], "0");
-            assert_eq!(row[79], "disabled");
-            assert_eq!(row[80], "65536");
-            assert_eq!(row[81], "");
-            assert_eq!(&row[82..86], ["", "", "", ""]);
-            assert_eq!(row[86], "fnv1a64:e1509da31486f25a");
+            assert_eq!(row[12], "on_demand");
+            assert_eq!(row[13], "prefetch_2_ap_target_scan_3x");
+            assert_eq!(&row[14..19], ["4", "12", "3", "1", "2"]);
+            assert_eq!(row[19], "1");
+            assert_eq!(row[20], "3");
+            assert_eq!(row[21], "4");
+            assert_eq!(row[22], "32768");
+            assert_eq!(row[23], "819772");
+            assert_eq!(row[24], "4");
+            assert_eq!(row[25], "12");
+            assert_eq!(row[26], "3");
+            assert_eq!(row[27], "1");
+            assert_eq!(&row[28..32], ["4", "4", "32768", "819772"]);
+            assert_eq!(&row[32..36], ["4", "4", "4", "4"]);
+            assert!(row[36..44].iter().all(|value| value == "0"));
+            assert_eq!(row[44], "36");
+            assert_eq!(row[45], "32756");
+            assert_eq!(&row[46..51], ["4", "4", "12", "0", "0"]);
+            assert_eq!(row[51], "32756");
+            assert_eq!(row[52], "36");
+            assert_eq!(row[53], optional(summary.peak_rss));
+            assert_eq!(row[54], optional(summary.peak_rss_delta));
+            assert_eq!(row[55], summary.table_initialization.p50.to_string());
+            assert_eq!(row[56], summary.table_initialization.p95.to_string());
+            assert_eq!(row[57], summary.table_initialization.p99.to_string());
+            assert!(row[58..66].iter().all(String::is_empty));
+            assert_eq!(row[66], summary.session_total.p50.to_string());
+            assert_eq!(row[67], summary.session_total.p95.to_string());
+            assert_eq!(row[68], summary.session_total.p99.to_string());
+            assert_eq!(row[69], summary.planning.p50.to_string());
+            assert_eq!(row[70], summary.planning.p95.to_string());
+            assert_eq!(row[71], summary.planning.p99.to_string());
+            assert_eq!(row[72], summary.first_batch.p50.to_string());
+            assert_eq!(row[73], summary.first_batch.p95.to_string());
+            assert_eq!(row[74], summary.first_batch.p99.to_string());
+            assert_eq!(row[75], summary.total.p50.to_string());
+            assert_eq!(row[76], summary.total.p95.to_string());
+            assert_eq!(row[77], summary.total.p99.to_string());
+            assert_eq!(row[78], summary.rows_per_second.p50.to_string());
+            assert_eq!(row[79], summary.rows_per_second.p95.to_string());
+            assert_eq!(row[80], summary.rows_per_second.p99.to_string());
+            assert_eq!(row[81], summary.batch_latency.p50.to_string());
+            assert_eq!(row[82], summary.batch_latency.p95.to_string());
+            assert_eq!(row[83], summary.batch_latency.p99.to_string());
+            assert_eq!(row[84], summary.min_total.to_string());
+            assert_eq!(row[85], summary.max_total.to_string());
+            assert_eq!(row[86], "0");
+            assert_eq!(row[87], "0");
+            assert_eq!(row[88], "disabled");
+            assert_eq!(row[89], "65536");
+            assert_eq!(row[90], "");
+            assert_eq!(&row[91..95], ["", "", "", ""]);
+            assert_eq!(row[95], "fnv1a64:e1509da31486f25a");
             Ok::<_, Box<dyn Error>>(())
         })?;
         Ok(())

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -22,18 +22,20 @@ snapshot, load the table again.
 ## Remote I/O phases
 
 For a table in remote storage, the read path has three distinct I/O phases.
-Only the first phase changes when you opt into eager Delta scan metadata
-initialization:
+The loading mode controls whether the first two phases happen during table
+initialization or during each query:
 
-| Phase | Lazy initialization | Eager initialization |
-| --- | --- | --- |
-| 1. Delta scan metadata | Every scan build performs Delta log/checkpoint replay and selects active files. | Table initialization performs the replay once. Later scan builds select files from the retained metadata. |
-| 2. Parquet footer | The query reads footers and prunes row groups. | Unchanged. |
-| 3. Parquet data | The query reads the selected row groups. | Unchanged. |
+| Phase | Lazy | Eager Delta metadata | Prepared Parquet metadata |
+| --- | --- | --- | --- |
+| 1. Delta scan metadata | Every scan build performs Delta log/checkpoint replay and selects active files. | Table initialization performs the replay once. Later scan builds select files from the retained metadata. | Same as eager Delta metadata. |
+| 2. Parquet metadata | The query reads footers and prunes row groups. | The query reads footers and prunes row groups. | Table initialization reads and parses footers and offset indexes for all active files. Each query still performs its own row-group pruning. |
+| 3. Parquet data | The query reads the selected row groups. | Unchanged. | Unchanged. |
 
-A successful eager load therefore needs no later Delta log/checkpoint reads for
-file discovery from that table. It does not move Parquet footer or Parquet data
-I/O into initialization, and it does not change deletion-vector behavior.
+A successful eager Delta metadata load needs no later Delta log/checkpoint reads
+for file discovery from that table. Experimental Parquet metadata preparation
+also removes later footer and offset-index reads for the prepared files. Neither
+mode moves Parquet data-page reads into initialization or changes
+deletion-vector behavior.
 
 The retained Delta scan metadata contains reconciled active `add` metadata and
 available file statistics, not raw JSON commit files. It belongs to one exact
@@ -41,6 +43,10 @@ snapshot and remains in memory for the lifetime of that loaded table.
 Separately loaded tables do not share this memory. There is no TTL, eviction,
 persistence, incremental update, or background refresh; load another table to
 observe a newer snapshot.
+
+Prepared Parquet metadata has the same snapshot lifetime and belongs to the
+loaded table. The [preparation guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+explains its resource limits and direct-backend requirement.
 
 ## Streaming API
 

--- a/docs/content/benchmarks.md
+++ b/docs/content/benchmarks.md
@@ -155,6 +155,9 @@ change.
 
 - [Lazy and eager scan metadata](benchmarks/eager-metadata.md) compares when
   Delta scan metadata is loaded and reused across repeated queries.
+- [Prepared Parquet metadata](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/prepared-parquet-metadata/)
+  compares on-demand footer reads with preparing parsed metadata during table
+  loading.
 - [Parquet row-filter predicate decoding](benchmarks/row-filter.md) compares
   decoding only predicate columns with decoding unrelated columns as well.
 - [Parquet page-index range reads](benchmarks/page-index.md) measures page-level

--- a/docs/content/benchmarks/prepared-parquet-metadata.md
+++ b/docs/content/benchmarks/prepared-parquet-metadata.md
@@ -1,0 +1,122 @@
+# Prepared Parquet metadata
+
+This benchmark compares fetching Parquet metadata during each query with
+preparing it once when the table loads. Both modes use eager Delta scan metadata
+so the comparison isolates the Parquet metadata lifecycle.
+
+## Run a matched pair
+
+Enable all features and keep every argument except the Parquet metadata mode
+and output path identical:
+
+```bash
+cargo bench --locked -p delta-arrow-reader --bench reader --all-features -- \
+  --mode provider-exec \
+  --seed 0 \
+  --output target/parquet-metadata-on-demand.csv \
+  --provider-exec-temp-dir target/parquet-metadata-bench \
+  --provider-exec-storage-profile s3_throttled \
+  --provider-exec-workload provider_many_unequal_files \
+  --provider-exec-query filter_tail_ids \
+  --provider-exec-backend direct-parquet \
+  --provider-exec-scan-metadata-mode eager \
+  --provider-exec-parquet-metadata-mode on-demand \
+  --provider-exec-queries-per-table 10 \
+  --provider-exec-scheduling-profile prefetch_2_ap_target_scan_3x \
+  --provider-exec-parquet-metadata-size-hint-bytes 65536 \
+  --provider-exec-parquet-full-file-read-threshold-bytes disabled \
+  --provider-exec-repetitions 5
+
+cargo bench --locked -p delta-arrow-reader --bench reader --all-features -- \
+  --mode provider-exec \
+  --seed 0 \
+  --output target/parquet-metadata-prepared.csv \
+  --provider-exec-temp-dir target/parquet-metadata-bench \
+  --provider-exec-storage-profile s3_throttled \
+  --provider-exec-workload provider_many_unequal_files \
+  --provider-exec-query filter_tail_ids \
+  --provider-exec-backend direct-parquet \
+  --provider-exec-scan-metadata-mode eager \
+  --provider-exec-parquet-metadata-mode prepared \
+  --provider-exec-queries-per-table 10 \
+  --provider-exec-scheduling-profile prefetch_2_ap_target_scan_3x \
+  --provider-exec-parquet-metadata-size-hint-bytes 65536 \
+  --provider-exec-parquet-full-file-read-threshold-bytes disabled \
+  --provider-exec-repetitions 5
+```
+
+Each repetition loads and registers a new table, then runs the configured query
+against it. The harness checks the result rows, schema, and fixture fingerprint
+before writing the CSV.
+
+The `s3_throttled` profile uses 15 ms object-open latency, 8 ms read latency,
+and 32 MiB/s bandwidth. It is a deterministic local HTTP model, not a claim
+about every S3 deployment.
+
+For prepared runs, the harness sets the file limit to the fixture's exact file
+count and leaves the estimated-memory limit unrestricted. This keeps a
+benchmark limit from ending a repetition early; it is not a recommended
+production configuration.
+
+## Read the measurements
+
+The main fields are:
+
+- `parquet_metadata_preparation_micros_*`: time spent fetching and parsing
+  metadata after Delta scan planning.
+- `prepared_parquet_metadata_file_count_p50`: unique files prepared.
+- `prepared_parquet_metadata_memory_bytes_p50`: estimated retained size of the
+  parsed metadata.
+- `table_initialization_micros_*`: complete table loading, including
+  preparation when selected.
+- `total_micros_*`: per-query planning and execution, excluding table loading.
+- `session_total_micros_*`: table loading followed by all configured queries.
+
+Preparation request and byte fields report the I/O moved into initialization.
+The normal provider read fields report the I/O that remains in each query.
+
+Before comparing timings, confirm that both rows have the same fixture
+fingerprint, seed, workload, query, storage profile, backend, scheduling
+profile, repetition count, and query count.
+
+## Controlled results
+
+The following results were measured on August 29, 2026. The machine had 16
+logical CPUs, and the harness therefore used 16 target partitions. Each value
+is the median of five repetitions.
+
+| Workload | Preparation | Query, on demand | Query, prepared | Estimated break-even | Retained metadata |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Four files, 32,768 rows, full scan | 31.4 ms | 69.1 ms | 35.7 ms | About 1 query | 9.7 KiB |
+| 64 mixed-size files, selective scan | 60.5 ms | 107.6 ms | 77.3 ms | About 2 queries | 154.5 KiB |
+| 4,096 one-row files, projected scan | 2.271 s | 6.685 s | 6.565 s | About 19 queries | 9.65 MiB |
+
+The break-even estimate divides preparation time by the median per-query time
+saved. It does not include memory cost or assume that later queries select the
+same files.
+
+For ten queries against one loaded table:
+
+| Workload | On-demand session | Prepared session | Difference |
+| --- | ---: | ---: | ---: |
+| Four files, full scan | 766.2 ms | 498.1 ms | -268.1 ms (-35.0%) |
+| 64 mixed-size files, selective scan | 1.175 s | 979.8 ms | -195.6 ms (-16.6%) |
+
+All matched modes returned the same rows and fixture fingerprints.
+
+## Interpret the result
+
+The four-file and 64-file workloads recover preparation cost after a small
+number of queries under the controlled remote profile. The 4,096-file workload
+shows why preparation is opt-in: startup spent about 2.27 seconds preparing
+metadata while one query improved by about 120 ms.
+
+The fixtures have two columns and one row group per file. Production metadata
+can be larger when schemas are wider or files contain more row groups,
+statistics, and page indexes. The 4,096 files are also smaller than the 64 KiB
+footer hint, so that case isolates per-file overhead rather than representing a
+typical Parquet table.
+
+Choose production limits from measurements on representative tables and their
+real object stores. The synthetic break-even counts above are not production
+defaults.

--- a/docs/content/datafusion.md
+++ b/docs/content/datafusion.md
@@ -104,3 +104,9 @@ follows this cache across several queries. For the rest of the read path, see
 [how the reader works](https://mag1cfrog.github.io/delta-arrow-reader/architecture/).
 The [Rust API reference](https://docs.rs/delta-arrow-reader) documents the
 available scan options and metrics.
+
+The experimental
+[Parquet metadata preparation mode](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+can also move footer and offset-index reads into table initialization. Configure
+it on `DeltaTableBuilder` before registration; DataFusion needs no separate
+cache option.

--- a/docs/content/delta-metadata-lifecycle.md
+++ b/docs/content/delta-metadata-lifecycle.md
@@ -6,14 +6,13 @@ values, and file statistics. The Delta log or checkpoint supplies the file
 list. The list and the information used to prune it are the table's scan
 metadata.
 
-Delta Arrow Reader can prepare this metadata at two different times. The
-default lazy mode prepares it when each scan is built. Eager mode prepares the
-reusable part when the table loads and keeps it in memory for later scans.
+Delta Arrow Reader has three loading modes. The default lazy mode prepares
+Delta scan metadata when each scan is built. Eager mode prepares the reusable
+part when the table loads. Experimental Parquet metadata preparation adds the
+parsed footers and offset indexes for every active file.
 
-Only the timing changes. Each query still gets its own pruning pass, and
-Parquet footers and data are still read on demand. Eager mode does not create
-an index, reuse one query's file selection for another query, or change query
-results.
+Each query still gets its own file, row-group, and page selection. The caches
+do not reuse one query's selection for another query or change query results.
 
 ## What happens before rows are read
 
@@ -30,7 +29,9 @@ A query against remote storage can involve three rounds of I/O:
 The first round mixes work that can be reused with work that belongs to one
 query. Replaying the Delta history and reconciling the active files can be
 reused for a loaded table version. Applying a predicate cannot. Eager mode
-moves only the reusable work to table initialization.
+moves only that reusable work to table initialization. Experimental Parquet
+metadata preparation also moves the reusable part of the second round while
+leaving row-group and page selection with each query.
 
 This difference matters most for a selective query. Statistics may reduce a
 large table to a few Parquet row groups, making the data read small, while
@@ -85,25 +86,50 @@ The cache belongs to one loaded table. If the same location is loaded twice,
 the two table objects have separate caches. Both also stay fixed at the exact
 table version they loaded.
 
+## Prepared Parquet metadata mode
+
+`DeltaTableBuilder::load_table_with_prepared_parquet_metadata()` first performs
+eager Delta scan metadata initialization. It then fetches and parses the
+Parquet footer and optional offset indexes for every unique active file:
+
+```text
+table initialization -> Delta replay -> active-file cache -> Parquet metadata cache
+                                                                    |
+query 1 -> pruning -------------------------------------------------+-> Parquet data
+query 2 -> pruning -------------------------------------------------+-> Parquet data
+query 3 -> pruning -------------------------------------------------+-> Parquet data
+```
+
+The experimental Cargo feature is disabled by default, and the loading method
+requires explicit file-count and estimated-memory limits. It supports only the
+direct Parquet backend. The returned table and its clones share one immutable
+cache through both the streaming API and DataFusion.
+
+Preparation does not read Parquet data pages. A query still decides which
+files, row groups, pages, and columns it needs. See
+[Prepare Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+for setup, limits, failure behavior, and report fields.
+
 ## Which mode should you use?
 
 This choice applies to the loaded table, whether you query it through the
-streaming API or DataFusion SQL. Both APIs support lazy and eager loading.
+streaming API or DataFusion SQL. Both APIs support all three modes.
 
-| Consideration | Lazy | Eager |
-| --- | --- | --- |
-| Typical use | One query, occasional queries, or tight memory limits | Repeated queries against a named, high-use table in a long-lived session |
-| Table loading | Returns without building the active-file cache | Waits for Delta replay and cache creation |
-| Memory while loaded | No reusable active-file cache | Keeps active-file metadata and statistics in memory |
-| Each later scan | Replays Delta metadata, then prunes for the query | Reuses the cache, then prunes for the query |
-| Seeing a newer version | Load a new table | Load a new table |
-| Parquet footer and data reads | Per query | Per query; unchanged by the cache |
+| Consideration | Lazy | Eager Delta metadata | Prepared Parquet metadata |
+| --- | --- | --- | --- |
+| Typical use | One query, occasional queries, or tight memory limits | Repeated queries where Delta replay is costly | Repeated remote queries where footer reads are also costly |
+| Table loading | Returns without building reusable scan caches | Waits for Delta replay and cache creation | Also fetches and parses metadata for every active Parquet file |
+| Memory while loaded | No reusable active-file cache | Keeps active-file metadata and statistics | Also keeps parsed Parquet footers and offset indexes |
+| Each later scan | Replays Delta metadata, then prunes | Reuses Delta metadata, then prunes | Reuses both caches, then performs query-specific pruning |
+| Seeing a newer version | Load a new table | Load a new table | Load and prepare a new table |
+| Parquet data reads | Per query | Per query | Per query |
 
 Use lazy mode unless you know the table will serve repeated queries and the
-saved planning time justifies slower initialization and higher memory use. No
-single query count is a reliable break-even point. The result depends on the
-table history, checkpoint shape, file count, available statistics, storage
-latency, query selectivity, and memory pressure.
+saved planning time justifies slower initialization and higher memory use. Add
+Parquet metadata preparation only when measurements show that repeated footer
+reads matter. No single query count is a reliable break-even point. The result
+depends on the table history, checkpoint shape, file count, available
+statistics, storage latency, query selectivity, and memory pressure.
 
 ## Results from a real S3 workload
 
@@ -127,6 +153,8 @@ same Parquet I/O.
 These numbers come from one workload. They are not a performance guarantee or
 a general break-even point. The [benchmark methodology, environment, and limitations](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/eager-metadata/#representative-real-s3-result)
 describe how the measurements were collected and what can affect them.
+This case study compares lazy and eager Delta scan metadata; it does not include
+experimental Parquet metadata preparation.
 
 ## Version and refresh behavior
 
@@ -135,14 +163,15 @@ version. Commits written later do not change what existing queries see. To use
 a newer version, load the table again and replace the old table or DataFusion
 registration.
 
-Eager loading does not provide:
+The in-memory loading modes do not provide:
 
 - incremental refresh;
 - background polling;
 - TTL or eviction;
 - persistence across processes;
-- sharing between independently loaded tables; or
-- Parquet footer, row-group, or data caching.
+- sharing between independently loaded tables;
+- Parquet data-page or decoded-batch caching; or
+- automatic selection of which tables to prepare.
 
 ## Related guides
 
@@ -150,4 +179,5 @@ Eager loading does not provide:
 - [Register and query a table with DataFusion](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
 - [Understand how scans are planned](https://mag1cfrog.github.io/delta-arrow-reader/scan-planning/)
 - [Review the benchmark methodology](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/eager-metadata/)
+- [Prepare Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
 - [Open the eager-loading Rust API](https://docs.rs/delta-arrow-reader/latest/delta_arrow_reader/struct.DeltaTableBuilder.html#method.load_table_with_eager_scan_metadata)

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -33,18 +33,23 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 The [DataFusion quickstart](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
 shows how to register a table and query it with SQL.
 
-## Optional feature
+## Optional features
 
-The streaming API and both Parquet backends are always available. The
-DataFusion integration is the only optional feature.
+The streaming API and both Parquet backends are always available.
 
 | Feature | Default | Purpose |
 | --- | --- | --- |
 | `datafusion` | No | Register Delta tables with DataFusion and expose execution metrics. |
+| `experimental-parquet-metadata-preparation` | No | Prepare and retain Parquet metadata while loading a table. |
 
 The direct Parquet backend is selected by default. Rust callers can choose the
 Delta Kernel backend through `DeltaScanExecutionOptions` without changing
 Cargo features.
+
+Parquet metadata preparation works with the streaming API by itself. Enable
+both optional features to reuse prepared metadata through DataFusion. See
+[Prepare Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+before enabling it for a table.
 
 Both APIs run on your application's Tokio runtime. Delta Arrow Reader does not
 create a separate runtime.

--- a/docs/content/prepared-parquet-metadata.md
+++ b/docs/content/prepared-parquet-metadata.md
@@ -1,0 +1,111 @@
+# Prepare Parquet metadata for repeated queries
+
+Parquet metadata preparation moves footer and offset-index reads into table
+initialization. Later scans against that loaded table can reuse the parsed
+metadata instead of fetching it again.
+
+This API is experimental and disabled by default. Use it in long-lived
+processes that repeatedly query the same immutable Delta snapshot. Preparation
+increases startup time and retained memory, so callers must set explicit
+file-count and memory limits.
+
+## Enable the feature
+
+The feature works with the streaming API and does not require DataFusion:
+
+```toml
+[dependencies]
+delta-arrow-reader = { version = "0.5", features = ["experimental-parquet-metadata-preparation"] }
+```
+
+To use the prepared table with DataFusion, enable both features:
+
+```toml
+[dependencies]
+delta-arrow-reader = { version = "0.5", features = ["datafusion", "experimental-parquet-metadata-preparation"] }
+```
+
+## Load a prepared table
+
+Pass both limits when loading the table:
+
+```no_run
+use delta_arrow_reader::{
+    DeltaTableBuilder,
+    ParquetMetadataPreparationLimits,
+};
+
+# async fn load() -> Result<(), Box<dyn std::error::Error>> {
+let table = DeltaTableBuilder::new("s3://example-bucket/orders")
+    .load_table_with_prepared_parquet_metadata(
+        ParquetMetadataPreparationLimits {
+            max_files: 10_000,
+            max_retained_metadata_bytes: 256 * 1024 * 1024,
+        },
+    )
+    .await?;
+
+if let Some(report) = table.parquet_metadata_preparation_report() {
+    println!("files={}", report.files_prepared);
+    println!(
+        "estimated_metadata_bytes={}",
+        report.estimated_retained_metadata_bytes
+    );
+    println!("preparation_time={:?}", report.preparation_duration);
+}
+# Ok(())
+# }
+```
+
+The method first prepares the reusable Delta scan metadata, just like
+`load_table_with_eager_scan_metadata`. It then fetches and parses the Parquet
+metadata for every unique active file. The returned `DeltaTable` owns both
+caches.
+
+Table clones, streaming scans, DataFusion providers, and DataFusion physical
+plans created from that table share the prepared Parquet metadata. You do not
+need a separate DataFusion option.
+
+## Choose limits
+
+`max_files` limits how many active files preparation will visit. The load fails
+before its first Parquet metadata request if the table exceeds this limit.
+
+`max_retained_metadata_bytes` limits the estimated size of the parsed metadata.
+This estimate comes from the retained Parquet metadata structures. It is not a
+measurement of process RSS or allocator overhead. Wider schemas, more row
+groups, larger statistics, and page indexes can increase the retained size.
+
+Preparation attaches the cache only after every file succeeds. A missing or
+corrupt file, cancellation, or an exceeded memory limit returns an error and
+does not return a partially prepared table.
+
+Start with limits based on a representative table, then inspect
+`parquet_metadata_preparation_report` in the environment where the table will
+run. The report also contains read metrics for the preparation phase.
+
+## What the cache retains
+
+The cache contains parsed Parquet footers and optional offset indexes. Offset
+indexes help exact row filters turn their row selections into page-range reads.
+The cache does not contain Parquet data pages or decoded Arrow batches.
+
+Preparation currently supports only the direct Parquet backend. A builder
+configured to use the Delta Kernel backend fails before starting Parquet
+metadata reads.
+
+The table remains fixed at the Delta version it loaded. Load a new table to see
+a newer version or to create a new prepared cache. Prepared metadata is kept in
+memory only; it is not persisted to disk or shared between separately loaded
+tables.
+
+## Decide whether to prepare
+
+Preparation is most useful when remote metadata requests take a noticeable
+part of query time and many queries reuse one loaded table. It is usually a poor
+fit for one-shot reads or tables with many files that are rarely queried.
+
+The [controlled benchmark](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/prepared-parquet-metadata/)
+shows the startup cost, retained-memory estimate, and measured break-even points
+for three synthetic workloads. Measure production-shaped queries before
+raising the limits or using preparation to meet a latency target.

--- a/docs/content/scan-planning.md
+++ b/docs/content/scan-planning.md
@@ -21,10 +21,15 @@ retained metadata to Delta Kernel through `Scan::scan_metadata_from`; Delta
 Kernel remains responsible for applying the query predicate and selecting
 files.
 
-Both modes produce the same file tasks. Partition values, schema transforms,
-and deletion-vector information follow the selected files in either mode.
-Parquet footer pruning happens later and is not part of this initialization
-choice.
+The experimental
+`DeltaTableBuilder::load_table_with_prepared_parquet_metadata` method performs
+the eager work and then prepares parsed metadata for every active Parquet file.
+Later scans reuse that metadata, but each scan still makes its own row-group and
+page selections.
+
+All three modes produce the same file tasks. Partition values, schema
+transforms, and deletion-vector information follow the selected files in every
+mode.
 
 In one dated real-S3 case study, eager initialization reduced the median time
 for a six-query session by 15.4% while adding 30.2 MiB of resident memory after
@@ -34,6 +39,9 @@ before applying those measurements to another table or workload.
 
 To see how this initialization choice plays out across several queries, follow
 the [lazy and eager metadata lifecycles](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
+For the experimental loading mode, see the
+[Parquet metadata preparation guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+and its [controlled benchmark](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/prepared-parquet-metadata/).
 
 ## Choose a partition target
 

--- a/docs/content/streaming-reader.md
+++ b/docs/content/streaming-reader.md
@@ -88,6 +88,11 @@ newer Delta version.
 The [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/)
 explains what the eager method caches and when the tradeoff is worthwhile.
 
+For a long-lived process that repeatedly queries Parquet files on remote
+storage, the experimental
+[Parquet metadata preparation guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+describes a second opt-in cache for file footers and offset indexes.
+
 ## Filter rows
 
 Add a predicate before building the scan to filter its rows:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - Installation: installation.md
       - Streaming reader quickstart: streaming-reader.md
       - DataFusion quickstart: datafusion.md
+      - Prepare Parquet metadata: prepared-parquet-metadata.md
   - How it works:
       - Architecture: architecture.md
       - Delta metadata lifecycle: delta-metadata-lifecycle.md
@@ -46,6 +47,7 @@ nav:
       - Reader benchmarks: benchmarks.md
       - Focused benchmarks:
           - Lazy and eager scan metadata: benchmarks/eager-metadata.md
+          - Prepared Parquet metadata: benchmarks/prepared-parquet-metadata.md
           - Parquet row-filter predicate decoding: benchmarks/row-filter.md
           - Parquet page-index range reads: benchmarks/page-index.md
           - Adaptive Parquet range planning: benchmarks/range-planning.md

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,5 +42,7 @@ pub use reader::{
     DeltaScanExecutionOptions, DeltaScanMetrics, DeltaScanMetricsSnapshot, DeltaSnapshotSelection,
     DeltaStorageOptions, DeltaTable, DeltaTableBuilder, DeltaTableSnapshot, ParquetReaderBackend,
 };
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+pub use reader::{ParquetMetadataPreparationLimits, ParquetMetadataPreparationReport};
 /// The crate version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -38,8 +38,13 @@ use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use futures_util::Stream;
 use snafu::ResultExt;
 
+#[cfg(any(
+    feature = "datafusion",
+    feature = "experimental-parquet-metadata-preparation"
+))]
+use self::backend::direct_parquet::ParquetMetadataCache;
 #[cfg(feature = "experimental-parquet-metadata-preparation")]
-use self::backend::direct_parquet::{ParquetMetadataCache, prepare_parquet_metadata};
+use self::backend::direct_parquet::prepare_parquet_metadata;
 use self::{
     planning::{DeltaScanPartitionTargetOptions, DeltaScanPlan, plan_scan},
     predicate::{evaluate_predicate, referenced_columns, validate_predicate},
@@ -452,6 +457,20 @@ impl DeltaTable {
         self.prepared_parquet_metadata
             .as_deref()
             .map(|prepared| &prepared.report)
+    }
+
+    #[cfg(feature = "datafusion")]
+    pub(crate) fn prepared_parquet_metadata_cache(&self) -> Option<Arc<ParquetMetadataCache>> {
+        #[cfg(feature = "experimental-parquet-metadata-preparation")]
+        {
+            self.prepared_parquet_metadata
+                .as_ref()
+                .map(|prepared| Arc::clone(&prepared.cache))
+        }
+        #[cfg(not(feature = "experimental-parquet-metadata-preparation"))]
+        {
+            None
+        }
     }
 
     /// Starts configuring a new single-use scan.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -31,10 +31,15 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use std::time::{Duration, Instant};
+
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use futures_util::Stream;
 use snafu::ResultExt;
 
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use self::backend::direct_parquet::{ParquetMetadataCache, prepare_parquet_metadata};
 use self::{
     planning::{DeltaScanPartitionTargetOptions, DeltaScanPlan, plan_scan},
     predicate::{evaluate_predicate, referenced_columns, validate_predicate},
@@ -60,6 +65,41 @@ use crate::{
 const TRACING_TARGET: &str = "delta_arrow_reader";
 const DELTA_LOG_SCAN_METADATA_SOURCE: &str = "delta_log";
 const EAGER_CACHE_SCAN_METADATA_SOURCE: &str = "eager_cache";
+
+/// Resource limits for experimental Parquet metadata preparation.
+///
+/// Both limits must be greater than zero. The retained-memory limit uses the reader's estimate of
+/// parsed Parquet metadata size, not allocator-level resident memory.
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParquetMetadataPreparationLimits {
+    /// Maximum number of active Parquet files to prepare.
+    pub max_files: usize,
+    /// Maximum estimated bytes of parsed Parquet metadata to retain.
+    pub max_retained_metadata_bytes: usize,
+}
+
+/// Measurements recorded while preparing one table's Parquet metadata.
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParquetMetadataPreparationReport {
+    /// Number of active Parquet files prepared.
+    pub files_prepared: usize,
+    /// Estimated bytes retained by the parsed Parquet metadata.
+    pub estimated_retained_metadata_bytes: usize,
+    /// Time spent fetching and parsing Parquet metadata after scan planning completed.
+    pub preparation_duration: Duration,
+    /// Reader metrics collected by the preparation scan plan.
+    pub read_metrics: DeltaScanMetricsSnapshot,
+}
+
+/// Table-owned prepared cache and the report describing how it was built.
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+struct PreparedParquetMetadata {
+    cache: Arc<ParquetMetadataCache>,
+    report: ParquetMetadataPreparationReport,
+}
 
 /// Configures and loads one immutable Delta table snapshot.
 ///
@@ -169,14 +209,33 @@ impl DeltaTableBuilder {
         )
         .await?;
         validate_protocol(snapshot.protocol())?;
-        let snapshot =
-            tokio::task::spawn_blocking(move || snapshot.materialize_eager_scan_metadata())
-                .await
-                .boxed()
-                .context(ScanPlanningSnafu {
-                    reason: "eager_scan_metadata_task_failed",
-                })??;
+        let snapshot = materialize_eager_scan_metadata(snapshot).await?;
         Ok(DeltaTable::new(snapshot, self.execution_options))
+    }
+
+    /// Loads a table and prepares the Parquet metadata for every active file.
+    ///
+    /// This experimental loading mode includes eager Delta scan metadata, then fetches and parses
+    /// each active file's Parquet footer and optional offset indexes. The returned table shares the
+    /// prepared metadata across its streaming scans and clones. Initialization fails without
+    /// returning a table if the direct Parquet backend is not selected, a resource limit is
+    /// exceeded, or any file cannot be prepared.
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    pub async fn load_table_with_prepared_parquet_metadata(
+        self,
+        limits: ParquetMetadataPreparationLimits,
+    ) -> Result<DeltaTable, DeltaReaderError> {
+        limits.validate()?;
+        if self.execution_options.parquet_backend() != ParquetReaderBackend::Direct {
+            return InvalidConfigurationSnafu {
+                reason: "parquet_metadata_preparation_requires_direct_backend",
+            }
+            .fail();
+        }
+        self.load_table_with_eager_scan_metadata()
+            .await?
+            .prepare_parquet_metadata(limits)
+            .await
     }
 
     /// Loads a Delta Kernel snapshot without converting its logical Arrow schema.
@@ -188,6 +247,36 @@ impl DeltaTableBuilder {
         )
         .await?;
         Ok(DeltaTableSnapshot::new(snapshot, self.execution_options))
+    }
+}
+
+async fn materialize_eager_scan_metadata(
+    snapshot: ArrowTableSnapshot,
+) -> Result<ArrowTableSnapshot, DeltaReaderError> {
+    tokio::task::spawn_blocking(move || snapshot.materialize_eager_scan_metadata())
+        .await
+        .boxed()
+        .context(ScanPlanningSnafu {
+            reason: "eager_scan_metadata_task_failed",
+        })?
+}
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+impl ParquetMetadataPreparationLimits {
+    fn validate(self) -> Result<(), DeltaReaderError> {
+        if self.max_files == 0 {
+            return InvalidConfigurationSnafu {
+                reason: "parquet_metadata_preparation_max_files_must_be_positive",
+            }
+            .fail();
+        }
+        if self.max_retained_metadata_bytes == 0 {
+            return InvalidConfigurationSnafu {
+                reason: "parquet_metadata_preparation_memory_limit_must_be_positive",
+            }
+            .fail();
+        }
+        Ok(())
     }
 }
 
@@ -262,6 +351,8 @@ impl fmt::Debug for DeltaTableSnapshot {
 pub struct DeltaTable {
     snapshot: Arc<ArrowTableSnapshot>,
     execution_options: DeltaScanExecutionOptions,
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    prepared_parquet_metadata: Option<Arc<PreparedParquetMetadata>>,
 }
 
 impl DeltaTable {
@@ -269,7 +360,52 @@ impl DeltaTable {
         Self {
             snapshot: Arc::new(snapshot),
             execution_options,
+            #[cfg(feature = "experimental-parquet-metadata-preparation")]
+            prepared_parquet_metadata: None,
         }
+    }
+
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    async fn prepare_parquet_metadata(
+        mut self,
+        limits: ParquetMetadataPreparationLimits,
+    ) -> Result<Self, DeltaReaderError> {
+        let snapshot = Arc::clone(&self.snapshot);
+        let execution_options = self.execution_options;
+        let plan = tokio::task::spawn_blocking(move || {
+            plan_scan(
+                snapshot.as_ref(),
+                None,
+                &[],
+                None,
+                false,
+                execution_options,
+                DeltaScanPartitionTargetOptions {
+                    explicit_target_partitions: None,
+                    datafusion_target_partitions: None,
+                },
+            )
+        })
+        .await
+        .boxed()
+        .context(ScanPlanningSnafu {
+            reason: "parquet_metadata_preparation_planning_task_failed",
+        })??;
+        let metadata_cache = Arc::new(ParquetMetadataCache::default());
+        let started = Instant::now();
+        let prepared =
+            prepare_parquet_metadata(&plan, Arc::clone(&metadata_cache), Arc::default(), limits)
+                .await?;
+        self.prepared_parquet_metadata = Some(Arc::new(PreparedParquetMetadata {
+            cache: metadata_cache,
+            report: ParquetMetadataPreparationReport {
+                files_prepared: prepared.file_count,
+                estimated_retained_metadata_bytes: prepared.memory_bytes,
+                preparation_duration: started.elapsed(),
+                read_metrics: plan.metrics.snapshot(),
+            },
+        }));
+        Ok(self)
     }
 
     /// Returns the loaded Delta snapshot version.
@@ -307,6 +443,15 @@ impl DeltaTable {
     /// Validates the loaded snapshot against the supported reader protocol.
     pub fn validate_protocol(&self) -> Result<(), DeltaReaderError> {
         validate_protocol(self.protocol())
+    }
+
+    /// Returns measurements from experimental Parquet metadata preparation, when used to load
+    /// this table.
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    pub fn parquet_metadata_preparation_report(&self) -> Option<&ParquetMetadataPreparationReport> {
+        self.prepared_parquet_metadata
+            .as_deref()
+            .map(|prepared| &prepared.report)
     }
 
     /// Starts configuring a new single-use scan.
@@ -450,6 +595,12 @@ impl<'table> DeltaScanBuilder<'table> {
                     predicate,
                     limit: self.limit,
                     enforce_physical_predicate_rows,
+                    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+                    parquet_metadata_cache: self
+                        .table
+                        .prepared_parquet_metadata
+                        .as_ref()
+                        .map(|prepared| Arc::clone(&prepared.cache)),
                 })
             }
             Err(error) => {
@@ -486,6 +637,8 @@ pub struct DeltaScan {
     predicate: Option<DeltaPredicate>,
     limit: Option<usize>,
     enforce_physical_predicate_rows: bool,
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    parquet_metadata_cache: Option<Arc<ParquetMetadataCache>>,
 }
 
 impl DeltaScan {
@@ -510,6 +663,16 @@ impl DeltaScan {
         let backend = self.plan.execution_options.parquet_backend();
         let projection = (self.plan.logical_schema.as_ref() != schema.as_ref())
             .then(|| (0..schema.fields().len()).collect::<Vec<_>>());
+        let parquet_metadata_cache = {
+            #[cfg(feature = "experimental-parquet-metadata-preparation")]
+            {
+                self.parquet_metadata_cache
+            }
+            #[cfg(not(feature = "experimental-parquet-metadata-preparation"))]
+            {
+                None
+            }
+        };
         let partitions = if self.limit == Some(0) {
             VecDeque::new()
         } else {
@@ -522,6 +685,7 @@ impl DeltaScan {
                     self.enforce_physical_predicate_rows
                         .then(|| self.plan.physical_predicate.clone())
                         .flatten(),
+                    parquet_metadata_cache,
                 ),
                 ParquetReaderBackend::DeltaKernel => delta_kernel_executor(&self.plan),
             };
@@ -692,13 +856,14 @@ pub(crate) fn direct_parquet_executor(
     plan: &Arc<DeltaScanPlan>,
     output_batch_size_rows: Option<usize>,
     row_predicate: Option<crate::delta::kernel::DeltaKernelPredicate>,
+    metadata_cache: Option<Arc<backend::direct_parquet::ParquetMetadataCache>>,
 ) -> FileExecutor<planning::DeltaScanFileTask, FileBatchStream> {
     backend::direct_parquet::direct_parquet_file_executor(
         plan,
         output_batch_size_rows,
         row_predicate,
         Arc::default(),
-        None,
+        metadata_cache,
     )
 }
 

--- a/src/reader/backend/direct_parquet.rs
+++ b/src/reader/backend/direct_parquet.rs
@@ -1,15 +1,15 @@
 //! Direct asynchronous Parquet data-file reader.
 
+mod metadata_cache;
 mod metered_object_store;
 mod range_planning;
 mod row_group_pruning;
 mod schema_alignment;
 
-use std::{
-    collections::HashMap,
-    ops::Range,
-    sync::{Arc, Mutex},
-};
+use std::{ops::Range, sync::Arc};
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use std::collections::HashSet;
 
 use arrow::{
     array::Int64Array,
@@ -30,8 +30,8 @@ use parquet::arrow::{
 use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData};
 use parquet::schema::types::SchemaDescriptor;
 use snafu::{IntoError, ResultExt};
-use tokio::sync::OnceCell;
 
+pub(crate) use self::metadata_cache::ParquetMetadataCache;
 pub(crate) use self::metered_object_store::ParquetRangeReadEstimator;
 use self::{
     metered_object_store::{MeteredParquetObjectStore, MultiRangeReadStrategy},
@@ -58,33 +58,22 @@ use crate::{
     },
 };
 
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use crate::reader::ParquetMetadataPreparationLimits;
+
 struct DirectParquetReader {
     engine_context: Arc<DeltaKernelEngineContext>,
     store: Arc<dyn ObjectStore>,
     execution_options: DeltaScanExecutionOptions,
     metrics: DeltaScanMetrics,
-    metadata_cache: Option<Arc<RangedParquetMetadataCache>>,
+    metadata_cache: Option<Arc<ParquetMetadataCache>>,
 }
 
-/// Parquet footer metadata shared by ranged tasks within one physical scan.
-#[derive(Default)]
-pub(crate) struct RangedParquetMetadataCache {
-    /// In-flight or completed footer loads keyed by file path and planned size.
-    entries: Mutex<HashMap<(Path, u64), Arc<ParquetMetadataCell>>>,
-}
-
-type ParquetMetadataCell = OnceCell<Arc<ParquetMetaData>>;
-
-impl RangedParquetMetadataCache {
-    fn entry(&self, path: &Path, file_size: u64) -> Arc<ParquetMetadataCell> {
-        Arc::clone(
-            self.entries
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .entry((path.clone(), file_size))
-                .or_insert_with(|| Arc::new(OnceCell::new())),
-        )
-    }
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PreparedParquetMetadataSummary {
+    pub(crate) file_count: usize,
+    pub(crate) memory_bytes: usize,
 }
 
 struct ParquetFileObject {
@@ -162,12 +151,12 @@ impl DirectParquetReader {
         }
     }
 
-    fn with_metadata_cache(mut self, metadata_cache: Arc<RangedParquetMetadataCache>) -> Self {
+    fn with_metadata_cache(mut self, metadata_cache: Arc<ParquetMetadataCache>) -> Self {
         self.metadata_cache = Some(metadata_cache);
         self
     }
 
-    async fn load_ranged_parquet_metadata(
+    async fn load_parquet_metadata(
         &self,
         path: &Path,
         file_size: u64,
@@ -185,6 +174,28 @@ impl DirectParquetReader {
         metadata.boxed().context(DataFileReadSnafu {
             reason: "parquet_read_setup_failed",
         })
+    }
+
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    async fn prepare_task_parquet_metadata(
+        &self,
+        task: &DeltaScanFileTask,
+    ) -> Result<usize, DeltaReaderError> {
+        let object = self.resolve_parquet_object(task)?;
+        let mut reader = ParquetObjectReader::new(Arc::clone(&object.store), object.path.clone())
+            .with_file_size(object.file_size);
+        if let Some(hint) = self.execution_options.parquet_metadata_size_hint_bytes() {
+            reader = reader.with_footer_size_hint(hint);
+        }
+        let options = arrow_reader_options(false, true)
+            .boxed()
+            .context(DataFileReadSnafu {
+                reason: "parquet_row_index_setup_failed",
+            })?;
+        let metadata = self
+            .load_parquet_metadata(&object.path, object.file_size, &mut reader, &options)
+            .await?;
+        Ok(metadata.memory_size())
     }
 
     async fn parquet_object_for_task(
@@ -286,8 +297,8 @@ impl DirectParquetReader {
             .context(DataFileReadSnafu {
                 reason: "parquet_row_index_setup_failed",
             })?;
-        if parquet_byte_range.is_some() {
-            self.create_ranged_stream_builder(
+        if parquet_byte_range.is_some() || self.metadata_cache.is_some() {
+            self.create_stream_builder_from_metadata(
                 path,
                 file_size,
                 reader,
@@ -307,11 +318,11 @@ impl DirectParquetReader {
         }
     }
 
-    /// Creates a stream builder for a ranged Parquet read.
+    /// Creates a stream builder from explicitly loaded Parquet metadata.
     ///
-    /// Ranged tasks load footer metadata explicitly so tasks for the same file can share it. The
-    /// metadata schema is rewritten first when `target_schema` uses view types.
-    async fn create_ranged_stream_builder(
+    /// Ranged tasks and prepared whole-file reads use this path so their metadata can be shared.
+    /// The metadata schema is rewritten first when `target_schema` uses view types.
+    async fn create_stream_builder_from_metadata(
         &self,
         path: &Path,
         file_size: u64,
@@ -320,7 +331,7 @@ impl DirectParquetReader {
         target_schema: &SchemaRef,
     ) -> Result<ParquetRecordBatchStreamBuilder<ParquetObjectReader>, DeltaReaderError> {
         let metadata = self
-            .load_ranged_parquet_metadata(path, file_size, &mut reader, &reader_options)
+            .load_parquet_metadata(path, file_size, &mut reader, &reader_options)
             .await?;
         let metadata = ArrowReaderMetadata::try_new(metadata, reader_options.clone())
             .boxed()
@@ -634,7 +645,7 @@ pub(crate) fn direct_parquet_file_executor(
     output_batch_size_rows: Option<usize>,
     row_predicate: Option<DeltaKernelPredicate>,
     range_read_estimator: Arc<ParquetRangeReadEstimator>,
-    metadata_cache: Option<Arc<RangedParquetMetadataCache>>,
+    metadata_cache: Option<Arc<ParquetMetadataCache>>,
 ) -> FileExecutor<DeltaScanFileTask, FileBatchStream> {
     let reader = DirectParquetReader::new(
         Arc::clone(&plan.engine_context),
@@ -683,6 +694,64 @@ pub(crate) fn direct_parquet_file_executor(
             });
             Ok(Box::pin(batches) as FileBatchStream)
         })
+    })
+}
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+pub(crate) async fn prepare_parquet_metadata(
+    plan: &DeltaScanPlan,
+    metadata_cache: Arc<ParquetMetadataCache>,
+    range_read_estimator: Arc<ParquetRangeReadEstimator>,
+    limits: ParquetMetadataPreparationLimits,
+) -> Result<PreparedParquetMetadataSummary, DeltaReaderError> {
+    let mut seen = HashSet::new();
+    let tasks = plan
+        .partitions
+        .iter()
+        .flat_map(|partition| &partition.file_tasks)
+        .filter(|task| seen.insert((task.path.clone(), task.file_size)))
+        .cloned()
+        .collect::<Vec<_>>();
+    if tasks.len() > limits.max_files {
+        return Err(DeltaReaderError::InvalidConfiguration {
+            reason: "parquet_metadata_preparation_file_limit_exceeded",
+        });
+    }
+
+    let file_count = tasks.len();
+    let reader = Arc::new(
+        DirectParquetReader::new(
+            Arc::clone(&plan.engine_context),
+            plan.execution_options,
+            plan.metrics.clone(),
+            range_read_estimator,
+        )
+        .with_metadata_cache(metadata_cache),
+    );
+    let concurrency = plan
+        .execution_options
+        .resolved_max_concurrent_file_reads_per_scan(
+            plan.partition_target_diagnostic.target_partitions,
+        );
+    let mut loads = stream::iter(tasks)
+        .map(|task| {
+            let reader = Arc::clone(&reader);
+            async move { reader.prepare_task_parquet_metadata(&task).await }
+        })
+        .buffer_unordered(concurrency);
+    let mut memory_bytes = 0_usize;
+    while let Some(result) = loads.next().await {
+        memory_bytes = memory_bytes
+            .checked_add(result?)
+            .filter(|bytes| *bytes <= limits.max_retained_metadata_bytes)
+            .ok_or(DeltaReaderError::InvalidConfiguration {
+                reason: "parquet_metadata_preparation_memory_limit_exceeded",
+            })?;
+    }
+
+    Ok(PreparedParquetMetadataSummary {
+        file_count,
+        memory_bytes,
     })
 }
 
@@ -851,11 +920,15 @@ mod tests {
     use parquet::file::metadata::ParquetMetaDataReader;
     use parquet::file::properties::{EnabledStatistics, WriterProperties};
 
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    use super::prepare_parquet_metadata;
     use super::{
-        DirectParquetReader, LogicalDataFileReadRequest, PhysicalParquetStreamOptions,
-        RangedParquetMetadataCache, RowFilterInput, arrow_reader_options, data_file_error,
+        DirectParquetReader, LogicalDataFileReadRequest, ParquetMetadataCache,
+        PhysicalParquetStreamOptions, RowFilterInput, arrow_reader_options, data_file_error,
         direct_parquet_file_executor,
     };
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    use crate::reader::ParquetMetadataPreparationLimits;
     use crate::reader::backend::kernel_reader::delta_kernel_file_executor;
     use crate::{
         DeltaReaderError, DeltaScanExecutionOptions, DeltaScanMetrics, DeltaSnapshotSelection,
@@ -1705,7 +1778,7 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, true),
         ]));
-        reader = reader.with_metadata_cache(Arc::new(RangedParquetMetadataCache::default()));
+        reader = reader.with_metadata_cache(Arc::new(ParquetMetadataCache::default()));
         Ok((Arc::new(reader), gated, task, schema))
     }
 
@@ -1914,6 +1987,80 @@ mod tests {
                 .snapshot()
                 .parquet_data_file_range_get_operations,
             Some(1)
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[tokio::test]
+    async fn prepared_metadata_is_reused_by_a_whole_file_read()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (reader, gated, mut task, schema) = gated_ranged_metadata_reader(
+            "direct-prepared-metadata-whole-file",
+            GateRequest::Range(1),
+        )
+        .await?;
+        task.parquet_byte_range = None;
+
+        let prepare_reader = Arc::clone(&reader);
+        let prepare_task = task.clone();
+        let prepare = tokio::spawn(async move {
+            prepare_reader
+                .prepare_task_parquet_metadata(&prepare_task)
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), gated.wait_started()).await?;
+        gated.release.add_permits(1);
+        tokio::time::timeout(std::time::Duration::from_secs(5), prepare).await???;
+
+        let range_calls_after_prepare = gated.range_calls.load(Ordering::Acquire);
+        assert!(range_calls_after_prepare > 0);
+        let object = reader.resolve_parquet_object(&task)?;
+        let cached = reader
+            .metadata_cache
+            .as_ref()
+            .ok_or("prepared reader must retain its metadata cache")?
+            .entry(&object.path, object.file_size);
+        assert!(cached.get().is_some());
+
+        reader
+            .create_stream_builder(&object, None, &schema, false, true)
+            .await?;
+        assert_eq!(
+            gated.range_calls.load(Ordering::Acquire),
+            range_calls_after_prepare
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[tokio::test]
+    async fn preparation_checks_the_file_limit_before_reading_parquet_metadata()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = TestDir::new("direct-prepare-file-limit")?;
+        let parquet_bytes = parquet_bytes()?;
+        write_partitioned_non_dv_table(&root, &parquet_bytes)?;
+        add_second_partition_file(&root, &parquet_bytes)?;
+        let plan = non_dv_plan(&root, None)?;
+
+        let error = prepare_parquet_metadata(
+            plan.as_ref(),
+            Arc::new(ParquetMetadataCache::default()),
+            Arc::default(),
+            ParquetMetadataPreparationLimits {
+                max_files: 1,
+                max_retained_metadata_bytes: usize::MAX,
+            },
+        )
+        .await
+        .expect_err("two files must exceed a one-file preparation limit");
+
+        assert_eq!(error.code(), "invalid_configuration");
+        assert_eq!(
+            plan.metrics
+                .snapshot()
+                .parquet_data_file_range_get_operations,
+            Some(0)
         );
         Ok(())
     }

--- a/src/reader/backend/direct_parquet.rs
+++ b/src/reader/backend/direct_parquet.rs
@@ -2035,6 +2035,44 @@ mod tests {
 
     #[cfg(feature = "experimental-parquet-metadata-preparation")]
     #[tokio::test]
+    async fn cancelled_metadata_preparation_leaves_the_cache_retryable()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (reader, gated, task, _) = gated_ranged_metadata_reader(
+            "direct-prepared-metadata-cancellation",
+            GateRequest::Range(1),
+        )
+        .await?;
+        let object = reader.resolve_parquet_object(&task)?;
+        let cached = reader
+            .metadata_cache
+            .as_ref()
+            .ok_or("prepared reader must retain its metadata cache")?
+            .entry(&object.path, object.file_size);
+
+        let prepare_reader = Arc::clone(&reader);
+        let prepare_task = task.clone();
+        let prepare = tokio::spawn(async move {
+            prepare_reader
+                .prepare_task_parquet_metadata(&prepare_task)
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), gated.wait_started()).await?;
+        prepare.abort();
+        let join_error = prepare
+            .await
+            .expect_err("aborted metadata preparation unexpectedly completed");
+        assert!(join_error.is_cancelled());
+        assert!(gated.was_cancelled());
+        assert!(cached.get().is_none());
+
+        reader.prepare_task_parquet_metadata(&task).await?;
+        assert!(cached.get().is_some());
+        assert_eq!(gated.range_calls.load(Ordering::Acquire), 2);
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[tokio::test]
     async fn preparation_checks_the_file_limit_before_reading_parquet_metadata()
     -> Result<(), Box<dyn std::error::Error>> {
         let root = TestDir::new("direct-prepare-file-limit")?;

--- a/src/reader/backend/direct_parquet/metadata_cache.rs
+++ b/src/reader/backend/direct_parquet/metadata_cache.rs
@@ -1,0 +1,34 @@
+//! Shared parsed Parquet metadata cache.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use object_store::path::Path;
+use parquet::file::metadata::ParquetMetaData;
+use tokio::sync::OnceCell;
+
+type ParquetMetadataCell = OnceCell<Arc<ParquetMetaData>>;
+
+/// Parsed Parquet metadata shared by file tasks.
+///
+/// An empty cache deduplicates lazy metadata loads for ranged tasks within one physical plan. A
+/// cache populated during table loading can instead be retained and reused by later scans. This
+/// type provides only keyed storage and single-flight loading; its owner defines the lifetime.
+#[derive(Default)]
+pub(crate) struct ParquetMetadataCache {
+    entries: Mutex<HashMap<(Path, u64), Arc<ParquetMetadataCell>>>,
+}
+
+impl ParquetMetadataCache {
+    pub(super) fn entry(&self, path: &Path, file_size: u64) -> Arc<ParquetMetadataCell> {
+        Arc::clone(
+            self.entries
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .entry((path.clone(), file_size))
+                .or_insert_with(|| Arc::new(OnceCell::new())),
+        )
+    }
+}

--- a/src/reader/backend/direct_parquet/metadata_cache.rs
+++ b/src/reader/backend/direct_parquet/metadata_cache.rs
@@ -32,3 +32,22 @@ impl ParquetMetadataCache {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entries_are_reused_only_for_the_same_path_and_size() {
+        let cache = ParquetMetadataCache::default();
+        let path = Path::from("part.parquet");
+        let entry = cache.entry(&path, 100);
+
+        assert!(Arc::ptr_eq(&entry, &cache.entry(&path, 100)));
+        assert!(!Arc::ptr_eq(&entry, &cache.entry(&path, 101)));
+        assert!(!Arc::ptr_eq(
+            &entry,
+            &cache.entry(&Path::from("other.parquet"), 100)
+        ));
+    }
+}

--- a/src/reader/datafusion.rs
+++ b/src/reader/datafusion.rs
@@ -232,13 +232,18 @@ impl DeltaTableProvider {
                 "Delta scan execution setup"
             )
             .entered();
+            let metrics = ScanMetrics::new(
+                self.registration_name.clone(),
+                reader_plan.metrics.clone(),
+                self.options.use_arrow_view_types,
+            );
             create_datafusion_execution_plan(
                 reader_plan,
                 datafusion_plan,
                 exact_row_predicate,
                 Arc::clone(&self.range_read_estimator),
-                self.registration_name.clone(),
-                self.options.use_arrow_view_types,
+                self.table.prepared_parquet_metadata_cache(),
+                metrics,
                 self.options.intra_file_repartitioning,
             )
         };

--- a/src/reader/datafusion/execution.rs
+++ b/src/reader/datafusion/execution.rs
@@ -148,8 +148,7 @@ struct MetricsInner {
 }
 
 impl ScanMetrics {
-    #[allow(dead_code)]
-    fn new(
+    pub(super) fn new(
         registration_name: Option<String>,
         reader_metrics: DeltaScanMetrics,
         use_arrow_view_types: bool,
@@ -310,8 +309,8 @@ pub(crate) fn create_datafusion_execution_plan(
     datafusion_plan: DataFusionScanPlan,
     exact_row_predicate: Option<DeltaKernelPredicate>,
     range_read_estimator: Arc<ParquetRangeReadEstimator>,
-    registration_name: Option<String>,
-    use_arrow_view_types: bool,
+    parquet_metadata_cache: Option<Arc<ParquetMetadataCache>>,
+    metrics: ScanMetrics,
     intra_file_repartitioning: IntraFileRepartitioning,
 ) -> Arc<dyn ExecutionPlan> {
     Arc::new(DeltaScanExec::new(
@@ -319,8 +318,8 @@ pub(crate) fn create_datafusion_execution_plan(
         datafusion_plan,
         exact_row_predicate,
         range_read_estimator,
-        registration_name,
-        use_arrow_view_types,
+        parquet_metadata_cache,
+        metrics,
         intra_file_repartitioning,
     ))
 }
@@ -349,18 +348,13 @@ impl DeltaScanExec {
         datafusion_plan: DataFusionScanPlan,
         exact_row_predicate: Option<DeltaKernelPredicate>,
         range_read_estimator: Arc<ParquetRangeReadEstimator>,
-        registration_name: Option<String>,
-        use_arrow_view_types: bool,
+        parquet_metadata_cache: Option<Arc<ParquetMetadataCache>>,
+        metrics: ScanMetrics,
         intra_file_repartitioning: IntraFileRepartitioning,
     ) -> Self {
         let schema = datafusion_plan.projection.output_schema;
         let output_projection = datafusion_plan.projection.output_projection.map(Arc::from);
         let properties = scan_properties(&schema, reader_plan.partitions.len());
-        let metrics = ScanMetrics::new(
-            registration_name,
-            reader_plan.metrics.clone(),
-            use_arrow_view_types,
-        );
         let limiter = ScanReadLimiter::new(
             reader_plan.execution_options,
             reader_plan.partition_target_diagnostic.target_partitions,
@@ -378,7 +372,7 @@ impl DeltaScanExec {
             dynamic_filters: Arc::from([]),
             intra_file_repartitioning,
             range_read_estimator,
-            parquet_metadata_cache: None,
+            parquet_metadata_cache,
             file_tasks_repartitioned: false,
         }
     }
@@ -1093,13 +1087,14 @@ mod tests {
                 datafusion_target_partitions: None,
             },
         )?;
+        let metrics = ScanMetrics::new(registration_name, reader_plan.metrics.clone(), true);
         Ok(create_datafusion_execution_plan(
             reader_plan,
             datafusion_plan,
             exact_row_predicate,
             Arc::default(),
-            registration_name,
-            true,
+            table.prepared_parquet_metadata_cache(),
+            metrics,
             intra_file_repartitioning,
         ))
     }

--- a/src/reader/datafusion/execution.rs
+++ b/src/reader/datafusion/execution.rs
@@ -58,7 +58,7 @@ use super::{
 };
 
 use crate::reader::backend::direct_parquet::{
-    ParquetRangeReadEstimator, RangedParquetMetadataCache, direct_parquet_file_executor,
+    ParquetMetadataCache, ParquetRangeReadEstimator, direct_parquet_file_executor,
 };
 use crate::{
     DeltaReaderError, DeltaScanMetrics, DeltaScanMetricsSnapshot, ParquetReaderBackend,
@@ -337,7 +337,9 @@ struct DeltaScanExec {
     dynamic_filters: Arc<[RetainedDynamicFilter]>,
     intra_file_repartitioning: IntraFileRepartitioning,
     range_read_estimator: Arc<ParquetRangeReadEstimator>,
-    parquet_metadata_cache: Option<Arc<RangedParquetMetadataCache>>,
+    parquet_metadata_cache: Option<Arc<ParquetMetadataCache>>,
+    // A prepared table can supply a cache before DataFusion repartitions this plan.
+    file_tasks_repartitioned: bool,
 }
 
 impl DeltaScanExec {
@@ -377,6 +379,7 @@ impl DeltaScanExec {
             intra_file_repartitioning,
             range_read_estimator,
             parquet_metadata_cache: None,
+            file_tasks_repartitioned: false,
         }
     }
 
@@ -406,11 +409,18 @@ impl DeltaScanExec {
             target_partitions,
             partition_count,
         );
+        // Preserve a table-prepared cache. Otherwise, give the ranged tasks created here an empty
+        // cache so they share their first metadata load.
+        let parquet_metadata_cache = self
+            .parquet_metadata_cache
+            .clone()
+            .unwrap_or_else(|| Arc::new(ParquetMetadataCache::default()));
         Arc::new(Self {
             reader_plan: Arc::new(reader_plan),
             properties: scan_properties(&self.schema, partition_count),
             limiter,
-            parquet_metadata_cache: Some(Arc::new(RangedParquetMetadataCache::default())),
+            parquet_metadata_cache: Some(parquet_metadata_cache),
+            file_tasks_repartitioned: true,
             ..self.clone()
         })
     }
@@ -603,7 +613,7 @@ impl ExecutionPlan for DeltaScanExec {
         _datafusion_target_partitions: usize,
         config: &ConfigOptions,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
-        if self.parquet_metadata_cache.is_some()
+        if self.file_tasks_repartitioned
             || self.reader_plan.execution_options.parquet_backend() != ParquetReaderBackend::Direct
         {
             return Ok(None);
@@ -1099,7 +1109,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provider_reuses_one_range_read_estimator_across_physical_plans() -> TestResult {
+    async fn provider_scopes_the_range_estimator_and_repartitioning_preserves_the_metadata_cache()
+    -> TestResult {
         let fixture = TestTable::partitioned("shared-range-read-estimator")?;
         let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let provider = DeltaTableProvider::try_new(table.clone(), ScanOptions::default())?;
@@ -1127,6 +1138,17 @@ mod tests {
             .as_ref()
             .downcast_ref::<DeltaScanExec>()
             .ok_or("repartitioned plan was not DeltaScanExec")?;
+        let prepared_cache = Arc::new(ParquetMetadataCache::default());
+        let prepared = DeltaScanExec {
+            parquet_metadata_cache: Some(Arc::clone(&prepared_cache)),
+            ..first.clone()
+        };
+        let prepared_repartitioned =
+            prepared.with_repartitioned_partitions(prepared.reader_plan.partitions.clone());
+        let prepared_repartitioned = prepared_repartitioned
+            .as_ref()
+            .downcast_ref::<DeltaScanExec>()
+            .ok_or("prepared plan was not repartitioned")?;
 
         assert!(Arc::ptr_eq(
             &first.range_read_estimator,
@@ -1139,6 +1161,15 @@ mod tests {
         assert!(!Arc::ptr_eq(
             &first.range_read_estimator,
             &separate.range_read_estimator
+        ));
+        assert!(repartitioned.file_tasks_repartitioned);
+        assert!(prepared_repartitioned.file_tasks_repartitioned);
+        assert!(Arc::ptr_eq(
+            prepared_repartitioned
+                .parquet_metadata_cache
+                .as_ref()
+                .ok_or("repartitioned plan lost its prepared metadata cache")?,
+            &prepared_cache,
         ));
         Ok(())
     }

--- a/tests/benchmark_harness.rs
+++ b/tests/benchmark_harness.rs
@@ -1,6 +1,9 @@
 //! Test target for the frozen reader benchmark harness.
 
-#![cfg(feature = "datafusion")]
+#![cfg(all(
+    feature = "datafusion",
+    feature = "experimental-parquet-metadata-preparation"
+))]
 
 #[allow(dead_code)]
 #[path = "../benches/reader.rs"]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -305,6 +305,30 @@ fn streaming_reader_contract_is_public() {
     let _ = (stream_schema, metrics);
 }
 
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[test]
+fn prepared_parquet_metadata_contract_is_public() {
+    use delta_arrow_reader::{ParquetMetadataPreparationLimits, ParquetMetadataPreparationReport};
+
+    fn assert_debug<T: std::fmt::Debug>() {}
+    fn assert_clone<T: Clone>() {}
+    fn assert_future<T>(_: impl Future<Output = T>) {}
+
+    assert_debug::<ParquetMetadataPreparationLimits>();
+    assert_clone::<ParquetMetadataPreparationReport>();
+    let limits = ParquetMetadataPreparationLimits {
+        max_files: 10,
+        max_retained_metadata_bytes: 1024 * 1024,
+    };
+    assert_future::<Result<DeltaTable, DeltaReaderError>>(
+        DeltaTableBuilder::new("file:///tmp/table")
+            .load_table_with_prepared_parquet_metadata(limits),
+    );
+    let report: for<'a> fn(&'a DeltaTable) -> Option<&'a ParquetMetadataPreparationReport> =
+        DeltaTable::parquet_metadata_preparation_report;
+    let _ = report;
+}
+
 #[cfg(feature = "datafusion")]
 #[test]
 fn datafusion_metrics_contract_is_public() {

--- a/tests/reader/datafusion_adapter.rs
+++ b/tests/reader/datafusion_adapter.rs
@@ -26,6 +26,8 @@ use datafusion::{
     physical_plan::{ExecutionPlan, displayable},
     prelude::{SessionConfig, SessionContext},
 };
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use delta_arrow_reader::ParquetMetadataPreparationLimits;
 use delta_arrow_reader::{
     DeltaReaderError, DeltaReaderPhase, DeltaScanExecutionOptions, DeltaTableBuilder,
     ParquetReaderBackend,
@@ -128,6 +130,19 @@ impl TestTable {
 
     fn disable_delta_log(&self) -> TestResult {
         fs::rename(self.0.join("_delta_log"), self.0.join("disabled-log"))?;
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    fn corrupt_parquet_footer(&self, name: &str) -> TestResult {
+        let path = self.0.join(name);
+        let mut bytes = fs::read(&path)?;
+        let footer_start = bytes
+            .len()
+            .checked_sub(8)
+            .ok_or("test Parquet file is too small to contain a footer")?;
+        bytes[footer_start..].fill(0);
+        fs::write(path, bytes)?;
         Ok(())
     }
 }
@@ -321,6 +336,48 @@ async fn registered_eager_table_reuses_metadata_across_sql_queries_without_the_l
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].snapshot().reader_metrics.files_planned, 1);
     }
+    Ok(())
+}
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[tokio::test]
+async fn datafusion_reuses_table_prepared_parquet_metadata_after_repartitioning() -> TestResult {
+    let fixture = TestTable::partitioned("prepared-parquet-metadata-datafusion")?;
+    let table = DeltaTableBuilder::new(fixture.uri())
+        .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            max_files: 2,
+            max_retained_metadata_bytes: 1024 * 1024,
+        })
+        .await?;
+    let context = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_target_partitions(4)
+            .with_repartition_file_min_size(1),
+    );
+    register_table(
+        &context,
+        "orders",
+        table,
+        ScanOptions {
+            target_partitions: Some(4),
+            ..Default::default()
+        },
+    )?;
+
+    fixture.corrupt_parquet_footer("west.parquet")?;
+    let plan = context
+        .sql("SELECT id FROM orders ORDER BY id")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let display = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        display.contains("DeltaScanExec: snapshot_version=0, partitions=4"),
+        "{display}"
+    );
+
+    let batches = collect_plan(&context, plan).await?;
+    assert_eq!(ids(&batches), [1, 2, 3, 4]);
     Ok(())
 }
 

--- a/tests/reader/datafusion_adapter.rs
+++ b/tests/reader/datafusion_adapter.rs
@@ -11,6 +11,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use arrow::compute::concat_batches;
 use arrow::{
     array::{
         Array, BinaryArray, BinaryViewArray, DictionaryArray, Int32Array, Int64Array, MapArray,
@@ -252,6 +254,13 @@ async fn collect_plan(
     Ok(datafusion::physical_plan::collect(plan, context.task_ctx()).await?)
 }
 
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+async fn collect_query(context: &SessionContext, query: &str) -> TestResult<RecordBatch> {
+    let batches = context.sql(query).await?.collect().await?;
+    let schema = batches.first().ok_or("query returned no batches")?.schema();
+    Ok(concat_batches(&schema, &batches)?)
+}
+
 #[tokio::test]
 async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> TestResult {
     let fixture = TestTable::partitioned("optimizer-file-repartitioning")?;
@@ -349,35 +358,71 @@ async fn datafusion_reuses_table_prepared_parquet_metadata_after_repartitioning(
             max_retained_metadata_bytes: 1024 * 1024,
         })
         .await?;
-    let context = SessionContext::new_with_config(
-        SessionConfig::new()
-            .with_target_partitions(4)
-            .with_repartition_file_min_size(1),
-    );
-    register_table(
-        &context,
-        "orders",
-        table,
-        ScanOptions {
-            target_partitions: Some(4),
-            ..Default::default()
-        },
-    )?;
-
     fixture.corrupt_parquet_footer("west.parquet")?;
-    let plan = context
-        .sql("SELECT id FROM orders ORDER BY id")
-        .await?
-        .create_physical_plan()
-        .await?;
-    let display = displayable(plan.as_ref()).indent(true).to_string();
-    assert!(
-        display.contains("DeltaScanExec: snapshot_version=0, partitions=4"),
-        "{display}"
-    );
+    for _ in 0..2 {
+        let context = SessionContext::new_with_config(
+            SessionConfig::new()
+                .with_target_partitions(4)
+                .with_repartition_file_min_size(1),
+        );
+        register_table(
+            &context,
+            "orders",
+            table.clone(),
+            ScanOptions {
+                target_partitions: Some(4),
+                ..Default::default()
+            },
+        )?;
 
-    let batches = collect_plan(&context, plan).await?;
-    assert_eq!(ids(&batches), [1, 2, 3, 4]);
+        let plan = context
+            .sql("SELECT id FROM orders ORDER BY id")
+            .await?
+            .create_physical_plan()
+            .await?;
+        let display = displayable(plan.as_ref()).indent(true).to_string();
+        assert!(
+            display.contains("DeltaScanExec: snapshot_version=0, partitions=4"),
+            "{display}"
+        );
+
+        let batches = collect_plan(&context, plan).await?;
+        assert_eq!(ids(&batches), [1, 2, 3, 4]);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[tokio::test]
+async fn prepared_parquet_metadata_preserves_datafusion_results() -> TestResult {
+    let fixture = RealParquetDeltaTable::new_with_two_row_groups_and_deletion_vector(
+        "prepared-datafusion-equivalence",
+        3,
+        &[1, 4],
+    )?;
+    let location = fixture.path().to_string_lossy().into_owned();
+    let eager = DeltaTableBuilder::new(location.clone())
+        .load_table_with_eager_scan_metadata()
+        .await?;
+    let prepared = DeltaTableBuilder::new(location)
+        .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            max_files: 1,
+            max_retained_metadata_bytes: 1024 * 1024,
+        })
+        .await?;
+    let context = SessionContext::new();
+    register_table(&context, "eager", eager, ScanOptions::default())?;
+    register_table(&context, "prepared", prepared, ScanOptions::default())?;
+
+    for query in [
+        "SELECT id, customer_name FROM {table} ORDER BY id",
+        "SELECT id FROM {table} ORDER BY id",
+        "SELECT id FROM {table} WHERE id > 3 ORDER BY id",
+    ] {
+        let eager = collect_query(&context, &query.replace("{table}", "eager")).await?;
+        let prepared = collect_query(&context, &query.replace("{table}", "prepared")).await?;
+        assert_eq!(prepared, eager, "{query}");
+    }
     Ok(())
 }
 

--- a/tests/reader/portable_fixtures.rs
+++ b/tests/reader/portable_fixtures.rs
@@ -11,9 +11,11 @@ use arrow::{
     record_batch::RecordBatch,
     util::display::array_value_to_string,
 };
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use delta_arrow_reader::ParquetMetadataPreparationLimits;
 use delta_arrow_reader::{
     DeltaBatchStream, DeltaComparison, DeltaPredicate, DeltaReaderError, DeltaReaderPhase,
-    DeltaScalar, DeltaScanExecutionOptions, DeltaScanMetrics, DeltaScanMetricsSnapshot,
+    DeltaScalar, DeltaScanExecutionOptions, DeltaScanMetrics, DeltaScanMetricsSnapshot, DeltaTable,
     DeltaTableBuilder, ParquetReaderBackend,
 };
 use futures_util::{StreamExt, TryStreamExt};
@@ -562,6 +564,14 @@ async fn scan_fixture(
         .with_execution_options(options)
         .load_table()
         .await?;
+    scan_table(&table, projection, predicate).await
+}
+
+async fn scan_table(
+    table: &DeltaTable,
+    projection: Option<Vec<String>>,
+    predicate: Option<DeltaPredicate>,
+) -> TestResult<ScanAttempt> {
     let scan = table.scan().with_target_partitions(1)?;
     let scan = match projection {
         Some(projection) => scan.with_projection(projection),
@@ -597,6 +607,74 @@ async fn scan_fixture(
             metrics: metrics.snapshot(),
         }),
     }
+}
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[test]
+fn prepared_parquet_metadata_preserves_streaming_scan_results() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = RealParquetDeltaTable::new_with_two_row_groups_and_deletion_vector(
+            "prepared-streaming-equivalence",
+            3,
+            &[1, 4],
+        )?;
+        let location = fixture.path().to_string_lossy().into_owned();
+        let eager = DeltaTableBuilder::new(location.clone())
+            .load_table_with_eager_scan_metadata()
+            .await?;
+        let prepared = DeltaTableBuilder::new(location)
+            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                max_files: 1,
+                max_retained_metadata_bytes: 1024 * 1024,
+            })
+            .await?;
+
+        let cases = [
+            ("full scan", None, None, vec![1, 3, 4, 6]),
+            ("projection", projection(&["id"]), None, vec![1, 3, 4, 6]),
+            (
+                "exact row filter",
+                projection(&["id"]),
+                Some(DeltaPredicate::Compare {
+                    column: "id".into(),
+                    op: DeltaComparison::Gt,
+                    value: DeltaScalar::Int32(3),
+                }),
+                vec![4, 6],
+            ),
+        ];
+
+        for (name, projection, predicate, expected_ids) in cases {
+            let (eager_batch, eager_metrics, _) = assert_success(
+                name,
+                ParquetReaderBackend::Direct,
+                scan_table(&eager, projection.clone(), predicate.clone()).await?,
+                &expected_ids,
+            )?;
+            let (prepared_batch, prepared_metrics, _) = assert_success(
+                name,
+                ParquetReaderBackend::Direct,
+                scan_table(&prepared, projection, predicate).await?,
+                &expected_ids,
+            )?;
+
+            assert_eq!(prepared_batch, eager_batch, "{name}");
+            assert_eq!(
+                (
+                    prepared_metrics.deletion_vector_payloads_loaded,
+                    prepared_metrics.deletion_vectors_applied,
+                    prepared_metrics.deletion_vector_rows_deleted,
+                ),
+                (
+                    eager_metrics.deletion_vector_payloads_loaded,
+                    eager_metrics.deletion_vectors_applied,
+                    eager_metrics.deletion_vector_rows_deleted,
+                ),
+                "{name}"
+            );
+        }
+        Ok::<_, Box<dyn Error>>(())
+    })
 }
 
 fn batch_ids(batch: &RecordBatch) -> TestResult<Vec<i32>> {

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -15,6 +15,10 @@ use arrow::{
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use delta_arrow_reader::DeltaReaderError;
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+use delta_arrow_reader::ParquetMetadataPreparationLimits;
 use delta_arrow_reader::ParquetReaderBackend;
 use delta_arrow_reader::{
     DeltaComparison, DeltaPredicate, DeltaReaderPhase, DeltaScalar, DeltaSnapshotSelection,
@@ -133,6 +137,19 @@ impl TestTable {
 
     fn disable_delta_log(&self) -> TestResult {
         fs::rename(self.0.join("_delta_log"), self.0.join("disabled-log"))?;
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    fn corrupt_parquet_footer(&self, name: &str) -> TestResult {
+        let path = self.0.join(name);
+        let mut bytes = fs::read(&path)?;
+        let footer_start = bytes
+            .len()
+            .checked_sub(8)
+            .ok_or("test Parquet file is too small to contain a footer")?;
+        bytes[footer_start..].fill(0);
+        fs::write(path, bytes)?;
         Ok(())
     }
 
@@ -392,6 +409,146 @@ fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestRes
         assert_eq!(low_metrics.snapshot().files_planned, 1);
         assert_eq!(high_metrics.snapshot().files_planned, 1);
         assert_eq!(fixed_metrics.snapshot().files_planned, 1);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[test]
+fn prepared_parquet_metadata_supports_repeated_streaming_scans_without_the_delta_log() -> TestResult
+{
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("prepared-parquet-metadata")?;
+        let table = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                max_files: 2,
+                max_retained_metadata_bytes: 1024 * 1024,
+            })
+            .await?;
+        let eager_only = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_eager_scan_metadata()
+            .await?;
+        let cloned = table.clone();
+        let report = table
+            .parquet_metadata_preparation_report()
+            .ok_or("prepared table must expose its preparation report")?;
+
+        assert_eq!(report.files_prepared, 2);
+        assert!(report.estimated_retained_metadata_bytes > 0);
+        assert_eq!(report.read_metrics.files_planned, 2);
+        assert!(std::ptr::eq(
+            report,
+            cloned
+                .parquet_metadata_preparation_report()
+                .ok_or("cloned table must share its preparation report")?
+        ));
+
+        fixture.corrupt_parquet_footer("part-0.parquet")?;
+        fixture.disable_delta_log()?;
+        let low_ids = DeltaPredicate::Compare {
+            column: "id".into(),
+            op: DeltaComparison::LtEq,
+            value: DeltaScalar::Int32(4),
+        };
+        let high_ids = DeltaPredicate::Compare {
+            column: "id".into(),
+            op: DeltaComparison::Gt,
+            value: DeltaScalar::Int32(4),
+        };
+        let ((low_batches, _), (high_batches, _)) = tokio::try_join!(
+            collect_scan(table.scan().with_predicate(low_ids).build().await?),
+            collect_scan(cloned.scan().with_predicate(high_ids).build().await?),
+        )?;
+
+        assert_eq!(sorted_ids(&low_batches), [1, 2, 3, 4]);
+        assert_eq!(sorted_ids(&high_batches), [5, 6, 7, 8]);
+        let eager_only_error = collect_scan(
+            eager_only
+                .scan()
+                .with_predicate(DeltaPredicate::Compare {
+                    column: "id".into(),
+                    op: DeltaComparison::LtEq,
+                    value: DeltaScalar::Int32(4),
+                })
+                .build()
+                .await?,
+        )
+        .await
+        .expect_err("the eager-only control must read the corrupted Parquet footer");
+        assert_eq!(
+            eager_only_error
+                .downcast_ref::<DeltaReaderError>()
+                .ok_or("the eager-only control returned an unexpected error type")?
+                .phase(),
+            DeltaReaderPhase::DataFileRead
+        );
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[test]
+fn prepared_parquet_metadata_rejects_unsafe_or_unsupported_requests() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("prepared-parquet-limits")?;
+        for limits in [
+            ParquetMetadataPreparationLimits {
+                max_files: 0,
+                max_retained_metadata_bytes: 1024 * 1024,
+            },
+            ParquetMetadataPreparationLimits {
+                max_files: 2,
+                max_retained_metadata_bytes: 0,
+            },
+        ] {
+            let error = DeltaTableBuilder::new(fixture.uri())
+                .load_table_with_prepared_parquet_metadata(limits)
+                .await
+                .expect_err("zero preparation limits must be rejected");
+            assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
+        }
+
+        let file_limit_error = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                max_files: 1,
+                max_retained_metadata_bytes: usize::MAX,
+            })
+            .await
+            .expect_err("two active files must exceed the one-file limit");
+        assert_eq!(file_limit_error.phase(), DeltaReaderPhase::Configuration);
+
+        let memory_limit_error = DeltaTableBuilder::new(fixture.uri())
+            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                max_files: 2,
+                max_retained_metadata_bytes: 1,
+            })
+            .await
+            .expect_err("one byte cannot retain two Parquet metadata objects");
+        assert_eq!(memory_limit_error.phase(), DeltaReaderPhase::Configuration);
+
+        let kernel_error = DeltaTableBuilder::new(fixture.uri())
+            .with_execution_options(
+                DeltaScanExecutionOptions::new()
+                    .with_parquet_backend(ParquetReaderBackend::DeltaKernel),
+            )
+            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                max_files: 2,
+                max_retained_metadata_bytes: 1024 * 1024,
+            })
+            .await
+            .expect_err("the Delta Kernel backend cannot prepare direct-reader metadata");
+        assert_eq!(kernel_error.phase(), DeltaReaderPhase::Configuration);
+
+        let missing = TestTable::missing_data_file("prepared-parquet-missing")?;
+        let missing_error = DeltaTableBuilder::new(missing.uri())
+            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                max_files: 1,
+                max_retained_metadata_bytes: 1024 * 1024,
+            })
+            .await
+            .expect_err("missing Parquet metadata must fail table preparation");
+        assert_eq!(missing_error.phase(), DeltaReaderPhase::DataFileRead);
+        assert!(!missing_error.to_string().contains("missing.parquet"));
         Ok::<_, Box<dyn Error>>(())
     })
 }


### PR DESCRIPTION
## Summary

- add an experimental builder-level loading mode that prepares Parquet footers and optional offset indexes for every active file
- share the prepared metadata across streaming scans, table clones, DataFusion providers, and repartitioned plans
- enforce explicit file-count and estimated-memory limits, with atomic failure and cancellation behavior
- document the opt-in trade-off and add controlled benchmark results for repeated-query workloads
- cover streaming and DataFusion equivalence, cache reuse, resource limits, corrupt metadata, cancellation, and feature combinations

## Validation

- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- feature-matrix `cargo check --locked --all-targets` runs
- `python -m zensical build --strict -f docs/mkdocs.yml`
- controlled prepared-Parquet-metadata benchmark rerun with matching rows and fixture fingerprints

Closes #77