### PR TITLE
test: validate adaptive Parquet range estimates against tiny reads

### DIFF
--- a/benches/range_planning.rs
+++ b/benches/range_planning.rs
@@ -29,8 +29,11 @@ use serde_json::json;
 
 #[path = "range_planning/controlled_http.rs"]
 mod controlled_http;
+#[path = "range_planning/plan_diagnostics.rs"]
+mod plan_diagnostics;
 
 use controlled_http::ControlledHttpServer;
+use plan_diagnostics::{AutomaticRangePlanCollector, AutomaticRangePlanDiagnostic};
 
 const MATCH_VALUE: &str = "match";
 const OTHER_VALUE: &str = "other";
@@ -218,7 +221,7 @@ impl TransportProfile {
     const HIGH_LATENCY_HIGH_THROUGHPUT: Self = Self {
         name: "high_latency_high_throughput",
         request_latency: Duration::from_millis(20),
-        shared_throughput_bytes_per_second: 512 * 1024 * 1024,
+        shared_throughput_bytes_per_second: 128 * 1024 * 1024,
     };
 
     const ALL: [Self; 3] = [
@@ -228,7 +231,7 @@ impl TransportProfile {
     ];
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct Measurement {
     case: BenchmarkCase,
     repetition: usize,
@@ -252,17 +255,23 @@ struct Measurement {
     cost_based_exact_plans: u64,
     cost_based_merged_plans: u64,
     store_delegated_plans: u64,
+    automatic_range_plans: Vec<AutomaticRangePlanDiagnostic>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     let config = Config::parse(env::args().skip(1))?;
+    let automatic_range_plans = AutomaticRangePlanCollector::install()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-    runtime.block_on(run(&config, BENCHMARK_SHAPE))
+    runtime.block_on(run(&config, BENCHMARK_SHAPE, &automatic_range_plans))
 }
 
-async fn run(config: &Config, shape: FixtureShape) -> Result<(), Box<dyn Error>> {
+async fn run(
+    config: &Config,
+    shape: FixtureShape,
+    automatic_range_plans: &AutomaticRangePlanCollector,
+) -> Result<(), Box<dyn Error>> {
     let mut measurements = Vec::new();
     for profile in TransportProfile::ALL {
         let fixture = Fixture::create(&config.temp_dir, shape, profile, config.retain_fixtures)?;
@@ -294,6 +303,7 @@ async fn run(config: &Config, shape: FixtureShape) -> Result<(), Box<dyn Error>>
                                 policy,
                             },
                             repetition,
+                            automatic_range_plans,
                         )
                         .await?,
                     );
@@ -311,6 +321,7 @@ async fn run(config: &Config, shape: FixtureShape) -> Result<(), Box<dyn Error>>
         )
     });
     print_measurements(&measurements);
+    print_automatic_range_plans(&measurements);
     Ok(())
 }
 
@@ -402,7 +413,9 @@ async fn measure_case(
     shape: FixtureShape,
     case: BenchmarkCase,
     repetition: usize,
+    automatic_range_plans: &AutomaticRangePlanCollector,
 ) -> Result<Measurement, Box<dyn Error>> {
+    drop(automatic_range_plans.take());
     let payload_indices = case
         .density
         .payload_indices(shape.payload_columns)
@@ -436,6 +449,7 @@ async fn measure_case(
         validate_batch(&batch?, &payload_indices, &mut row_ids)?;
     }
     let total_micros = saturating_u64(started.elapsed().as_micros());
+    let automatic_range_plans = automatic_range_plans.take();
     row_ids.sort_unstable();
     if row_ids != shape.expected_row_ids() {
         return Err(io::Error::other("benchmark scan returned unexpected row IDs").into());
@@ -515,6 +529,7 @@ async fn measure_case(
         cost_based_exact_plans,
         cost_based_merged_plans,
         store_delegated_plans,
+        automatic_range_plans,
     })
 }
 
