### PR TITLE
refactor!: configure table metadata warmup through one builder API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 [[bench]]
 name = "reader"
 harness = false
-required-features = ["datafusion", "experimental-parquet-metadata-preparation"]
+required-features = ["datafusion", "experimental-parquet-metadata-warmup"]
 test = false
 
 [[bench]]
@@ -50,7 +50,7 @@ test = false
 
 [features]
 datafusion = ["dep:datafusion"]
-experimental-parquet-metadata-preparation = []
+experimental-parquet-metadata-warmup = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -17,8 +17,8 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use delta_arrow_reader::{
-    DeltaScanExecutionOptions, DeltaStorageOptions, DeltaTableBuilder,
-    ParquetMetadataPreparationLimits, ParquetMetadataPreparationReport, ParquetReaderBackend,
+    DeltaScanExecutionOptions, DeltaStorageOptions, DeltaTableBuilder, ParquetReaderBackend,
+    ParquetWarmupReport, WarmupMode,
     datafusion::{ScanMetricsSnapshot, ScanOptions, collect_scan_metrics, register_table},
 };
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
@@ -271,7 +271,7 @@ struct RepetitionMeasurement {
 #[derive(Debug)]
 struct ParquetMetadataPreparationMeasurement {
     micros: u64,
-    prepared: ParquetMetadataPreparationReport,
+    prepared: ParquetWarmupReport,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1478,14 +1478,18 @@ async fn run_repetition(
     let table = match (config.scan_metadata_mode, config.parquet_metadata_mode) {
         (ScanMetadataMode::Lazy, ParquetMetadataMode::OnDemand) => builder.load_table().await?,
         (ScanMetadataMode::Eager, ParquetMetadataMode::OnDemand) => {
-            builder.load_table_with_eager_scan_metadata().await?
+            builder
+                .with_warmup(WarmupMode::QueryPlanning)
+                .load_table()
+                .await?
         }
         (ScanMetadataMode::Eager, ParquetMetadataMode::Prepared) => {
             builder
-                .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+                .with_warmup(WarmupMode::ParquetMetadata {
                     max_files: fixture.file_count,
-                    max_retained_metadata_bytes: usize::MAX,
+                    max_memory_bytes: usize::MAX,
                 })
+                .load_table()
                 .await?
         }
         (ScanMetadataMode::Lazy, ParquetMetadataMode::Prepared) => {
@@ -1496,14 +1500,12 @@ async fn run_repetition(
     let table_load_count = 1;
     let table_initialization_micros =
         saturating_u64(table_initialization_started.elapsed().as_micros());
-    let parquet_metadata_preparation =
-        table
-            .parquet_metadata_preparation_report()
-            .cloned()
-            .map(|prepared| ParquetMetadataPreparationMeasurement {
-                micros: saturating_u64(prepared.preparation_duration.as_micros()),
-                prepared,
-            });
+    let parquet_metadata_preparation = table.parquet_warmup_report().cloned().map(|prepared| {
+        ParquetMetadataPreparationMeasurement {
+            micros: saturating_u64(prepared.duration.as_micros()),
+            prepared,
+        }
+    });
     register_table(&context, "orders", table, scan_options)?;
     #[cfg(test)]
     let table_registration_count = 1;
@@ -1760,7 +1762,7 @@ fn summarize_parquet_metadata_preparation(
         file_count: Some(percentile(
             &measurements
                 .iter()
-                .map(|measurement| saturating_u64(measurement.prepared.files_prepared as u128))
+                .map(|measurement| saturating_u64(measurement.prepared.file_count as u128))
                 .collect::<Vec<_>>(),
             50,
         )),
@@ -1768,7 +1770,7 @@ fn summarize_parquet_metadata_preparation(
             &measurements
                 .iter()
                 .map(|measurement| {
-                    saturating_u64(measurement.prepared.estimated_retained_metadata_bytes as u128)
+                    saturating_u64(measurement.prepared.estimated_memory_bytes as u128)
                 })
                 .collect::<Vec<_>>(),
             50,
@@ -2579,8 +2581,8 @@ mod tests {
                             .parquet_metadata_preparation
                             .as_ref()
                             .ok_or("prepared mode did not report metadata preparation")?;
-                        assert_eq!(preparation.prepared.files_prepared, fixture.file_count);
-                        assert!(preparation.prepared.estimated_retained_metadata_bytes > 0);
+                        assert_eq!(preparation.prepared.file_count, fixture.file_count);
+                        assert!(preparation.prepared.estimated_memory_bytes > 0);
                         assert!(
                             preparation
                                 .prepared

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -22,19 +22,19 @@ snapshot, load the table again.
 ## Remote I/O phases
 
 For a table in remote storage, the read path has three distinct I/O phases.
-The loading mode controls whether the first two phases happen during table
+The warmup mode controls whether the first two phases happen during table
 initialization or during each query:
 
-| Phase | Lazy | Eager Delta metadata | Prepared Parquet metadata |
+| Phase | No warmup | Query planning | Parquet metadata |
 | --- | --- | --- | --- |
-| 1. Delta scan metadata | Every scan build performs Delta log/checkpoint replay and selects active files. | Table initialization performs the replay once. Later scan builds select files from the retained metadata. | Same as eager Delta metadata. |
+| 1. Delta scan metadata | Every scan build performs Delta log/checkpoint replay and selects active files. | Table initialization performs the replay once. Later scan builds select files from the retained metadata. | Same as query-planning warmup. |
 | 2. Parquet metadata | The query reads footers and prunes row groups. | The query reads footers and prunes row groups. | Table initialization reads and parses footers and offset indexes for all active files. Each query still performs its own row-group pruning. |
 | 3. Parquet data | The query reads the selected row groups. | Unchanged. | Unchanged. |
 
-A successful eager Delta metadata load needs no later Delta log/checkpoint reads
-for file discovery from that table. Experimental Parquet metadata preparation
-also removes later footer and offset-index reads for the prepared files. Neither
-mode moves Parquet data-page reads into initialization or changes
+A successful query-planning warmup needs no later Delta log/checkpoint reads
+for file discovery from that table. Experimental Parquet metadata warmup also
+removes later footer and offset-index reads for the warmed files. Neither mode
+moves Parquet data-page reads into initialization or changes
 deletion-vector behavior.
 
 The retained Delta scan metadata contains reconciled active `add` metadata and
@@ -44,8 +44,8 @@ Separately loaded tables do not share this memory. There is no TTL, eviction,
 persistence, incremental update, or background refresh; load another table to
 observe a newer snapshot.
 
-Prepared Parquet metadata has the same snapshot lifetime and belongs to the
-loaded table. The [preparation guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+Warmed Parquet metadata has the same snapshot lifetime and belongs to the
+loaded table. The [warmup guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
 explains its resource limits and direct-backend requirement.
 
 ## Streaming API

--- a/docs/content/datafusion.md
+++ b/docs/content/datafusion.md
@@ -56,7 +56,7 @@ metadata before registration:
 ```no_run
 use datafusion::prelude::SessionContext;
 use delta_arrow_reader::{
-    DeltaTableBuilder,
+    DeltaTableBuilder, WarmupMode,
     datafusion::{ScanOptions, register_table},
 };
 
@@ -64,7 +64,8 @@ use delta_arrow_reader::{
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let context = SessionContext::new();
     let table = DeltaTableBuilder::new("/tmp/example-delta-table")
-        .load_table_with_eager_scan_metadata()
+        .with_warmup(WarmupMode::QueryPlanning)
+        .load_table()
         .await?;
 
     register_table(
@@ -84,15 +85,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-`load_table_with_eager_scan_metadata` builds the cache while loading the table.
-`register_table` uses that same loaded table and does not build another cache.
-All SQL queries through the registered provider can therefore reuse the cached
-metadata without replaying the Delta log or checkpoint. Each query still
-applies its own projection and predicate and reads its own Parquet footers and
-data.
+`WarmupMode::QueryPlanning` builds the cache while `load_table` loads the
+table. `register_table` uses that same loaded table and does not build another
+cache. All SQL queries through the registered provider can therefore reuse the
+cached metadata without replaying the Delta log or checkpoint. Each query
+still applies its own projection and predicate and reads its own Parquet
+footers and data.
 
-Use eager loading for a named table that will be queried repeatedly. Keep a
-table on the default `load_table` path when you will query it only once or
+Use query-planning warmup for a named table that will be queried repeatedly.
+Keep the default `WarmupMode::None` when you will query it only once or
 occasionally. The crate does not maintain a table-name registry or choose a
 mode automatically.
 
@@ -106,7 +107,7 @@ The [Rust API reference](https://docs.rs/delta-arrow-reader) documents the
 available scan options and metrics.
 
 The experimental
-[Parquet metadata preparation mode](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+[Parquet metadata warmup mode](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
 can also move footer and offset-index reads into table initialization. Configure
 it on `DeltaTableBuilder` before registration; DataFusion needs no separate
 cache option.

--- a/docs/content/delta-metadata-lifecycle.md
+++ b/docs/content/delta-metadata-lifecycle.md
@@ -6,10 +6,11 @@ values, and file statistics. The Delta log or checkpoint supplies the file
 list. The list and the information used to prune it are the table's scan
 metadata.
 
-Delta Arrow Reader has three loading modes. The default lazy mode prepares
-Delta scan metadata when each scan is built. Eager mode prepares the reusable
-part when the table loads. Experimental Parquet metadata preparation adds the
-parsed footers and offset indexes for every active file.
+`WarmupMode` controls how much reusable metadata `load_table` prepares. The
+default `None` mode waits until each scan is built. `QueryPlanning` prepares the
+reusable Delta metadata while the table loads. The experimental
+`ParquetMetadata` mode also loads parsed footers and offset indexes for every
+active file.
 
 Each query still gets its own file, row-group, and page selection. The caches
 do not reuse one query's selection for another query or change query results.
@@ -28,10 +29,10 @@ A query against remote storage can involve three rounds of I/O:
 
 The first round mixes work that can be reused with work that belongs to one
 query. Replaying the Delta history and reconciling the active files can be
-reused for a loaded table version. Applying a predicate cannot. Eager mode
-moves only that reusable work to table initialization. Experimental Parquet
-metadata preparation also moves the reusable part of the second round while
-leaving row-group and page selection with each query.
+reused for a loaded table version. Applying a predicate cannot.
+`WarmupMode::QueryPlanning` moves only that reusable work to table
+initialization. `WarmupMode::ParquetMetadata` also moves the reusable part of
+the second round while leaving row-group and page selection with each query.
 
 This difference matters most for a selective query. Statistics may reduce a
 large table to a few Parquet row groups, making the data read small, while
@@ -39,9 +40,9 @@ Delta replay remains a fixed planning cost. On remote storage, that planning
 cost can take longer than reading the result. Reusing active-file metadata
 removes the repeated replay without changing the later pruning or Parquet I/O.
 
-## Lazy mode
+## No warmup
 
-`DeltaTableBuilder::load_table()` uses lazy mode:
+`DeltaTableBuilder::load_table()` uses `WarmupMode::None` by default:
 
 ```text
 table load -> table version and schema
@@ -56,13 +57,13 @@ Kernel to prune it for that scan.
 
 This keeps table loading quick and avoids retaining an active-file cache. The
 tradeoff is that every scan against the loaded table repeats the Delta replay.
-Lazy mode usually fits tables that are queried once, queried occasionally, or
+No warmup usually fits tables that are queried once, queried occasionally, or
 loaded in a process with tight memory limits.
 
-## Eager mode
+## Query-planning warmup
 
-`DeltaTableBuilder::load_table_with_eager_scan_metadata()` prepares the same
-reusable metadata while loading the table:
+`DeltaTableBuilder::with_warmup(WarmupMode::QueryPlanning)` prepares the same
+reusable metadata before `load_table()` returns:
 
 ```text
 table initialization -> Delta replay -> metadata cache
@@ -86,11 +87,11 @@ The cache belongs to one loaded table. If the same location is loaded twice,
 the two table objects have separate caches. Both also stay fixed at the exact
 table version they loaded.
 
-## Prepared Parquet metadata mode
+## Parquet metadata warmup
 
-`DeltaTableBuilder::load_table_with_prepared_parquet_metadata()` first performs
-eager Delta scan metadata initialization. It then fetches and parses the
-Parquet footer and optional offset indexes for every unique active file:
+`DeltaTableBuilder::with_warmup(WarmupMode::ParquetMetadata { .. })` first
+performs query-planning warmup. It then fetches and parses the Parquet footer
+and optional offset indexes for every unique active file:
 
 ```text
 table initialization -> Delta replay -> active-file cache -> Parquet metadata cache
@@ -100,14 +101,14 @@ query 2 -> pruning -------------------------------------------------+-> Parquet 
 query 3 -> pruning -------------------------------------------------+-> Parquet data
 ```
 
-The experimental Cargo feature is disabled by default, and the loading method
+The experimental Cargo feature is disabled by default, and this warmup mode
 requires explicit file-count and estimated-memory limits. It supports only the
 direct Parquet backend. The returned table and its clones share one immutable
 cache through both the streaming API and DataFusion.
 
-Preparation does not read Parquet data pages. A query still decides which
+Warmup does not read Parquet data pages. A query still decides which
 files, row groups, pages, and columns it needs. See
-[Prepare Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+[Warm Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
 for setup, limits, failure behavior, and report fields.
 
 ## Which mode should you use?
@@ -115,18 +116,18 @@ for setup, limits, failure behavior, and report fields.
 This choice applies to the loaded table, whether you query it through the
 streaming API or DataFusion SQL. Both APIs support all three modes.
 
-| Consideration | Lazy | Eager Delta metadata | Prepared Parquet metadata |
+| Consideration | No warmup | Query planning | Parquet metadata |
 | --- | --- | --- | --- |
 | Typical use | One query, occasional queries, or tight memory limits | Repeated queries where Delta replay is costly | Repeated remote queries where footer reads are also costly |
 | Table loading | Returns without building reusable scan caches | Waits for Delta replay and cache creation | Also fetches and parses metadata for every active Parquet file |
 | Memory while loaded | No reusable active-file cache | Keeps active-file metadata and statistics | Also keeps parsed Parquet footers and offset indexes |
 | Each later scan | Replays Delta metadata, then prunes | Reuses Delta metadata, then prunes | Reuses both caches, then performs query-specific pruning |
-| Seeing a newer version | Load a new table | Load a new table | Load and prepare a new table |
+| Seeing a newer version | Load a new table | Load a new table | Load and warm a new table |
 | Parquet data reads | Per query | Per query | Per query |
 
-Use lazy mode unless you know the table will serve repeated queries and the
+Use no warmup unless you know the table will serve repeated queries and the
 saved planning time justifies slower initialization and higher memory use. Add
-Parquet metadata preparation only when measurements show that repeated footer
+Parquet metadata warmup only when measurements show that repeated footer
 reads matter. No single query count is a reliable break-even point. The result
 depends on the table history, checkpoint shape, file count, available
 statistics, storage latency, query selectivity, and memory pressure.
@@ -136,7 +137,7 @@ statistics, storage latency, query selectivity, and memory pressure.
 On August 27, 2026, a real-S3 benchmark loaded two production-shaped tables
 and ran six queries:
 
-| Measurement | Lazy | Eager |
+| Measurement | No warmup | Query-planning warmup |
 | --- | ---: | ---: |
 | Table initialization | 1.196 s | 4.089 s |
 | HIP physical planning | 2.097 s | 5.1 ms |
@@ -145,7 +146,7 @@ and ran six queries:
 | Resident memory after initialization | 38.5 MiB | 68.7 MiB |
 | Full-session peak resident memory | 233.9 MiB | 248.9 MiB |
 
-The eager run spent more time and memory during initialization. After that,
+The warmed run spent more time and memory during initialization. After that,
 physical planning fell from seconds to milliseconds, and the six-query
 session finished sooner. Both runs returned the same results and performed the
 same Parquet I/O.
@@ -153,8 +154,8 @@ same Parquet I/O.
 These numbers come from one workload. They are not a performance guarantee or
 a general break-even point. The [benchmark methodology, environment, and limitations](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/eager-metadata/#representative-real-s3-result)
 describe how the measurements were collected and what can affect them.
-This case study compares lazy and eager Delta scan metadata; it does not include
-experimental Parquet metadata preparation.
+This case study compares no warmup with query-planning warmup; it does not
+include experimental Parquet metadata warmup.
 
 ## Version and refresh behavior
 
@@ -163,7 +164,7 @@ version. Commits written later do not change what existing queries see. To use
 a newer version, load the table again and replace the old table or DataFusion
 registration.
 
-The in-memory loading modes do not provide:
+The in-memory warmup modes do not provide:
 
 - incremental refresh;
 - background polling;
@@ -171,7 +172,7 @@ The in-memory loading modes do not provide:
 - persistence across processes;
 - sharing between independently loaded tables;
 - Parquet data-page or decoded-batch caching; or
-- automatic selection of which tables to prepare.
+- automatic selection of which tables to warm.
 
 ## Related guides
 
@@ -179,5 +180,5 @@ The in-memory loading modes do not provide:
 - [Register and query a table with DataFusion](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
 - [Understand how scans are planned](https://mag1cfrog.github.io/delta-arrow-reader/scan-planning/)
 - [Review the benchmark methodology](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/eager-metadata/)
-- [Prepare Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
-- [Open the eager-loading Rust API](https://docs.rs/delta-arrow-reader/latest/delta_arrow_reader/struct.DeltaTableBuilder.html#method.load_table_with_eager_scan_metadata)
+- [Warm Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+- [Open the warmup Rust API](https://docs.rs/delta-arrow-reader/latest/delta_arrow_reader/struct.DeltaTableBuilder.html#method.with_warmup)

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -8,11 +8,9 @@ depend on whether you plan to use the streaming API or DataFusion.
 For streaming Arrow batches, add the reader, Tokio, and the futures utilities
 used by the quickstart:
 
-```toml
-[dependencies]
-delta-arrow-reader = "0.3.0"
-futures-util = "0.3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```bash
+cargo add delta-arrow-reader futures-util
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 The [streaming reader quickstart](https://mag1cfrog.github.io/delta-arrow-reader/streaming-reader/)
@@ -20,14 +18,12 @@ shows how to load a table and consume its Arrow batches.
 
 ## DataFusion adapter
 
-For SQL queries, enable the reader's `datafusion` feature and add the matching
-DataFusion release:
+For SQL queries, enable the reader's `datafusion` feature and add DataFusion:
 
-```toml
-[dependencies]
-datafusion = { version = "54.1.0", default-features = false, features = ["sql"] }
-delta-arrow-reader = { version = "0.3.0", features = ["datafusion"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```bash
+cargo add delta-arrow-reader --features datafusion
+cargo add datafusion --no-default-features --features sql
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 The [DataFusion quickstart](https://mag1cfrog.github.io/delta-arrow-reader/datafusion/)
@@ -40,15 +36,15 @@ The streaming API and both Parquet backends are always available.
 | Feature | Default | Purpose |
 | --- | --- | --- |
 | `datafusion` | No | Register Delta tables with DataFusion and expose execution metrics. |
-| `experimental-parquet-metadata-preparation` | No | Prepare and retain Parquet metadata while loading a table. |
+| `experimental-parquet-metadata-warmup` | No | Warm and retain Parquet metadata while loading a table. |
 
 The direct Parquet backend is selected by default. Rust callers can choose the
 Delta Kernel backend through `DeltaScanExecutionOptions` without changing
 Cargo features.
 
-Parquet metadata preparation works with the streaming API by itself. Enable
-both optional features to reuse prepared metadata through DataFusion. See
-[Prepare Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+Parquet metadata warmup works with the streaming API by itself. Enable both
+optional features to reuse warmed metadata through DataFusion. See
+[Warm Parquet metadata for repeated queries](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
 before enabling it for a table.
 
 Both APIs run on your application's Tokio runtime. Delta Arrow Reader does not

--- a/docs/content/prepared-parquet-metadata.md
+++ b/docs/content/prepared-parquet-metadata.md
@@ -1,11 +1,11 @@
-# Prepare Parquet metadata for repeated queries
+# Warm Parquet metadata for repeated queries
 
-Parquet metadata preparation moves footer and offset-index reads into table
+Parquet metadata warmup moves footer and offset-index reads into table
 initialization. Later scans against that loaded table can reuse the parsed
 metadata instead of fetching it again.
 
 This API is experimental and disabled by default. Use it in long-lived
-processes that repeatedly query the same immutable Delta snapshot. Preparation
+processes that repeatedly query the same immutable Delta snapshot. Warmup
 increases startup time and retained memory, so callers must set explicit
 file-count and memory limits.
 
@@ -13,76 +13,70 @@ file-count and memory limits.
 
 The feature works with the streaming API and does not require DataFusion:
 
-```toml
-[dependencies]
-delta-arrow-reader = { version = "0.5", features = ["experimental-parquet-metadata-preparation"] }
+```bash
+cargo add delta-arrow-reader --features experimental-parquet-metadata-warmup
 ```
 
-To use the prepared table with DataFusion, enable both features:
+To use the same warmed table with DataFusion, enable both features:
 
-```toml
-[dependencies]
-delta-arrow-reader = { version = "0.5", features = ["datafusion", "experimental-parquet-metadata-preparation"] }
+```bash
+cargo add delta-arrow-reader --features datafusion,experimental-parquet-metadata-warmup
+cargo add datafusion --no-default-features --features sql
 ```
 
-## Load a prepared table
+## Warm the metadata
 
 Pass both limits when loading the table:
 
 ```no_run
-use delta_arrow_reader::{
-    DeltaTableBuilder,
-    ParquetMetadataPreparationLimits,
-};
+use delta_arrow_reader::{DeltaTableBuilder, WarmupMode};
 
 # async fn load() -> Result<(), Box<dyn std::error::Error>> {
 let table = DeltaTableBuilder::new("s3://example-bucket/orders")
-    .load_table_with_prepared_parquet_metadata(
-        ParquetMetadataPreparationLimits {
-            max_files: 10_000,
-            max_retained_metadata_bytes: 256 * 1024 * 1024,
-        },
-    )
+    .with_warmup(WarmupMode::ParquetMetadata {
+        max_files: 10_000,
+        max_memory_bytes: 256 * 1024 * 1024,
+    })
+    .load_table()
     .await?;
 
-if let Some(report) = table.parquet_metadata_preparation_report() {
-    println!("files={}", report.files_prepared);
+if let Some(report) = table.parquet_warmup_report() {
+    println!("files={}", report.file_count);
     println!(
         "estimated_metadata_bytes={}",
-        report.estimated_retained_metadata_bytes
+        report.estimated_memory_bytes
     );
-    println!("preparation_time={:?}", report.preparation_duration);
+    println!("warmup_time={:?}", report.duration);
 }
 # Ok(())
 # }
 ```
 
-The method first prepares the reusable Delta scan metadata, just like
-`load_table_with_eager_scan_metadata`. It then fetches and parses the Parquet
-metadata for every unique active file. The returned `DeltaTable` owns both
-caches.
+`WarmupMode::ParquetMetadata` includes query-planning warmup. It then fetches
+and parses the Parquet metadata for every unique active file. The returned
+`DeltaTable` owns both caches.
 
 Table clones, streaming scans, DataFusion providers, and DataFusion physical
-plans created from that table share the prepared Parquet metadata. You do not
+plans created from that table share the warmed Parquet metadata. You do not
 need a separate DataFusion option.
 
 ## Choose limits
 
-`max_files` limits how many active files preparation will visit. The load fails
+`max_files` limits how many active files warmup will visit. The load fails
 before its first Parquet metadata request if the table exceeds this limit.
 
-`max_retained_metadata_bytes` limits the estimated size of the parsed metadata.
+`max_memory_bytes` limits the estimated size of the parsed metadata.
 This estimate comes from the retained Parquet metadata structures. It is not a
 measurement of process RSS or allocator overhead. Wider schemas, more row
 groups, larger statistics, and page indexes can increase the retained size.
 
-Preparation attaches the cache only after every file succeeds. A missing or
-corrupt file, cancellation, or an exceeded memory limit returns an error and
-does not return a partially prepared table.
+Warmup attaches the cache only after every file succeeds. A missing or corrupt
+file, cancellation, or an exceeded memory limit returns an error and does not
+return a partially warmed table.
 
 Start with limits based on a representative table, then inspect
-`parquet_metadata_preparation_report` in the environment where the table will
-run. The report also contains read metrics for the preparation phase.
+`parquet_warmup_report` in the environment where the table will run. The report
+also contains read metrics for the warmup phase.
 
 ## What the cache retains
 
@@ -90,22 +84,33 @@ The cache contains parsed Parquet footers and optional offset indexes. Offset
 indexes help exact row filters turn their row selections into page-range reads.
 The cache does not contain Parquet data pages or decoded Arrow batches.
 
-Preparation currently supports only the direct Parquet backend. A builder
-configured to use the Delta Kernel backend fails before starting Parquet
-metadata reads.
+Parquet metadata warmup currently supports only the direct Parquet backend. A
+builder configured to use the Delta Kernel backend fails before starting
+Parquet metadata reads.
 
 The table remains fixed at the Delta version it loaded. Load a new table to see
-a newer version or to create a new prepared cache. Prepared metadata is kept in
-memory only; it is not persisted to disk or shared between separately loaded
-tables.
+a newer version or to create a new warm cache. Warmed metadata is kept in memory
+only; it is not persisted to disk or shared between separately loaded tables.
 
-## Decide whether to prepare
+## Decide whether to warm the metadata
 
-Preparation is most useful when remote metadata requests take a noticeable
+Warmup is most useful when remote metadata requests take a noticeable
 part of query time and many queries reuse one loaded table. It is usually a poor
 fit for one-shot reads or tables with many files that are rarely queried.
 
 The [controlled benchmark](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/prepared-parquet-metadata/)
 shows the startup cost, retained-memory estimate, and measured break-even points
 for three synthetic workloads. Measure production-shaped queries before
-raising the limits or using preparation to meet a latency target.
+raising the limits or using warmup to meet a latency target.
+
+## Migrate from 0.5
+
+Version 0.6 replaces separate loading methods with one warmup setting and one
+`load_table` method:
+
+| 0.5 | 0.6 |
+| --- | --- |
+| `load_table()` | `load_table()` or `WarmupMode::None` |
+| `load_table_with_eager_scan_metadata()` | `WarmupMode::QueryPlanning` |
+| `load_table_with_prepared_parquet_metadata(limits)` | `WarmupMode::ParquetMetadata { .. }` |
+| `experimental-parquet-metadata-preparation` | `experimental-parquet-metadata-warmup` |

--- a/docs/content/scan-planning.md
+++ b/docs/content/scan-planning.md
@@ -7,40 +7,39 @@ before it opens any Parquet data files.
 If you only need to run a query, the defaults are a good place to start. This
 page is for readers who want to understand or tune how the work is divided.
 
-## Choose a metadata initialization mode
+## Choose a warmup mode
 
-`DeltaTableBuilder::load_table` uses lazy Delta scan metadata initialization.
-Each scan build performs Delta log/checkpoint replay before Delta Kernel applies
-the query predicate and selects active files.
+`DeltaTableBuilder::load_table` uses `WarmupMode::None` by default. Each scan
+build performs Delta log/checkpoint replay before Delta Kernel applies the query
+predicate and selects active files.
 
-`DeltaTableBuilder::load_table_with_eager_scan_metadata` instead materializes a
-query-unfiltered set of reconciled active `add` metadata during table
+`DeltaTableBuilder::with_warmup(WarmupMode::QueryPlanning)` instead materializes
+a query-unfiltered set of reconciled active `add` metadata during table
 initialization. It retains all available file statistics, so later scan builds
 can still make query-specific data-skipping decisions. Those builds pass the
 retained metadata to Delta Kernel through `Scan::scan_metadata_from`; Delta
 Kernel remains responsible for applying the query predicate and selecting
 files.
 
-The experimental
-`DeltaTableBuilder::load_table_with_prepared_parquet_metadata` method performs
-the eager work and then prepares parsed metadata for every active Parquet file.
-Later scans reuse that metadata, but each scan still makes its own row-group and
-page selections.
+The experimental `WarmupMode::ParquetMetadata` mode includes query-planning
+warmup and then loads parsed metadata for every active Parquet file. Later scans
+reuse that metadata, but each scan still makes its own row-group and page
+selections.
 
 All three modes produce the same file tasks. Partition values, schema
 transforms, and deletion-vector information follow the selected files in every
 mode.
 
-In one dated real-S3 case study, eager initialization reduced the median time
+In one dated real-S3 case study, query-planning warmup reduced the median time
 for a six-query session by 15.4% while adding 30.2 MiB of resident memory after
 initialization and 15.0 MiB to full-session peak memory. See the
 [methodology, results, and limitations](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/eager-metadata/#representative-real-s3-result)
 before applying those measurements to another table or workload.
 
 To see how this initialization choice plays out across several queries, follow
-the [lazy and eager metadata lifecycles](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
-For the experimental loading mode, see the
-[Parquet metadata preparation guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+the [metadata warmup lifecycles](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/).
+For the experimental Parquet metadata mode, see the
+[Parquet metadata warmup guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
 and its [controlled benchmark](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/prepared-parquet-metadata/).
 
 ## Choose a partition target
@@ -70,12 +69,12 @@ storage, or stress probes while planning a scan.
 
 ## Select the files
 
-Delta Kernel consumes the table's Delta scan metadata. Lazy Delta
-log/checkpoint replay reconciles the active `add` metadata for that scan; eager
-mode starts from the retained reconciled result. Delta Kernel then applies
-partition and data-statistics pruning. Each selected file becomes a scan task
-with its path, size and row estimates when available, partition values, schema
-transforms, and deletion-vector information.
+Delta Kernel consumes the table's Delta scan metadata. With no warmup, Delta
+log/checkpoint replay reconciles the active `add` metadata for that scan;
+query-planning warmup starts from the retained reconciled result. Delta Kernel
+then applies partition and data-statistics pruning. Each selected file becomes
+a scan task with its path, size and row estimates when available, partition
+values, schema transforms, and deletion-vector information.
 
 Choosing the partition target before this step keeps host policy separate from
 table shape. Parquet file size is not a reliable estimate of decoded Arrow

--- a/docs/content/streaming-reader.md
+++ b/docs/content/streaming-reader.md
@@ -48,13 +48,14 @@ occasionally. If one process will run several queries against the same loaded
 table, you can cache its reusable scan metadata during table loading:
 
 ```no_run
-use delta_arrow_reader::DeltaTableBuilder;
+use delta_arrow_reader::{DeltaTableBuilder, WarmupMode};
 use futures_util::TryStreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let table = DeltaTableBuilder::new("/tmp/example-delta-table")
-        .load_table_with_eager_scan_metadata()
+        .with_warmup(WarmupMode::QueryPlanning)
+        .load_table()
         .await?;
 
     let scan = table
@@ -73,12 +74,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-`load_table_with_eager_scan_metadata` returns after it has built the cache. The
-cache holds active-file metadata and available file statistics in memory.
-Later scan builds reuse it instead of replaying the Delta log or checkpoint.
-This reduces repeated planning work when metadata accounts for much of a
-selective query's latency. The cache remains in memory as long as the loaded
-table does.
+`WarmupMode::QueryPlanning` tells `load_table` to build the cache before it
+returns. The cache holds active-file metadata and available file statistics in
+memory. Later scan builds reuse it instead of replaying the Delta log or
+checkpoint. This reduces repeated planning work when metadata accounts for
+much of a selective query's latency. The cache remains in memory as long as
+the loaded table does.
 
 The cache does not contain Parquet footers or Parquet data. Each scan still
 applies its own projection and predicate, then performs its Parquet I/O when
@@ -86,11 +87,11 @@ you poll the returned stream. Load the table again when you want to read a
 newer Delta version.
 
 The [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/)
-explains what the eager method caches and when the tradeoff is worthwhile.
+explains what query-planning warmup caches and when the tradeoff is worthwhile.
 
 For a long-lived process that repeatedly queries Parquet files on remote
 storage, the experimental
-[Parquet metadata preparation guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
+[Parquet metadata warmup guide](https://mag1cfrog.github.io/delta-arrow-reader/prepared-parquet-metadata/)
 describes a second opt-in cache for file footers and offset indexes.
 
 ## Filter rows

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,7 +37,7 @@ nav:
       - Installation: installation.md
       - Streaming reader quickstart: streaming-reader.md
       - DataFusion quickstart: datafusion.md
-      - Prepare Parquet metadata: prepared-parquet-metadata.md
+      - Warm Parquet metadata: prepared-parquet-metadata.md
   - How it works:
       - Architecture: architecture.md
       - Delta metadata lifecycle: delta-metadata-lifecycle.md

--- a/src/delta/snapshot.rs
+++ b/src/delta/snapshot.rs
@@ -114,7 +114,7 @@ impl ArrowTableSnapshot {
             .and_then(|scan| scan.materialize_scan_metadata(self.engine_context.as_ref()))
             .boxed()
             .context(ScanPlanningSnafu {
-                reason: "eager_scan_metadata_materialization_failed",
+                reason: "query_planning_warmup_materialization_failed",
             });
 
         match result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,13 @@ pub mod diagnostics {
         };
     }
 }
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
+pub use reader::ParquetWarmupReport;
 pub use reader::{
     DeltaBatchStream, DeltaComparison, DeltaPredicate, DeltaScalar, DeltaScan, DeltaScanBuilder,
     DeltaScanExecutionOptions, DeltaScanMetrics, DeltaScanMetricsSnapshot, DeltaSnapshotSelection,
     DeltaStorageOptions, DeltaTable, DeltaTableBuilder, DeltaTableSnapshot, ParquetReaderBackend,
+    WarmupMode,
 };
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
-pub use reader::{ParquetMetadataPreparationLimits, ParquetMetadataPreparationReport};
 /// The crate version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -31,7 +31,7 @@ use std::{
     task::{Context, Poll},
 };
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 use std::time::{Duration, Instant};
 
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
@@ -40,10 +40,10 @@ use snafu::ResultExt;
 
 #[cfg(any(
     feature = "datafusion",
-    feature = "experimental-parquet-metadata-preparation"
+    feature = "experimental-parquet-metadata-warmup"
 ))]
 use self::backend::direct_parquet::ParquetMetadataCache;
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 use self::backend::direct_parquet::prepare_parquet_metadata;
 use self::{
     planning::{DeltaScanPartitionTargetOptions, DeltaScanPlan, plan_scan},
@@ -69,41 +69,60 @@ use crate::{
 
 const TRACING_TARGET: &str = "delta_arrow_reader";
 const DELTA_LOG_SCAN_METADATA_SOURCE: &str = "delta_log";
-const EAGER_CACHE_SCAN_METADATA_SOURCE: &str = "eager_cache";
+const QUERY_PLANNING_CACHE_SCAN_METADATA_SOURCE: &str = "query_planning_cache";
 
-/// Resource limits for experimental Parquet metadata preparation.
+/// Selects how much work table loading performs before returning.
 ///
-/// Both limits must be greater than zero. The retained-memory limit uses the reader's estimate of
-/// parsed Parquet metadata size, not allocator-level resident memory.
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ParquetMetadataPreparationLimits {
-    /// Maximum number of active Parquet files to prepare.
-    pub max_files: usize,
-    /// Maximum estimated bytes of parsed Parquet metadata to retain.
-    pub max_retained_metadata_bytes: usize,
+/// Each warmup level includes the work performed by the levels before it. The default performs no
+/// warmup and leaves reusable metadata work to individual queries.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WarmupMode {
+    /// Performs no warmup.
+    #[default]
+    None,
+    /// Loads and retains the active-file metadata used during query planning.
+    QueryPlanning,
+    /// Also loads and retains Parquet footers and optional offset indexes for every active file.
+    ///
+    /// Both limits must be greater than zero. `max_memory_bytes` applies to the reader's estimate
+    /// of parsed metadata size, not allocator-level resident memory.
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
+    ParquetMetadata {
+        /// Maximum number of active Parquet files to warm.
+        max_files: usize,
+        /// Maximum estimated bytes of parsed Parquet metadata to retain.
+        max_memory_bytes: usize,
+    },
 }
 
-/// Measurements recorded while preparing one table's Parquet metadata.
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParquetMetadataPreparationLimits {
+    pub(crate) max_files: usize,
+    pub(crate) max_retained_metadata_bytes: usize,
+}
+
+/// Measurements recorded while warming one table's Parquet metadata.
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParquetMetadataPreparationReport {
-    /// Number of active Parquet files prepared.
-    pub files_prepared: usize,
-    /// Estimated bytes retained by the parsed Parquet metadata.
-    pub estimated_retained_metadata_bytes: usize,
-    /// Time spent fetching and parsing Parquet metadata after scan planning completed.
-    pub preparation_duration: Duration,
-    /// Reader metrics collected by the preparation scan plan.
+pub struct ParquetWarmupReport {
+    /// Number of active Parquet files included in the warmup.
+    pub file_count: usize,
+    /// Estimated bytes retained by parsed Parquet metadata.
+    pub estimated_memory_bytes: usize,
+    /// Time spent fetching and parsing Parquet metadata.
+    pub duration: Duration,
+    /// Reader metrics collected during the warmup.
     pub read_metrics: DeltaScanMetricsSnapshot,
 }
 
 /// Table-owned prepared cache and the report describing how it was built.
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 struct PreparedParquetMetadata {
     cache: Arc<ParquetMetadataCache>,
-    report: ParquetMetadataPreparationReport,
+    report: ParquetWarmupReport,
 }
 
 /// Configures and loads one immutable Delta table snapshot.
@@ -146,6 +165,7 @@ pub struct DeltaTableBuilder {
     storage_options: DeltaStorageOptions,
     snapshot_selection: DeltaSnapshotSelection,
     execution_options: DeltaScanExecutionOptions,
+    warmup: WarmupMode,
 }
 
 impl DeltaTableBuilder {
@@ -156,6 +176,7 @@ impl DeltaTableBuilder {
             storage_options: DeltaStorageOptions::new(),
             snapshot_selection: DeltaSnapshotSelection::Latest,
             execution_options: DeltaScanExecutionOptions::new(),
+            warmup: WarmupMode::None,
         }
     }
 
@@ -183,68 +204,94 @@ impl DeltaTableBuilder {
         self
     }
 
-    /// Loads table metadata and its logical Arrow schema through the caller-owned Tokio runtime.
+    /// Selects work to finish during [`Self::load_table`] for reuse by later queries.
     ///
-    /// Unsupported protocol metadata remains inspectable; scan planning validates it.
+    /// [`Self::load_snapshot`] does not build a table and rejects any setting other than
+    /// [`WarmupMode::None`].
+    pub const fn with_warmup(mut self, warmup: WarmupMode) -> Self {
+        self.warmup = warmup;
+        self
+    }
+
+    /// Loads the table through the caller-owned Tokio runtime.
+    ///
+    /// With [`WarmupMode::None`], this method loads the snapshot and converts its schema. Protocol
+    /// validation and scan metadata loading remain deferred until a scan is built. This allows an
+    /// application to inspect the version, schema, and protocol of a table that the reader cannot
+    /// scan.
+    ///
+    /// A warmup mode validates the protocol while loading because it builds reusable query-planning
+    /// state. Query-planning warmup retains active-file metadata. When its experimental feature is
+    /// enabled, Parquet metadata warmup also reads and retains footers and offset indexes within the
+    /// configured file and memory limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the table location, storage, snapshot, or schema cannot be loaded. A
+    /// warmup can also fail if the table protocol is unsupported or its reusable metadata cannot be
+    /// built. Parquet metadata warmup additionally validates its limits and direct-backend
+    /// requirement, and returns an error if any required Parquet metadata cannot be read.
     pub async fn load_table(self) -> Result<DeltaTable, DeltaReaderError> {
-        let snapshot = load_delta_table_snapshot(
-            self.table_location,
-            self.storage_options,
-            self.snapshot_selection,
-        )
-        .await?;
-        Ok(DeltaTable::new(snapshot, self.execution_options))
-    }
-
-    /// Loads a table and eagerly retains its active Delta scan metadata in memory.
-    ///
-    /// This moves Delta log and checkpoint replay into initialization so later scans of this
-    /// immutable snapshot can plan without reopening the Delta log. It increases initialization
-    /// time and retains active-file metadata and statistics for the lifetime of the table.
-    /// Parquet footer and data reads remain query-time operations. Load a new table to observe a
-    /// newer snapshot. Unlike [`Self::load_table`], unsupported protocols fail during
-    /// initialization because materialization constructs a scan.
-    /// See [the scan-planning guide](crate::guides::concepts::scan_planning) for measured
-    /// tradeoffs.
-    pub async fn load_table_with_eager_scan_metadata(self) -> Result<DeltaTable, DeltaReaderError> {
-        let snapshot = load_delta_table_snapshot(
-            self.table_location,
-            self.storage_options,
-            self.snapshot_selection,
-        )
-        .await?;
-        validate_protocol(snapshot.protocol())?;
-        let snapshot = materialize_eager_scan_metadata(snapshot).await?;
-        Ok(DeltaTable::new(snapshot, self.execution_options))
-    }
-
-    /// Loads a table and prepares the Parquet metadata for every active file.
-    ///
-    /// This experimental loading mode includes eager Delta scan metadata, then fetches and parses
-    /// each active file's Parquet footer and optional offset indexes. The returned table shares the
-    /// prepared metadata across its streaming scans and clones. Initialization fails without
-    /// returning a table if the direct Parquet backend is not selected, a resource limit is
-    /// exceeded, or any file cannot be prepared.
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
-    pub async fn load_table_with_prepared_parquet_metadata(
-        self,
-        limits: ParquetMetadataPreparationLimits,
-    ) -> Result<DeltaTable, DeltaReaderError> {
-        limits.validate()?;
-        if self.execution_options.parquet_backend() != ParquetReaderBackend::Direct {
-            return InvalidConfigurationSnafu {
-                reason: "parquet_metadata_preparation_requires_direct_backend",
+        #[cfg(feature = "experimental-parquet-metadata-warmup")]
+        let parquet_limits = match self.warmup {
+            WarmupMode::ParquetMetadata {
+                max_files,
+                max_memory_bytes,
+            } => {
+                let limits = ParquetMetadataPreparationLimits {
+                    max_files,
+                    max_retained_metadata_bytes: max_memory_bytes,
+                };
+                limits.validate()?;
+                if self.execution_options.parquet_backend() != ParquetReaderBackend::Direct {
+                    return InvalidConfigurationSnafu {
+                        reason: "parquet_metadata_warmup_requires_direct_backend",
+                    }
+                    .fail();
+                }
+                Some(limits)
             }
-            .fail();
+            _ => None,
+        };
+
+        let snapshot = load_delta_table_snapshot(
+            self.table_location,
+            self.storage_options,
+            self.snapshot_selection,
+        )
+        .await?;
+        let snapshot = if self.warmup == WarmupMode::None {
+            snapshot
+        } else {
+            validate_protocol(snapshot.protocol())?;
+            materialize_eager_scan_metadata(snapshot).await?
+        };
+        let table = DeltaTable::new(snapshot, self.execution_options);
+
+        #[cfg(feature = "experimental-parquet-metadata-warmup")]
+        if let Some(limits) = parquet_limits {
+            return table.prepare_parquet_metadata(limits).await;
         }
-        self.load_table_with_eager_scan_metadata()
-            .await?
-            .prepare_parquet_metadata(limits)
-            .await
+        Ok(table)
     }
 
     /// Loads a Delta Kernel snapshot without converting its logical Arrow schema.
+    ///
+    /// Warmup settings apply to [`DeltaTable`] and are not supported by this method. Calling this
+    /// method after selecting any mode other than [`WarmupMode::None`] returns a configuration
+    /// error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if warmup was requested or if the table location, storage, or snapshot
+    /// cannot be loaded.
     pub async fn load_snapshot(self) -> Result<DeltaTableSnapshot, DeltaReaderError> {
+        if self.warmup != WarmupMode::None {
+            return InvalidConfigurationSnafu {
+                reason: "snapshot_load_does_not_support_table_warmup",
+            }
+            .fail();
+        }
         let snapshot = load_kernel_table_snapshot(
             self.table_location,
             self.storage_options,
@@ -262,22 +309,22 @@ async fn materialize_eager_scan_metadata(
         .await
         .boxed()
         .context(ScanPlanningSnafu {
-            reason: "eager_scan_metadata_task_failed",
+            reason: "query_planning_warmup_task_failed",
         })?
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 impl ParquetMetadataPreparationLimits {
     fn validate(self) -> Result<(), DeltaReaderError> {
         if self.max_files == 0 {
             return InvalidConfigurationSnafu {
-                reason: "parquet_metadata_preparation_max_files_must_be_positive",
+                reason: "parquet_metadata_warmup_max_files_must_be_positive",
             }
             .fail();
         }
         if self.max_retained_metadata_bytes == 0 {
             return InvalidConfigurationSnafu {
-                reason: "parquet_metadata_preparation_memory_limit_must_be_positive",
+                reason: "parquet_metadata_warmup_memory_limit_must_be_positive",
             }
             .fail();
         }
@@ -293,6 +340,7 @@ impl fmt::Debug for DeltaTableBuilder {
             .field("storage_options", &"<redacted>")
             .field("snapshot_selection", &self.snapshot_selection)
             .field("execution_options", &self.execution_options)
+            .field("warmup", &self.warmup)
             .finish()
     }
 }
@@ -356,7 +404,7 @@ impl fmt::Debug for DeltaTableSnapshot {
 pub struct DeltaTable {
     snapshot: Arc<ArrowTableSnapshot>,
     execution_options: DeltaScanExecutionOptions,
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     prepared_parquet_metadata: Option<Arc<PreparedParquetMetadata>>,
 }
 
@@ -365,12 +413,12 @@ impl DeltaTable {
         Self {
             snapshot: Arc::new(snapshot),
             execution_options,
-            #[cfg(feature = "experimental-parquet-metadata-preparation")]
+            #[cfg(feature = "experimental-parquet-metadata-warmup")]
             prepared_parquet_metadata: None,
         }
     }
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     async fn prepare_parquet_metadata(
         mut self,
         limits: ParquetMetadataPreparationLimits,
@@ -394,7 +442,7 @@ impl DeltaTable {
         .await
         .boxed()
         .context(ScanPlanningSnafu {
-            reason: "parquet_metadata_preparation_planning_task_failed",
+            reason: "parquet_metadata_warmup_planning_task_failed",
         })??;
         let metadata_cache = Arc::new(ParquetMetadataCache::default());
         let started = Instant::now();
@@ -403,10 +451,10 @@ impl DeltaTable {
                 .await?;
         self.prepared_parquet_metadata = Some(Arc::new(PreparedParquetMetadata {
             cache: metadata_cache,
-            report: ParquetMetadataPreparationReport {
-                files_prepared: prepared.file_count,
-                estimated_retained_metadata_bytes: prepared.memory_bytes,
-                preparation_duration: started.elapsed(),
+            report: ParquetWarmupReport {
+                file_count: prepared.file_count,
+                estimated_memory_bytes: prepared.memory_bytes,
+                duration: started.elapsed(),
                 read_metrics: plan.metrics.snapshot(),
             },
         }));
@@ -450,10 +498,10 @@ impl DeltaTable {
         validate_protocol(self.protocol())
     }
 
-    /// Returns measurements from experimental Parquet metadata preparation, when used to load
-    /// this table.
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
-    pub fn parquet_metadata_preparation_report(&self) -> Option<&ParquetMetadataPreparationReport> {
+    /// Returns measurements from experimental Parquet metadata warmup, when enabled for this
+    /// table.
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
+    pub fn parquet_warmup_report(&self) -> Option<&ParquetWarmupReport> {
         self.prepared_parquet_metadata
             .as_deref()
             .map(|prepared| &prepared.report)
@@ -461,13 +509,13 @@ impl DeltaTable {
 
     #[cfg(feature = "datafusion")]
     pub(crate) fn prepared_parquet_metadata_cache(&self) -> Option<Arc<ParquetMetadataCache>> {
-        #[cfg(feature = "experimental-parquet-metadata-preparation")]
+        #[cfg(feature = "experimental-parquet-metadata-warmup")]
         {
             self.prepared_parquet_metadata
                 .as_ref()
                 .map(|prepared| Arc::clone(&prepared.cache))
         }
-        #[cfg(not(feature = "experimental-parquet-metadata-preparation"))]
+        #[cfg(not(feature = "experimental-parquet-metadata-warmup"))]
         {
             None
         }
@@ -562,7 +610,7 @@ impl<'table> DeltaScanBuilder<'table> {
         let snapshot_version = self.table.version();
         let backend = self.execution_options.parquet_backend();
         let scan_metadata_source = if self.table.snapshot.eager_scan_metadata().is_some() {
-            EAGER_CACHE_SCAN_METADATA_SOURCE
+            QUERY_PLANNING_CACHE_SCAN_METADATA_SOURCE
         } else {
             DELTA_LOG_SCAN_METADATA_SOURCE
         };
@@ -614,7 +662,7 @@ impl<'table> DeltaScanBuilder<'table> {
                     predicate,
                     limit: self.limit,
                     enforce_physical_predicate_rows,
-                    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+                    #[cfg(feature = "experimental-parquet-metadata-warmup")]
                     parquet_metadata_cache: self
                         .table
                         .prepared_parquet_metadata
@@ -656,7 +704,7 @@ pub struct DeltaScan {
     predicate: Option<DeltaPredicate>,
     limit: Option<usize>,
     enforce_physical_predicate_rows: bool,
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     parquet_metadata_cache: Option<Arc<ParquetMetadataCache>>,
 }
 
@@ -683,11 +731,11 @@ impl DeltaScan {
         let projection = (self.plan.logical_schema.as_ref() != schema.as_ref())
             .then(|| (0..schema.fields().len()).collect::<Vec<_>>());
         let parquet_metadata_cache = {
-            #[cfg(feature = "experimental-parquet-metadata-preparation")]
+            #[cfg(feature = "experimental-parquet-metadata-warmup")]
             {
                 self.parquet_metadata_cache
             }
-            #[cfg(not(feature = "experimental-parquet-metadata-preparation"))]
+            #[cfg(not(feature = "experimental-parquet-metadata-warmup"))]
             {
                 None
             }
@@ -1325,9 +1373,14 @@ mod tests {
         let error = InvalidConfigurationSnafu { reason: "test" }.build();
 
         let (_, events) = capture_events(|| {
-            trace_planning_started(7, ParquetReaderBackend::Direct, "eager_cache");
-            trace_planning_completed(7, ParquetReaderBackend::Direct, 2, "eager_cache");
-            trace_planning_failed(7, ParquetReaderBackend::Direct, "eager_cache", &error);
+            trace_planning_started(7, ParquetReaderBackend::Direct, "query_planning_cache");
+            trace_planning_completed(7, ParquetReaderBackend::Direct, 2, "query_planning_cache");
+            trace_planning_failed(
+                7,
+                ParquetReaderBackend::Direct,
+                "query_planning_cache",
+                &error,
+            );
             trace_execution_started(7, ParquetReaderBackend::Direct, 2);
             trace_execution_completed(7, ParquetReaderBackend::Direct, 2);
             trace_execution_failed(7, ParquetReaderBackend::Direct, 2, &error);
@@ -1358,7 +1411,7 @@ mod tests {
             {
                 assert_eq!(
                     fields.get("scan_metadata_source").map(String::as_str),
-                    Some("eager_cache")
+                    Some("query_planning_cache")
                 );
             }
         }
@@ -1397,7 +1450,7 @@ mod tests {
             Some("scan_planning.completed")
         );
         assert!(eager_events.iter().all(|event| {
-            event.get("scan_metadata_source").map(String::as_str) == Some("eager_cache")
+            event.get("scan_metadata_source").map(String::as_str) == Some("query_planning_cache")
         }));
 
         let (failed_result, failed_events) =
@@ -1413,7 +1466,7 @@ mod tests {
             Some("scan_planning.failed")
         );
         assert!(failed_events.iter().all(|event| {
-            event.get("scan_metadata_source").map(String::as_str) == Some("eager_cache")
+            event.get("scan_metadata_source").map(String::as_str) == Some("query_planning_cache")
         }));
 
         let (lazy_result, lazy_events) = capture_events(|| runtime.block_on(lazy.scan().build()));

--- a/src/reader/backend/direct_parquet.rs
+++ b/src/reader/backend/direct_parquet.rs
@@ -8,7 +8,7 @@ mod schema_alignment;
 
 use std::{ops::Range, sync::Arc};
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 use std::collections::HashSet;
 
 use arrow::{
@@ -58,7 +58,7 @@ use crate::{
     },
 };
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 use crate::reader::ParquetMetadataPreparationLimits;
 
 struct DirectParquetReader {
@@ -69,7 +69,7 @@ struct DirectParquetReader {
     metadata_cache: Option<Arc<ParquetMetadataCache>>,
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PreparedParquetMetadataSummary {
     pub(crate) file_count: usize,
@@ -176,7 +176,7 @@ impl DirectParquetReader {
         })
     }
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     async fn prepare_task_parquet_metadata(
         &self,
         task: &DeltaScanFileTask,
@@ -697,7 +697,7 @@ pub(crate) fn direct_parquet_file_executor(
     })
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 pub(crate) async fn prepare_parquet_metadata(
     plan: &DeltaScanPlan,
     metadata_cache: Arc<ParquetMetadataCache>,
@@ -714,7 +714,7 @@ pub(crate) async fn prepare_parquet_metadata(
         .collect::<Vec<_>>();
     if tasks.len() > limits.max_files {
         return Err(DeltaReaderError::InvalidConfiguration {
-            reason: "parquet_metadata_preparation_file_limit_exceeded",
+            reason: "parquet_metadata_warmup_file_limit_exceeded",
         });
     }
 
@@ -745,7 +745,7 @@ pub(crate) async fn prepare_parquet_metadata(
             .checked_add(result?)
             .filter(|bytes| *bytes <= limits.max_retained_metadata_bytes)
             .ok_or(DeltaReaderError::InvalidConfiguration {
-                reason: "parquet_metadata_preparation_memory_limit_exceeded",
+                reason: "parquet_metadata_warmup_memory_limit_exceeded",
             })?;
     }
 
@@ -920,14 +920,14 @@ mod tests {
     use parquet::file::metadata::ParquetMetaDataReader;
     use parquet::file::properties::{EnabledStatistics, WriterProperties};
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     use super::prepare_parquet_metadata;
     use super::{
         DirectParquetReader, LogicalDataFileReadRequest, ParquetMetadataCache,
         PhysicalParquetStreamOptions, RowFilterInput, arrow_reader_options, data_file_error,
         direct_parquet_file_executor,
     };
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     use crate::reader::ParquetMetadataPreparationLimits;
     use crate::reader::backend::kernel_reader::delta_kernel_file_executor;
     use crate::{
@@ -1991,7 +1991,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     #[tokio::test]
     async fn prepared_metadata_is_reused_by_a_whole_file_read()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -2033,7 +2033,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     #[tokio::test]
     async fn cancelled_metadata_preparation_leaves_the_cache_retryable()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -2071,7 +2071,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     #[tokio::test]
     async fn preparation_checks_the_file_limit_before_reading_parquet_metadata()
     -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/benchmark_harness.rs
+++ b/tests/benchmark_harness.rs
@@ -2,7 +2,7 @@
 
 #![cfg(all(
     feature = "datafusion",
-    feature = "experimental-parquet-metadata-preparation"
+    feature = "experimental-parquet-metadata-warmup"
 ))]
 
 #[allow(dead_code)]

--- a/tests/eager_metadata_tracing.rs
+++ b/tests/eager_metadata_tracing.rs
@@ -159,13 +159,15 @@ fn public_eager_initialization_emits_complete_structured_lifecycle_events() -> T
     let table = runtime.block_on(
         DeltaTableBuilder::new(success.uri())
             .with_storage_options(storage_options())
-            .load_table_with_eager_scan_metadata(),
+            .with_warmup(delta_arrow_reader::WarmupMode::QueryPlanning)
+            .load_table(),
     )?;
     assert_eq!(table.version(), 0);
     let error = match runtime.block_on(
         DeltaTableBuilder::new(failure.uri())
             .with_storage_options(storage_options())
-            .load_table_with_eager_scan_metadata(),
+            .with_warmup(delta_arrow_reader::WarmupMode::QueryPlanning)
+            .load_table(),
     ) {
         Ok(_) => return Err("malformed eager metadata should fail".into()),
         Err(error) => error,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -7,7 +7,7 @@ use delta_arrow_reader::{
     DeltaBatchStream, DeltaComparison, DeltaPredicate, DeltaProtocol, DeltaReaderError,
     DeltaReaderPhase, DeltaScalar, DeltaScan, DeltaScanBuilder, DeltaScanExecutionOptions,
     DeltaScanMetrics, DeltaScanMetricsSnapshot, DeltaSnapshotSelection, DeltaStorageOptions,
-    DeltaTable, DeltaTableBuilder, DeltaTableSnapshot, ParquetReaderBackend,
+    DeltaTable, DeltaTableBuilder, DeltaTableSnapshot, ParquetReaderBackend, WarmupMode,
     diagnostics::parquet_range_planning::{
         Policy as ParquetRangeReadPolicy, Snapshot as ParquetRangePlanningSnapshot,
         snapshot as parquet_range_planning_snapshot,
@@ -228,6 +228,8 @@ fn streaming_reader_contract_is_public() {
     assert_send_sync::<DeltaTable>();
     assert_clone::<DeltaTable>();
     assert_debug::<DeltaScanMetrics>();
+    assert_debug::<WarmupMode>();
+    assert_eq!(WarmupMode::default(), WarmupMode::None);
     assert_send::<DeltaBatchStream>();
     assert_batch_stream::<DeltaBatchStream>();
 
@@ -238,7 +240,9 @@ fn streaming_reader_contract_is_public() {
     assert_future::<Result<DeltaTable, DeltaReaderError>>(builder.load_table());
     let eager_builder = DeltaTableBuilder::new("file:///tmp/table");
     assert_future::<Result<DeltaTable, DeltaReaderError>>(
-        eager_builder.load_table_with_eager_scan_metadata(),
+        eager_builder
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table(),
     );
     let snapshot_builder = DeltaTableBuilder::new("file:///tmp/table");
     assert_future::<Result<DeltaTableSnapshot, DeltaReaderError>>(snapshot_builder.load_snapshot());
@@ -305,27 +309,25 @@ fn streaming_reader_contract_is_public() {
     let _ = (stream_schema, metrics);
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[test]
-fn prepared_parquet_metadata_contract_is_public() {
-    use delta_arrow_reader::{ParquetMetadataPreparationLimits, ParquetMetadataPreparationReport};
+fn parquet_metadata_warmup_contract_is_public() {
+    use delta_arrow_reader::ParquetWarmupReport;
 
-    fn assert_debug<T: std::fmt::Debug>() {}
     fn assert_clone<T: Clone>() {}
     fn assert_future<T>(_: impl Future<Output = T>) {}
 
-    assert_debug::<ParquetMetadataPreparationLimits>();
-    assert_clone::<ParquetMetadataPreparationReport>();
-    let limits = ParquetMetadataPreparationLimits {
-        max_files: 10,
-        max_retained_metadata_bytes: 1024 * 1024,
-    };
+    assert_clone::<ParquetWarmupReport>();
     assert_future::<Result<DeltaTable, DeltaReaderError>>(
         DeltaTableBuilder::new("file:///tmp/table")
-            .load_table_with_prepared_parquet_metadata(limits),
+            .with_warmup(WarmupMode::ParquetMetadata {
+                max_files: 10,
+                max_memory_bytes: 1024 * 1024,
+            })
+            .load_table(),
     );
-    let report: for<'a> fn(&'a DeltaTable) -> Option<&'a ParquetMetadataPreparationReport> =
-        DeltaTable::parquet_metadata_preparation_report;
+    let report: for<'a> fn(&'a DeltaTable) -> Option<&'a ParquetWarmupReport> =
+        DeltaTable::parquet_warmup_report;
     let _ = report;
 }
 

--- a/tests/reader/datafusion_adapter.rs
+++ b/tests/reader/datafusion_adapter.rs
@@ -11,7 +11,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 use arrow::compute::concat_batches;
 use arrow::{
     array::{
@@ -28,11 +28,9 @@ use datafusion::{
     physical_plan::{ExecutionPlan, displayable},
     prelude::{SessionConfig, SessionContext},
 };
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
-use delta_arrow_reader::ParquetMetadataPreparationLimits;
 use delta_arrow_reader::{
     DeltaReaderError, DeltaReaderPhase, DeltaScanExecutionOptions, DeltaTableBuilder,
-    ParquetReaderBackend,
+    ParquetReaderBackend, WarmupMode,
     datafusion::{
         DeltaTableProvider, IntraFileRepartitioning, ScanOptions, collect_scan_metrics,
         register_table,
@@ -135,7 +133,7 @@ impl TestTable {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     fn corrupt_parquet_footer(&self, name: &str) -> TestResult {
         let path = self.0.join(name);
         let mut bytes = fs::read(&path)?;
@@ -254,7 +252,7 @@ async fn collect_plan(
     Ok(datafusion::physical_plan::collect(plan, context.task_ctx()).await?)
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 async fn collect_query(context: &SessionContext, query: &str) -> TestResult<RecordBatch> {
     let batches = context.sql(query).await?.collect().await?;
     let schema = batches.first().ok_or("query returned no batches")?.schema();
@@ -324,7 +322,8 @@ async fn optimizer_repartitions_parquet_files_through_normal_sql_planning() -> T
 async fn registered_eager_table_reuses_metadata_across_sql_queries_without_the_log() -> TestResult {
     let fixture = TestTable::partitioned("eager-metadata-registration")?;
     let table = DeltaTableBuilder::new(fixture.uri())
-        .load_table_with_eager_scan_metadata()
+        .with_warmup(WarmupMode::QueryPlanning)
+        .load_table()
         .await?;
     let context = SessionContext::new();
     register_table(&context, "orders", table, ScanOptions::default())?;
@@ -348,15 +347,16 @@ async fn registered_eager_table_reuses_metadata_across_sql_queries_without_the_l
     Ok(())
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[tokio::test]
 async fn datafusion_reuses_table_prepared_parquet_metadata_after_repartitioning() -> TestResult {
     let fixture = TestTable::partitioned("prepared-parquet-metadata-datafusion")?;
     let table = DeltaTableBuilder::new(fixture.uri())
-        .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+        .with_warmup(WarmupMode::ParquetMetadata {
             max_files: 2,
-            max_retained_metadata_bytes: 1024 * 1024,
+            max_memory_bytes: 1024 * 1024,
         })
+        .load_table()
         .await?;
     fixture.corrupt_parquet_footer("west.parquet")?;
     for _ in 0..2 {
@@ -392,7 +392,7 @@ async fn datafusion_reuses_table_prepared_parquet_metadata_after_repartitioning(
     Ok(())
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[tokio::test]
 async fn prepared_parquet_metadata_preserves_datafusion_results() -> TestResult {
     let fixture = RealParquetDeltaTable::new_with_two_row_groups_and_deletion_vector(
@@ -402,13 +402,15 @@ async fn prepared_parquet_metadata_preserves_datafusion_results() -> TestResult 
     )?;
     let location = fixture.path().to_string_lossy().into_owned();
     let eager = DeltaTableBuilder::new(location.clone())
-        .load_table_with_eager_scan_metadata()
+        .with_warmup(WarmupMode::QueryPlanning)
+        .load_table()
         .await?;
     let prepared = DeltaTableBuilder::new(location)
-        .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+        .with_warmup(WarmupMode::ParquetMetadata {
             max_files: 1,
-            max_retained_metadata_bytes: 1024 * 1024,
+            max_memory_bytes: 1024 * 1024,
         })
+        .load_table()
         .await?;
     let context = SessionContext::new();
     register_table(&context, "eager", eager, ScanOptions::default())?;

--- a/tests/reader/portable_fixtures.rs
+++ b/tests/reader/portable_fixtures.rs
@@ -11,8 +11,8 @@ use arrow::{
     record_batch::RecordBatch,
     util::display::array_value_to_string,
 };
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
-use delta_arrow_reader::ParquetMetadataPreparationLimits;
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
+use delta_arrow_reader::WarmupMode;
 use delta_arrow_reader::{
     DeltaBatchStream, DeltaComparison, DeltaPredicate, DeltaReaderError, DeltaReaderPhase,
     DeltaScalar, DeltaScanExecutionOptions, DeltaScanMetrics, DeltaScanMetricsSnapshot, DeltaTable,
@@ -609,7 +609,7 @@ async fn scan_table(
     }
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[test]
 fn prepared_parquet_metadata_preserves_streaming_scan_results() -> TestResult {
     runtime()?.block_on(async {
@@ -620,13 +620,15 @@ fn prepared_parquet_metadata_preserves_streaming_scan_results() -> TestResult {
         )?;
         let location = fixture.path().to_string_lossy().into_owned();
         let eager = DeltaTableBuilder::new(location.clone())
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         let prepared = DeltaTableBuilder::new(location)
-            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            .with_warmup(WarmupMode::ParquetMetadata {
                 max_files: 1,
-                max_retained_metadata_bytes: 1024 * 1024,
+                max_memory_bytes: 1024 * 1024,
             })
+            .load_table()
             .await?;
 
         let cases = [

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -15,14 +15,12 @@ use arrow::{
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 use delta_arrow_reader::DeltaReaderError;
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
-use delta_arrow_reader::ParquetMetadataPreparationLimits;
 use delta_arrow_reader::ParquetReaderBackend;
 use delta_arrow_reader::{
     DeltaComparison, DeltaPredicate, DeltaReaderPhase, DeltaScalar, DeltaSnapshotSelection,
-    DeltaStorageOptions,
+    DeltaStorageOptions, WarmupMode,
 };
 use delta_arrow_reader::{
     DeltaScan, DeltaScanExecutionOptions, DeltaScanMetrics, DeltaTableBuilder,
@@ -140,7 +138,7 @@ impl TestTable {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-parquet-metadata-preparation")]
+    #[cfg(feature = "experimental-parquet-metadata-warmup")]
     fn corrupt_parquet_footer(&self, name: &str) -> TestResult {
         let path = self.0.join(name);
         let mut bytes = fs::read(&path)?;
@@ -345,6 +343,25 @@ fn table_loads_versions_and_public_state_is_redacted() -> TestResult {
 }
 
 #[test]
+fn snapshot_loading_rejects_table_warmup() -> TestResult {
+    let error = runtime()?
+        .block_on(
+            DeltaTableBuilder::new("file:///tmp/table")
+                .with_warmup(WarmupMode::QueryPlanning)
+                .load_snapshot(),
+        )
+        .expect_err("snapshot loading must not silently ignore table warmup");
+
+    assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
+    assert!(
+        error
+            .to_string()
+            .contains("snapshot_load_does_not_support_table_warmup")
+    );
+    Ok(())
+}
+
+#[test]
 fn local_end_to_end_example_reads_without_sql() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("local-example")?;
@@ -371,11 +388,13 @@ fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestRes
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("eager-scan-metadata")?;
         let eager = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         let fixed = DeltaTableBuilder::new(fixture.uri())
             .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         let lazy = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
         let low_ids = DeltaPredicate::Compare {
@@ -413,34 +432,36 @@ fn eager_scan_metadata_plans_repeated_queries_without_the_delta_log() -> TestRes
     })
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[test]
 fn prepared_parquet_metadata_supports_repeated_streaming_scans_without_the_delta_log() -> TestResult
 {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("prepared-parquet-metadata")?;
         let table = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            .with_warmup(WarmupMode::ParquetMetadata {
                 max_files: 2,
-                max_retained_metadata_bytes: 1024 * 1024,
+                max_memory_bytes: 1024 * 1024,
             })
+            .load_table()
             .await?;
         let eager_only = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         let cloned = table.clone();
         let report = table
-            .parquet_metadata_preparation_report()
-            .ok_or("prepared table must expose its preparation report")?;
+            .parquet_warmup_report()
+            .ok_or("warmed table must expose its warmup report")?;
 
-        assert_eq!(report.files_prepared, 2);
-        assert!(report.estimated_retained_metadata_bytes > 0);
+        assert_eq!(report.file_count, 2);
+        assert!(report.estimated_memory_bytes > 0);
         assert_eq!(report.read_metrics.files_planned, 2);
         assert!(std::ptr::eq(
             report,
             cloned
-                .parquet_metadata_preparation_report()
-                .ok_or("cloned table must share its preparation report")?
+                .parquet_warmup_report()
+                .ok_or("cloned table must share its warmup report")?
         ));
 
         fixture.corrupt_parquet_footer("part-0.parquet")?;
@@ -486,42 +507,39 @@ fn prepared_parquet_metadata_supports_repeated_streaming_scans_without_the_delta
     })
 }
 
-#[cfg(feature = "experimental-parquet-metadata-preparation")]
+#[cfg(feature = "experimental-parquet-metadata-warmup")]
 #[test]
 fn prepared_parquet_metadata_rejects_unsafe_or_unsupported_requests() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("prepared-parquet-limits")?;
-        for limits in [
-            ParquetMetadataPreparationLimits {
-                max_files: 0,
-                max_retained_metadata_bytes: 1024 * 1024,
-            },
-            ParquetMetadataPreparationLimits {
-                max_files: 2,
-                max_retained_metadata_bytes: 0,
-            },
-        ] {
+        for (max_files, max_memory_bytes) in [(0, 1024 * 1024), (2, 0)] {
             let error = DeltaTableBuilder::new(fixture.uri())
-                .load_table_with_prepared_parquet_metadata(limits)
+                .with_warmup(WarmupMode::ParquetMetadata {
+                    max_files,
+                    max_memory_bytes,
+                })
+                .load_table()
                 .await
                 .expect_err("zero preparation limits must be rejected");
             assert_eq!(error.phase(), DeltaReaderPhase::Configuration);
         }
 
         let file_limit_error = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            .with_warmup(WarmupMode::ParquetMetadata {
                 max_files: 1,
-                max_retained_metadata_bytes: usize::MAX,
+                max_memory_bytes: usize::MAX,
             })
+            .load_table()
             .await
             .expect_err("two active files must exceed the one-file limit");
         assert_eq!(file_limit_error.phase(), DeltaReaderPhase::Configuration);
 
         let memory_limit_error = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            .with_warmup(WarmupMode::ParquetMetadata {
                 max_files: 2,
-                max_retained_metadata_bytes: 1,
+                max_memory_bytes: 1,
             })
+            .load_table()
             .await
             .expect_err("one byte cannot retain two Parquet metadata objects");
         assert_eq!(memory_limit_error.phase(), DeltaReaderPhase::Configuration);
@@ -531,20 +549,22 @@ fn prepared_parquet_metadata_rejects_unsafe_or_unsupported_requests() -> TestRes
                 DeltaScanExecutionOptions::new()
                     .with_parquet_backend(ParquetReaderBackend::DeltaKernel),
             )
-            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            .with_warmup(WarmupMode::ParquetMetadata {
                 max_files: 2,
-                max_retained_metadata_bytes: 1024 * 1024,
+                max_memory_bytes: 1024 * 1024,
             })
+            .load_table()
             .await
             .expect_err("the Delta Kernel backend cannot prepare direct-reader metadata");
         assert_eq!(kernel_error.phase(), DeltaReaderPhase::Configuration);
 
         let missing = TestTable::missing_data_file("prepared-parquet-missing")?;
         let missing_error = DeltaTableBuilder::new(missing.uri())
-            .load_table_with_prepared_parquet_metadata(ParquetMetadataPreparationLimits {
+            .with_warmup(WarmupMode::ParquetMetadata {
                 max_files: 1,
-                max_retained_metadata_bytes: 1024 * 1024,
+                max_memory_bytes: 1024 * 1024,
             })
+            .load_table()
             .await
             .expect_err("missing Parquet metadata must fail table preparation");
         assert_eq!(missing_error.phase(), DeltaReaderPhase::DataFileRead);
@@ -558,7 +578,8 @@ fn eager_scan_metadata_supports_concurrent_planning_without_the_delta_log() -> T
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("eager-concurrent-planning")?;
         let table = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         fixture.disable_delta_log()?;
 
@@ -615,7 +636,8 @@ fn eager_scan_metadata_preserves_pruning_from_a_parsed_stats_only_checkpoint() -
         );
 
         let table = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         fixture.disable_delta_log()?;
         let (batches, metrics) = collect_scan(
@@ -660,8 +682,11 @@ fn unsupported_protocol_is_inspectable_but_never_scannable() -> TestResult {
         Err(error) => error,
     };
     assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
-    let eager = runtime
-        .block_on(DeltaTableBuilder::new(fixture.uri()).load_table_with_eager_scan_metadata());
+    let eager = runtime.block_on(
+        DeltaTableBuilder::new(fixture.uri())
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table(),
+    );
     let error = match eager {
         Ok(_) => panic!("unsupported protocol eagerly loaded a table"),
         Err(error) => error,
@@ -679,9 +704,11 @@ fn eager_metadata_failure_returns_no_table_and_redacts_the_source() -> TestResul
 
     let lazy = runtime.block_on(DeltaTableBuilder::new(fixture.uri()).load_table())?;
     assert_eq!(lazy.version(), 0);
-    let error = match runtime
-        .block_on(DeltaTableBuilder::new(fixture.uri()).load_table_with_eager_scan_metadata())
-    {
+    let error = match runtime.block_on(
+        DeltaTableBuilder::new(fixture.uri())
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table(),
+    ) {
         Ok(_) => return Err("malformed eager metadata should not return a table".into()),
         Err(error) => error,
     };
@@ -691,7 +718,7 @@ fn eager_metadata_failure_returns_no_table_and_redacts_the_source() -> TestResul
     assert!(
         error
             .to_string()
-            .contains("eager_scan_metadata_materialization_failed")
+            .contains("query_planning_warmup_materialization_failed")
     );
     assert!(
         error
@@ -950,14 +977,16 @@ fn eager_metadata_preserves_direct_and_delta_kernel_results_without_the_log() ->
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("backend-parity")?;
         let direct = DeltaTableBuilder::new(fixture.uri())
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         let kernel = DeltaTableBuilder::new(fixture.uri())
             .with_execution_options(
                 DeltaScanExecutionOptions::new()
                     .with_parquet_backend(ParquetReaderBackend::DeltaKernel),
             )
-            .load_table_with_eager_scan_metadata()
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
             .await?;
         fixture.disable_delta_log()?;
         let kernel_options = DeltaScanExecutionOptions::new()


### PR DESCRIPTION
## Summary

- replace separate lazy, eager, and prepared loading methods with `WarmupMode` and one `load_table` method
- keep query-planning warmup available by default and Parquet metadata warmup behind its experimental feature
- rename the Parquet warmup report, tracing values, feature flag, examples, and guides around the same public vocabulary
- use versionless `cargo add` installation commands and document the 0.5 to 0.6 migration

## Breaking changes

- remove `load_table_with_eager_scan_metadata` and `load_table_with_prepared_parquet_metadata`
- replace the preparation limits and report APIs with `WarmupMode::ParquetMetadata` and `ParquetWarmupReport`
- rename `experimental-parquet-metadata-preparation` to `experimental-parquet-metadata-warmup`

## Verification

- `cargo test --all-features`
- `cargo test --no-default-features`
- Clippy with warnings denied for all features and isolated feature combinations
- Rustdoc with warnings denied with and without optional features
- strict documentation site build