@@ -601,7 +616,11 @@ fn benchmark_batch(
 fn payload_value(row_id: i32, payload_index: usize) -> Option<String> {
     let row_id_usize = usize::try_from(row_id).ok()?;
     (!(row_id_usize + payload_index).is_multiple_of(17))
-        .then(|| format!("payload-{payload_index:03}-{row_id:08}-{PAYLOAD_FILLER}"))
+        .then(|| {
+            format!(
+                "payload-{payload_index:03}-{row_id:08}-{PAYLOAD_FILLER}{PAYLOAD_FILLER}{PAYLOAD_FILLER}{PAYLOAD_FILLER}"
+            )
+        })
 }
 
 fn payload_name(index: usize) -> String {
@@ -704,13 +723,27 @@ fn validate_measurements(measurements: &[Measurement]) -> Result<(), io::Error> 
         let decisions = automatic
             .iter()
             .map(|measurement| {
+                let max_selected_bytes = measurement
+                    .automatic_range_plans
+                    .iter()
+                    .map(|plan| plan.selected_bytes)
+                    .max()
+                    .unwrap_or(0);
+                let max_throughput_samples = measurement
+                    .automatic_range_plans
+                    .iter()
+                    .map(|plan| plan.throughput_sample_count)
+                    .max()
+                    .unwrap_or(0);
                 format!(
-                    "{}/{}:cold={},exact={},merged={}",
+                    "{}/{}:cold={},exact={},merged={},max_selected_bytes={},max_throughput_samples={}",
                     measurement.case.profile.name,
                     measurement.case.density.name(),
                     measurement.cold_start_plans,
                     measurement.cost_based_exact_plans,
                     measurement.cost_based_merged_plans,
+                    max_selected_bytes,
+                    max_throughput_samples,
                 )
             })
             .collect::<Vec<_>>()
@@ -800,6 +833,57 @@ fn print_measurements(measurements: &[Measurement]) {
             measurement.cost_based_merged_plans,
             measurement.store_delegated_plans,
         );
+    }
+}
+
+fn print_automatic_range_plans(measurements: &[Measurement]) {
+    println!();
+    println!(
+        "transport_profile,projection_density,repetition,plan_index,latency_sample_count,throughput_sample_count,estimated_request_latency_micros,estimated_shared_throughput_bytes_per_second,estimated_bandwidth_delay_bytes,decision,exact_range_count,exact_request_waves,exact_bytes,baseline_range_count,baseline_request_waves,baseline_bytes,selected_range_count,selected_request_waves,selected_bytes,estimated_selected_plan_micros,observed_selected_plan_micros,prediction_error_micros"
+    );
+    for measurement in measurements {
+        for (plan_index, plan) in measurement.automatic_range_plans.iter().enumerate() {
+            let predicted_micros = plan.predicted_micros();
+            println!(
+                "{}",
+                [
+                    measurement.case.profile.name.to_owned(),
+                    measurement.case.density.name().to_owned(),
+                    measurement.repetition.to_string(),
+                    plan_index.saturating_add(1).to_string(),
+                    plan.latency_sample_count.to_string(),
+                    plan.throughput_sample_count.to_string(),
+                    optional(plan.estimated_request_latency_micros),
+                    optional(plan.estimated_shared_throughput_bytes_per_second),
+                    optional(plan.estimated_bandwidth_delay_bytes),
+                    plan.decision.clone(),
+                    plan.exact_range_count.to_string(),
+                    plan.exact_request_waves.to_string(),
+                    plan.exact_bytes.to_string(),
+                    plan.baseline_range_count.to_string(),
+                    plan.baseline_request_waves.to_string(),
+                    plan.baseline_bytes.to_string(),
+                    plan.selected_range_count.to_string(),
+                    plan.selected_request_waves.to_string(),
+                    plan.selected_bytes.to_string(),
+                    optional(predicted_micros),
+                    plan.observed_selected_plan_micros.to_string(),
+                    optional(predicted_micros.map(|predicted| signed_difference(
+                        plan.observed_selected_plan_micros,
+                        predicted,
+                    ))),
+                ]
+                .join(",")
+            );
+        }
+    }
+}
+
+fn signed_difference(left: u128, right: u128) -> i128 {
+    if left >= right {
+        i128::try_from(left - right).unwrap_or(i128::MAX)
+    } else {
+        -i128::try_from(right - left).unwrap_or(i128::MAX)
     }
 }
 
@@ -918,6 +1002,7 @@ mod tests {
 
     #[test]
     fn all_range_policies_return_identical_remote_query_results() -> TestResult {
+        let automatic_range_plans = AutomaticRangePlanCollector::install()?;
         let fixture = Fixture::create(&std::env::temp_dir(), TEST_SHAPE, TEST_PROFILE, false)?;
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -934,9 +1019,16 @@ mod tests {
                     density: ProjectionDensity::Sparse,
                     policy,
                 };
-                let measurement = measure_case(&fixture, &table, TEST_SHAPE, case, 1)
-                    .await
-                    .map_err(|error| benchmark_test_error(case, error.as_ref()))?;
+                let measurement = measure_case(
+                    &fixture,
+                    &table,
+                    TEST_SHAPE,
+                    case,
+                    1,
+                    &automatic_range_plans,
+                )
+                .await
+                .map_err(|error| benchmark_test_error(case, error.as_ref()))?;
                 measurements.push(measurement);
             }
             let first = measurements
@@ -953,6 +1045,13 @@ mod tests {
                     measurement.planned_request_waves == 0 && measurement.predicted_micros.is_none()
                 } else {
                     measurement.planned_request_waves != 0 && measurement.predicted_micros.is_some()
+                }
+            }));
+            assert!(measurements.iter().all(|measurement| {
+                if measurement.case.policy == BenchmarkPolicy::Automatic {
+                    !measurement.automatic_range_plans.is_empty()
+                } else {
+                    measurement.automatic_range_plans.is_empty()
                 }
             }));
             Ok::<_, Box<dyn Error>>(())

--- a/benches/range_planning.rs
+++ b/benches/range_planning.rs
@@ -39,6 +39,7 @@ const MATCH_VALUE: &str = "match";
 const OTHER_VALUE: &str = "other";
 const DEFAULT_REPETITIONS: usize = 3;
 const MAX_REPETITIONS: usize = 128;
+const THROUGHPUT_SAMPLE_BYTE_FLOOR: u128 = 1024 * 1024;
 const BENCHMARK_SHAPE: FixtureShape = FixtureShape {
     data_files: 4,
     row_groups: 2,
@@ -676,6 +677,19 @@ fn write_delta_log(
 }
 
 fn validate_measurements(measurements: &[Measurement]) -> Result<(), io::Error> {
+    for measurement in measurements {
+        if measurement.case.policy == BenchmarkPolicy::Automatic {
+            validate_automatic_range_plans(measurement)?;
+        } else if !measurement.automatic_range_plans.is_empty() {
+            return Err(io::Error::other(format!(
+                "non-automatic benchmark case captured automatic plan diagnostics: profile={} projection={} policy={}",
+                measurement.case.profile.name,
+                measurement.case.density.name(),
+                measurement.case.policy.name(),
+            )));
+        }
+    }
+
     for profile in TransportProfile::ALL {
         for density in ProjectionDensity::ALL {
             for repetition in 1..=measurements
@@ -713,11 +727,23 @@ fn validate_measurements(measurements: &[Measurement]) -> Result<(), io::Error> 
         .iter()
         .filter(|measurement| measurement.case.policy == BenchmarkPolicy::Automatic)
         .collect::<Vec<_>>();
-    if !automatic
+    if automatic
         .iter()
-        .any(|measurement| measurement.cost_based_exact_plans != 0)
+        .filter(|measurement| {
+            measurement.case.profile == TransportProfile::LOW_LATENCY_LOW_THROUGHPUT
+        })
+        .any(|measurement| measurement.cost_based_merged_plans != 0)
         || !automatic
             .iter()
+            .filter(|measurement| {
+                measurement.case.profile == TransportProfile::LOW_LATENCY_LOW_THROUGHPUT
+            })
+            .any(|measurement| measurement.cost_based_exact_plans != 0)
+        || !automatic
+            .iter()
+            .filter(|measurement| {
+                measurement.case.profile == TransportProfile::HIGH_LATENCY_HIGH_THROUGHPUT
+            })
             .any(|measurement| measurement.cost_based_merged_plans != 0)
     {
         let decisions = automatic
@@ -749,8 +775,94 @@ fn validate_measurements(measurements: &[Measurement]) -> Result<(), io::Error> 
             .collect::<Vec<_>>()
             .join("; ");
         return Err(io::Error::other(format!(
-            "automatic benchmark cases did not exercise both exact and merged decisions: {decisions}"
+            "automatic benchmark decisions did not preserve low-throughput exact plans and high-throughput merged plans: {decisions}"
         )));
+    }
+    Ok(())
+}
+
+fn validate_automatic_range_plans(measurement: &Measurement) -> Result<(), io::Error> {
+    let plans = &measurement.automatic_range_plans;
+    let context = || {
+        format!(
+            "profile={} projection={} repetition={}",
+            measurement.case.profile.name,
+            measurement.case.density.name(),
+            measurement.repetition,
+        )
+    };
+    if plans.is_empty() {
+        return Err(io::Error::other(format!(
+            "automatic benchmark captured no plan diagnostics: {}",
+            context()
+        )));
+    }
+
+    let tiny_plan_count = plans
+        .iter()
+        .filter(|plan| plan.selected_bytes < THROUGHPUT_SAMPLE_BYTE_FLOOR)
+        .count();
+    let representative_plan_count = plans.len().saturating_sub(tiny_plan_count);
+    if tiny_plan_count < 4 || representative_plan_count < 4 {
+        return Err(io::Error::other(format!(
+            "benchmark fixture did not produce enough tiny and representative plans: {}, tiny={}, representative={}",
+            context(),
+            tiny_plan_count,
+            representative_plan_count,
+        )));
+    }
+
+    for (plan_index, pair) in plans.windows(2).enumerate() {
+        let (current, next) = (&pair[0], &pair[1]);
+        if current.selected_bytes < THROUGHPUT_SAMPLE_BYTE_FLOOR
+            && current.throughput_sample_count != next.throughput_sample_count
+        {
+            return Err(io::Error::other(format!(
+                "tiny plan changed the throughput sample count: {}, plan={}",
+                context(),
+                plan_index.saturating_add(1),
+            )));
+        }
+    }
+
+    for (plan_index, plan) in plans.iter().enumerate() {
+        let has_estimate = plan.estimated_request_latency_micros.is_some()
+            && plan.estimated_shared_throughput_bytes_per_second.is_some()
+            && plan.estimated_bandwidth_delay_bytes.is_some()
+            && plan.predicted_micros().is_some();
+        if has_estimate != (plan.throughput_sample_count >= 3) {
+            return Err(io::Error::other(format!(
+                "plan estimate did not match its throughput evidence: {}, plan={}, throughput_samples={}",
+                context(),
+                plan_index.saturating_add(1),
+                plan.throughput_sample_count,
+            )));
+        }
+        if !has_estimate
+            && (plan.decision != "cold_start"
+                || plan.selected_range_count != plan.baseline_range_count
+                || plan.selected_request_waves != plan.baseline_request_waves
+                || plan.selected_bytes != plan.baseline_bytes)
+        {
+            return Err(io::Error::other(format!(
+                "latency-only plan did not preserve the cold-start baseline: {}, plan={}",
+                context(),
+                plan_index.saturating_add(1),
+            )));
+        }
+        if plan
+            .estimated_shared_throughput_bytes_per_second
+            .is_some_and(|estimate| {
+                u128::from(estimate)
+                    > u128::from(measurement.case.profile.shared_throughput_bytes_per_second) * 2
+            })
+        {
+            return Err(io::Error::other(format!(
+                "controlled throughput estimate exceeded twice the configured rate: {}, plan={}",
+                context(),
+                plan_index.saturating_add(1),
+            )));
+        }
     }
     Ok(())
 }

--- a/benches/range_planning/plan_diagnostics.rs
+++ b/benches/range_planning/plan_diagnostics.rs
@@ -1,0 +1,147 @@
+//! Capture of the doc-hidden automatic range-planning trace event.
+
+use std::sync::{Arc, Mutex};
+
+use tracing::{
+    Event, Level, Metadata, Subscriber,
+    field::{Field as TracingField, Visit},
+    span::{Attributes as TracingAttributes, Id, Record},
+    subscriber::Interest,
+};
+
+const RANGE_PLANNING_DIAGNOSTIC_TARGET: &str =
+    "delta_arrow_reader::diagnostics::parquet_range_planning";
+
+#[derive(Debug, Default)]
+pub(super) struct AutomaticRangePlanDiagnostic {
+    pub(super) latency_sample_count: u64,
+    pub(super) throughput_sample_count: u64,
+    pub(super) estimated_request_latency_micros: Option<u128>,
+    pub(super) estimated_shared_throughput_bytes_per_second: Option<u64>,
+    pub(super) estimated_bandwidth_delay_bytes: Option<u128>,
+    pub(super) exact_range_count: u64,
+    pub(super) exact_bytes: u128,
+    pub(super) exact_request_waves: u64,
+    pub(super) baseline_range_count: u64,
+    pub(super) baseline_bytes: u128,
+    pub(super) baseline_request_waves: u64,
+    pub(super) selected_range_count: u64,
+    pub(super) selected_bytes: u128,
+    pub(super) selected_request_waves: u64,
+    selected_predicted_cost_bytes: Option<u128>,
+    pub(super) observed_selected_plan_micros: u128,
+    pub(super) decision: String,
+}
+
+impl AutomaticRangePlanDiagnostic {
+    pub(super) fn predicted_micros(&self) -> Option<u128> {
+        self.selected_predicted_cost_bytes?
+            .checked_mul(1_000_000)?
+            .checked_div(u128::from(
+                self.estimated_shared_throughput_bytes_per_second?,
+            ))
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct AutomaticRangePlanCollector(Arc<Mutex<Vec<AutomaticRangePlanDiagnostic>>>);
+
+impl AutomaticRangePlanCollector {
+    pub(super) fn install() -> Result<Self, tracing::subscriber::SetGlobalDefaultError> {
+        let collector = Self::default();
+        tracing::subscriber::set_global_default(collector.clone())?;
+        Ok(collector)
+    }
+
+    pub(super) fn take(&self) -> Vec<AutomaticRangePlanDiagnostic> {
+        std::mem::take(
+            &mut *self
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+    }
+}
+
+impl Subscriber for AutomaticRangePlanCollector {
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        if self.enabled(metadata) {
+            Interest::always()
+        } else {
+            Interest::never()
+        }
+    }
+
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.target() == RANGE_PLANNING_DIAGNOSTIC_TARGET && *metadata.level() == Level::DEBUG
+    }
+
+    fn new_span(&self, _attributes: &TracingAttributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut diagnostic = AutomaticRangePlanDiagnostic::default();
+        event.record(&mut AutomaticRangePlanVisitor(&mut diagnostic));
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(diagnostic);
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+struct AutomaticRangePlanVisitor<'diagnostic>(&'diagnostic mut AutomaticRangePlanDiagnostic);
+
+impl Visit for AutomaticRangePlanVisitor<'_> {
+    fn record_u64(&mut self, field: &TracingField, value: u64) {
+        match field.name() {
+            "latency_sample_count" => self.0.latency_sample_count = value,
+            "throughput_sample_count" => self.0.throughput_sample_count = value,
+            "estimated_shared_throughput_bytes_per_second" => {
+                self.0.estimated_shared_throughput_bytes_per_second = Some(value);
+            }
+            "exact_range_count" => self.0.exact_range_count = value,
+            "exact_request_waves" => self.0.exact_request_waves = value,
+            "baseline_range_count" => self.0.baseline_range_count = value,
+            "baseline_request_waves" => self.0.baseline_request_waves = value,
+            "selected_range_count" => self.0.selected_range_count = value,
+            "selected_request_waves" => self.0.selected_request_waves = value,
+            _ => {}
+        }
+    }
+
+    fn record_u128(&mut self, field: &TracingField, value: u128) {
+        match field.name() {
+            "estimated_request_latency_micros" => {
+                self.0.estimated_request_latency_micros = Some(value);
+            }
+            "estimated_bandwidth_delay_bytes" => {
+                self.0.estimated_bandwidth_delay_bytes = Some(value);
+            }
+            "exact_bytes" => self.0.exact_bytes = value,
+            "baseline_bytes" => self.0.baseline_bytes = value,
+            "selected_bytes" => self.0.selected_bytes = value,
+            "selected_predicted_cost_bytes" => {
+                self.0.selected_predicted_cost_bytes = Some(value);
+            }
+            "observed_selected_plan_micros" => self.0.observed_selected_plan_micros = value,
+            _ => {}
+        }
+    }
+
+    fn record_str(&mut self, field: &TracingField, value: &str) {
+        if field.name() == "decision" {
+            self.0.decision = value.to_owned();
+        }
+    }
+
+    fn record_debug(&mut self, _field: &TracingField, _value: &dyn std::fmt::Debug) {}
+}

--- a/docs/content/benchmarks/range-planning.md
+++ b/docs/content/benchmarks/range-planning.md
@@ -19,26 +19,26 @@ the median across the three repetitions.
 
 | Transport profile | Projection | Automatic decision | Automatic | Exact | Fixed 1 MiB | Store |
 | --- | --- | --- | ---: | ---: | ---: | ---: |
-| 1 ms, 4 MiB/s | Dense | Exact | 1,651.383 ms | 1,651.866 ms | 3,073.868 ms | 3,071.922 ms |
-| 1 ms, 4 MiB/s | Sparse | Exact | 889.087 ms | 889.419 ms | 2,946.789 ms | 2,944.323 ms |
-| 8 ms, 64 MiB/s | Dense | Exact | 407.493 ms | 409.929 ms | 414.190 ms | 410.567 ms |
-| 8 ms, 64 MiB/s | Sparse | Exact | 308.087 ms | 308.080 ms | 403.085 ms | 405.404 ms |
-| 20 ms, 512 MiB/s | Dense | Mixed | 524.478 ms | 810.457 ms | 484.354 ms | 487.108 ms |
-| 20 ms, 512 MiB/s | Sparse | Mixed | 485.104 ms | 626.989 ms | 483.390 ms | 479.688 ms |
+| 1 ms, 4 MiB/s | Dense | Exact | 5,272.098 ms | 5,281.722 ms | 10,172.175 ms | 10,209.733 ms |
+| 1 ms, 4 MiB/s | Sparse | Exact | 2,695.092 ms | 2,696.388 ms | 9,730.659 ms | 9,724.068 ms |
+| 8 ms, 64 MiB/s | Dense | Exact | 627.667 ms | 628.953 ms | 895.589 ms | 901.363 ms |
+| 8 ms, 64 MiB/s | Sparse | Exact | 430.329 ms | 427.028 ms | 864.418 ms | 865.889 ms |
+| 20 ms, 128 MiB/s | Dense | Mixed | 839.120 ms | 947.932 ms | 829.059 ms | 828.809 ms |
+| 20 ms, 128 MiB/s | Sparse | Mixed | 636.674 ms | 705.257 ms | 810.093 ms | 811.155 ms |
 
 The low-throughput profile favored exact ranges because transferring gaps cost
 more than the requests it removed. Under high latency and high throughput, the
-automatic planner used 3 cold-start plans, 6 cost-based exact plans, and 7
+automatic planner used 6 cold-start plans, 5 cost-based exact plans, and 5
 cost-based merged plans. Compared with forcing exact ranges, automatic planning
-reduced total time by 35.3% for the dense projection and 22.6% for the sparse
+reduced total time by 11.5% for the dense projection and 9.7% for the sparse
 projection.
 
 Automatic planning did not beat the best fixed choice in every case. In the
-high-latency dense case, the fixed 1 MiB plan was 7.7% faster than automatic.
-The scan is short enough that its three cold-start plans remain visible in the
-total, and the 10% stability margin deliberately prefers lower byte usage when
-two estimates are close. The goal is to avoid a consistently poor fixed choice,
-not to predict the fastest plan perfectly for every file.
+high-latency dense case, the fixed 1 MiB plan was 1.2% faster than automatic.
+The scan is short enough that its six cold-start plans remain visible in the
+total, and the 10% stability margin prefers lower byte usage when two estimates
+are close. The goal is to avoid a consistently poor fixed choice, not to predict
+the fastest plan perfectly for every file.
 
 ## How the planner chooses a range plan
 
@@ -58,9 +58,13 @@ estimated_time = request_waves * typical_request_latency
 
 Request latency is the time until response data becomes available. Shared
 throughput is the aggregate payload rate across concurrent requests, not a
-separate bandwidth estimate for each request. After three successful plans,
-the planner uses the median latency and throughput from up to nine recent
-samples. Failed, truncated, and cancelled plans do not update the estimate.
+separate bandwidth estimate for each request. The estimator keeps separate
+windows of up to nine latency and throughput samples. Every successful plan
+adds latency evidence. A plan adds throughput evidence only when it transfers
+at least 1 MiB over at least 10 ms of payload delivery. The planner waits for
+three samples in both windows, then uses the median latency and a byte-weighted
+median throughput. Failed, truncated, and cancelled plans do not update either
+window.
 
 The planner finds the candidate with the lowest estimated time, then keeps all
 candidates whose estimate is within 10% of that result. Among those candidates,
@@ -82,23 +86,43 @@ successful multi-range plan executions and excludes the rest of the scan.
 
 | Transport profile | Projection | Predicted plan | Observed plan | Difference |
 | --- | --- | ---: | ---: | ---: |
-| 1 ms, 4 MiB/s | Dense | 1,516.921 ms | 1,567.955 ms | +3.4% |
-| 1 ms, 4 MiB/s | Sparse | 769.908 ms | 808.017 ms | +4.9% |
-| 8 ms, 64 MiB/s | Dense | 348.807 ms | 359.217 ms | +3.0% |
-| 8 ms, 64 MiB/s | Sparse | 238.619 ms | 263.161 ms | +10.3% |
-| 20 ms, 512 MiB/s | Dense | 377.525 ms | 430.014 ms | +13.9% |
-| 20 ms, 512 MiB/s | Sparse | 348.383 ms | 391.933 ms | +12.5% |
+| 1 ms, 4 MiB/s | Dense | 5,091.206 ms | 5,186.512 ms | +1.9% |
+| 1 ms, 4 MiB/s | Sparse | 2,557.012 ms | 2,613.054 ms | +2.2% |
+| 8 ms, 64 MiB/s | Dense | 572.200 ms | 577.442 ms | +0.9% |
+| 8 ms, 64 MiB/s | Sparse | 350.313 ms | 381.972 ms | +9.0% |
+| 20 ms, 128 MiB/s | Dense | 655.746 ms | 739.630 ms | +12.8% |
+| 20 ms, 128 MiB/s | Sparse | 483.899 ms | 540.354 ms | +11.7% |
 
 The simple model is consistently optimistic in this run because it does not
 include scheduling, protocol handling, or result assembly. Its error stayed
-between 3.0% and 13.9% across these cases.
+between 0.9% and 12.8% across these cases.
+
+## Estimator validation
+
+Each automatic scan produced 16 physical plans. Eight transferred only 2,456
+bytes. The other eight transferred about 2.53 MiB for the dense projection or
+1.26 MiB for the sparse projection. This alternating pattern checks that small
+Parquet reads can update latency without adding a throughput sample.
+
+The benchmark fails if a small plan increments the throughput sample count or
+if the planner leaves its cold-start baseline before three eligible throughput
+samples exist. It requires the 4 MiB/s profile to keep exact plans and the 128
+MiB/s profile to merge at least one representative plan. The run also rejects a
+controlled throughput estimate above twice the configured rate. That last
+bound is a regression guard against the large inflation caused by tiny reads,
+not a claim that estimates are exact.
+
+The second CSV table contains one row for every automatic plan. It reports the
+latency and throughput sample counts, current transport estimate, exact and
+selected plan shapes, estimated plan time, observed plan time, and prediction
+error.
 
 ## Fixture and query
 
 The synthetic Delta table contains four Parquet files. Each file has two row
 groups of 256 rows, with 32 rows per data page and offset indexes enabled. The
 schema contains `row_id`, the predicate column `event_id`, and 48 nullable
-string payload columns. The four Parquet files occupy 12,994,891 bytes in
+string payload columns. The four Parquet files occupy 42,985,459 bytes in
 total.
 
 The row filter matches one row in each data page, for 64 rows across the table.
@@ -129,7 +153,7 @@ count and byte count as the fixed 1 MiB policy.
 | --- | ---: | ---: |
 | Low latency, low throughput | 1 ms | 4 MiB/s |
 | Balanced | 8 ms | 64 MiB/s |
-| High latency, high throughput | 20 ms | 512 MiB/s |
+| High latency, high throughput | 20 ms | 128 MiB/s |
 
 The server applies latency to each request and shares the throughput limit
 across concurrent responses. A physical plan can issue up to 10 range requests
@@ -143,9 +167,9 @@ read. Server totals include every Parquet range GET after scan construction,
 including one 64 KiB footer read per data file. Server totals are therefore
 four requests and 256 KiB higher than their corresponding planned values.
 
-For example, the dense exact case planned 208 requests and 5.940 MiB, while the
-server observed 212 requests and 6.190 MiB. The dense fixed case planned 16
-requests and 11.624 MiB, while the server observed 20 requests and 11.874 MiB.
+For example, the dense exact case planned 208 requests and 20.237 MiB, while the
+server observed 212 requests and 20.487 MiB. The dense fixed case planned 16
+requests and 39.623 MiB, while the server observed 20 requests and 39.873 MiB.
 Request merging nearly doubled planned bytes in that case, but reduced the
 number of planned requests by 92.3%.
 
@@ -157,11 +181,11 @@ prefetch. The timer starts when the prepared stream is first polled and stops
 after the result has been consumed and checked. Policy order reverses on
 alternating repetitions, and there is no separate warmup run.
 
-The CSV reports the configured transport, projection, policy, logical result,
-exact ranges, chosen physical plan, actual server traffic, predicted and
-observed plan times, full scan time, and automatic decision counts. Use the
-server traffic with the timing results: a plan can reduce requests by
-transferring substantially more data.
+The first CSV table reports the configured transport, projection, policy,
+logical result, exact ranges, chosen physical plan, actual server traffic,
+predicted and observed plan times, full scan time, and automatic decision
+counts. Use the server traffic with the timing results: a plan can reduce
+requests by transferring substantially more data.
 
 ## Run the benchmark
 


### PR DESCRIPTION
## Summary

- add a controlled range-planning benchmark that interleaves tiny Parquet reads with representative multi-megabyte plans
- capture per-plan estimator evidence and fail when tiny reads affect throughput sampling or conservative planning
- verify low-throughput profiles remain exact while reliable high-throughput evidence still permits merging
- document the estimator model, fixture, diagnostics, and three-repetition results

This completes the benchmark validation for the estimator fix merged in #79.

## Validation

- `cargo bench --locked --bench range_planning -- --repetitions 3`
- `cargo test --locked --test range_planning_benchmark_harness`
- `cargo clippy --locked --test range_planning_benchmark_harness -- -D warnings`
- `cargo fmt --all --check`
- `python -m zensical build --strict -f docs/mkdocs.yml`

Closes #78