### PR TITLE
feat: refresh loaded Delta tables and DataFusion providers without mutating active scans

### DIFF
--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -16,8 +16,9 @@ At a high level, the reader does three things:
    vectors and Delta schema changes, and returns batches as the application
    asks for them.
 
-Once loaded, a `DeltaTable` always points to the same snapshot. To read a newer
-snapshot, load the table again.
+Once loaded, a `DeltaTable` always points to the same snapshot. Its `refresh`
+method loads the latest snapshot into a new table and leaves the original
+unchanged.
 
 ## Remote I/O phases
 
@@ -39,8 +40,9 @@ The retained Delta scan metadata contains reconciled active `add` metadata and
 available file statistics, not raw JSON commit files. It belongs to one exact
 snapshot and remains in memory for the lifetime of that loaded table.
 Separately loaded tables do not share this memory. There is no TTL, eviction,
-persistence, incremental update, or background refresh; load another table to
-observe a newer snapshot.
+persistence, or background refresh. An explicit refresh can update the retained
+metadata from commits written after its version. If a newer checkpoint makes
+that impossible, Delta Kernel rebuilds the metadata from the checkpoint.
 
 ## Streaming API
 

--- a/docs/content/datafusion.md
+++ b/docs/content/datafusion.md
@@ -97,8 +97,66 @@ Keep the default `WarmupMode::None` when you will query it only once or
 occasionally. The crate does not maintain a table-name registry or choose a
 mode automatically.
 
-A registered table stays on the Delta version that was loaded. To read a newer
-version, load the table again and replace the existing registration.
+A registered provider stays on the Delta version that it loaded. Refreshing a
+provider does not modify the DataFusion catalog entry that points to the old
+provider.
+
+## Refresh a registered provider
+
+Keep the concrete `DeltaTableProvider` when a long-running service needs to
+refresh its registration:
+
+```no_run
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use delta_arrow_reader::{
+    DeltaTableBuilder,
+    datafusion::{DeltaTableProvider, ScanOptions},
+};
+
+async fn refresh_orders(
+    context: &SessionContext,
+    provider: &mut DeltaTableProvider,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let refreshed = provider.refresh().await?;
+    let previous = context.deregister_table("orders")?;
+
+    if let Err(error) = context.register_table("orders", Arc::new(refreshed.clone())) {
+        if let Some(previous) = previous {
+            let _ = context.register_table("orders", previous)?;
+        }
+        return Err(error.into());
+    }
+
+    *provider = refreshed;
+    Ok(())
+}
+
+# async fn setup() -> Result<(), Box<dyn std::error::Error>> {
+let context = SessionContext::new();
+let table = DeltaTableBuilder::new("/tmp/example-delta-table")
+    .load_table()
+    .await?;
+let mut provider = DeltaTableProvider::try_new(table, ScanOptions::default())?;
+let _ = context.register_table("orders", Arc::new(provider.clone()))?;
+refresh_orders(&context, &mut provider).await?;
+# Ok(())
+# }
+```
+
+The returned provider keeps the existing scan options and range-read
+estimates. It also rebuilds the DataFusion schema if the Delta schema changed.
+The original provider remains usable, so queries that already hold it continue
+against the old snapshot.
+
+DataFusion uses separate deregistration and registration calls, so there is a
+short interval with no `orders` registration. If that gap matters, pause new
+query planning while the two calls run. The example restores the previous
+provider if the new registration fails.
+
+`DeltaTableProvider::refresh` does not poll in the background. The application
+chooses when to refresh and when to replace its registration.
 
 The [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/)
 follows this cache across several queries. For the rest of the read path, see

--- a/docs/content/delta-metadata-lifecycle.md
+++ b/docs/content/delta-metadata-lifecycle.md
@@ -81,8 +81,9 @@ and statistics pruning. Different queries can therefore select different
 files while sharing the result of Delta replay.
 
 The cache belongs to one loaded table. If the same location is loaded twice,
-the two table objects have separate caches. Both also stay fixed at the exact
-table version they loaded.
+the two table objects have separate caches. Each table stays fixed at its
+loaded version. Calling `refresh` creates another table instead of changing the
+existing one.
 
 ## Which mode should you use?
 
@@ -96,7 +97,7 @@ APIs.
 | Table loading | Returns without building a reusable scan cache | Waits for Delta replay and cache creation |
 | Memory while loaded | No reusable active-file cache | Keeps active-file metadata and statistics |
 | Each later scan | Replays Delta metadata, then prunes | Reuses Delta metadata, then prunes |
-| Seeing a newer version | Load a new table | Load a new table |
+| Seeing a newer version | `refresh` returns a new lazy table | `refresh` updates or reuses the retained cache |
 | Parquet metadata and data reads | Per query | Per query |
 
 Use no warmup unless you know the table will serve repeated queries and the
@@ -130,14 +131,32 @@ describe how the measurements were collected and what can affect them.
 
 ## Version and refresh behavior
 
-The cache lasts as long as its loaded table and represents one exact Delta
-version. Commits written later do not change what existing queries see. To use
-a newer version, load the table again and replace the old table or DataFusion
-registration.
+Every loaded table and cache represents one exact Delta version. Commits
+written later do not change that table or any scan already built from it.
+`DeltaTable::refresh` checks for the latest version and returns another
+immutable table. If no newer version exists, it reuses the existing snapshot,
+schema, and query-planning cache.
+
+With no warmup, the returned table has no retained active-file cache. Its scans
+continue to assemble scan metadata when they are built. With query-planning
+warmup, refresh passes the old version and retained active-file metadata to
+Delta Kernel. Delta Kernel reconciles commits written after that version. If a
+newer checkpoint prevents incremental reconciliation, it performs a full
+metadata replay from that checkpoint instead.
+
+Refresh returns an error rather than a partially updated table when the latest
+snapshot, schema, or retained query-planning metadata cannot be loaded. The
+caller can keep using the original table after such an error. A lazy table may
+load a newer unsupported protocol for inspection, but its scans still reject
+that protocol. Refreshing a warmed table fails if the newer protocol cannot be
+used to rebuild its query-planning cache.
+
+`DeltaTableProvider::refresh` applies the same table refresh and rebuilds its
+DataFusion schema when needed. It returns a new provider but does not replace a
+provider already registered in a `SessionContext`.
 
 The in-memory cache does not provide:
 
-- incremental refresh;
 - background polling;
 - TTL or eviction;
 - persistence across processes;

--- a/docs/content/streaming-reader.md
+++ b/docs/content/streaming-reader.md
@@ -83,11 +83,38 @@ the loaded table does.
 
 The cache does not contain Parquet footers or Parquet data. Each scan still
 applies its own projection and predicate, then performs its Parquet I/O when
-you poll the returned stream. Load the table again when you want to read a
-newer Delta version.
+you poll the returned stream.
 
 The [Delta metadata lifecycle](https://mag1cfrog.github.io/delta-arrow-reader/delta-metadata-lifecycle/)
 explains what query-planning warmup caches and when the tradeoff is worthwhile.
+
+## Refresh a loaded table
+
+Call `refresh` when a long-running process is ready to use the latest Delta
+version:
+
+```no_run
+use delta_arrow_reader::{DeltaReaderError, DeltaTable};
+
+async fn refresh_table(table: &mut DeltaTable) -> Result<(), DeltaReaderError> {
+    *table = table.refresh().await?;
+    Ok(())
+}
+```
+
+`refresh` returns a new immutable table. The original table and scans already
+built from it stay on their original version. If the refresh fails, the
+assignment does not run and the original table remains available.
+
+With `WarmupMode::None`, the new table remains lazy. With
+`WarmupMode::QueryPlanning`, refresh updates the retained active-file metadata
+from the previous version. If the table has not changed, the new table reuses
+the same cache. A checkpoint written after the previous version may require a
+full metadata replay instead.
+
+The crate does not refresh tables on a timer. Call `refresh` from the polling
+or scheduling code that owns the table, then publish the returned table when
+your application is ready for new scans to see it.
 
 ## Filter rows
 

--- a/src/delta/kernel.rs
+++ b/src/delta/kernel.rs
@@ -187,22 +187,47 @@ impl KernelScan {
         &self,
         engine_context: &DeltaKernelEngineContext,
     ) -> delta_kernel::DeltaResult<Arc<[RecordBatch]>> {
-        let mut batches = Vec::new();
-        for metadata in self.scan.scan_metadata(engine_context.engine.as_ref())? {
-            let metadata = metadata?;
-            let data = metadata.scan_files.apply_selection_vector()?;
-            let mut batch: RecordBatch = ArrowEngineData::try_from_engine_data(data)?.into();
-            // Cached replay rebuilds typed stats from JSON `stats`, so retaining
-            // `stats_parsed` would only duplicate the same statistics in memory.
-            if let Ok(index) = batch.schema().index_of("stats_parsed") {
-                batch.remove_column(index);
-            }
-            if batch.num_rows() > 0 {
-                batches.push(batch);
-            }
-        }
-        Ok(batches.into())
+        materialize_scan_metadata(self.scan.scan_metadata(engine_context.engine.as_ref())?)
     }
+
+    pub(crate) fn materialize_scan_metadata_from(
+        &self,
+        engine_context: &DeltaKernelEngineContext,
+        existing_version: u64,
+        existing_metadata: &[RecordBatch],
+    ) -> delta_kernel::DeltaResult<Arc<[RecordBatch]>> {
+        let existing_data = existing_metadata
+            .iter()
+            .cloned()
+            .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
+            .collect::<Vec<_>>();
+        materialize_scan_metadata(self.scan.scan_metadata_from(
+            engine_context.engine.as_ref(),
+            existing_version,
+            existing_data,
+            None,
+        )?)
+    }
+}
+
+fn materialize_scan_metadata(
+    metadata: impl Iterator<Item = delta_kernel::DeltaResult<ScanMetadata>>,
+) -> delta_kernel::DeltaResult<Arc<[RecordBatch]>> {
+    let mut batches = Vec::new();
+    for metadata in metadata {
+        let metadata = metadata?;
+        let data = metadata.scan_files.apply_selection_vector()?;
+        let mut batch: RecordBatch = ArrowEngineData::try_from_engine_data(data)?.into();
+        // Cached replay rebuilds typed stats from JSON `stats`, so retaining
+        // `stats_parsed` would only duplicate the same statistics in memory.
+        if let Ok(index) = batch.schema().index_of("stats_parsed") {
+            batch.remove_column(index);
+        }
+        if batch.num_rows() > 0 {
+            batches.push(batch);
+        }
+    }
+    Ok(batches.into())
 }
 
 fn collect_scan_files(
@@ -500,6 +525,15 @@ impl DeltaKernelEngineContext {
             builder = builder.at_version(version);
         }
         builder.build(self.engine.as_ref()).map(KernelSnapshot)
+    }
+
+    pub(crate) fn refresh_snapshot(
+        &self,
+        existing_snapshot: &KernelSnapshot,
+    ) -> delta_kernel::DeltaResult<KernelSnapshot> {
+        Snapshot::builder_from(Arc::clone(&existing_snapshot.0))
+            .build(self.engine.as_ref())
+            .map(KernelSnapshot)
     }
 
     #[allow(dead_code)]

--- a/src/delta/snapshot.rs
+++ b/src/delta/snapshot.rs
@@ -21,6 +21,9 @@ const TRACING_TARGET: &str = "delta_arrow_reader";
 const SNAPSHOT_LOAD_STARTED_EVENT: &str = "snapshot_load.started";
 const SNAPSHOT_LOAD_COMPLETED_EVENT: &str = "snapshot_load.completed";
 const SNAPSHOT_LOAD_FAILED_EVENT: &str = "snapshot_load.failed";
+const SNAPSHOT_REFRESH_STARTED_EVENT: &str = "snapshot_refresh.started";
+const SNAPSHOT_REFRESH_COMPLETED_EVENT: &str = "snapshot_refresh.completed";
+const SNAPSHOT_REFRESH_FAILED_EVENT: &str = "snapshot_refresh.failed";
 const SCAN_METADATA_CACHE_BUILD_STARTED_EVENT: &str = "scan_metadata_cache_build.started";
 const SCAN_METADATA_CACHE_BUILD_COMPLETED_EVENT: &str = "scan_metadata_cache_build.completed";
 const SCAN_METADATA_CACHE_BUILD_FAILED_EVENT: &str = "scan_metadata_cache_build.failed";
@@ -139,6 +142,27 @@ impl ArrowTableSnapshot {
     }
 
     pub(crate) fn refresh(&self) -> Result<Self, DeltaReaderError> {
+        let previous_snapshot_version = self.version();
+        trace_snapshot_refresh_started(previous_snapshot_version);
+        let started_at = Instant::now();
+        let result = self.build_refreshed_snapshot();
+
+        match &result {
+            Ok(snapshot) => trace_snapshot_refresh_completed(
+                previous_snapshot_version,
+                snapshot,
+                started_at.elapsed().as_micros(),
+            ),
+            Err(error) => trace_snapshot_refresh_failed(
+                previous_snapshot_version,
+                started_at.elapsed().as_micros(),
+                error,
+            ),
+        }
+        result
+    }
+
+    fn build_refreshed_snapshot(&self) -> Result<Self, DeltaReaderError> {
         let snapshot = self
             .engine_context
             .refresh_snapshot(&self.snapshot)
@@ -344,6 +368,52 @@ fn trace_snapshot_load_failed(selection: &'static str, error: &DeltaReaderError)
         target: TRACING_TARGET,
         event = SNAPSHOT_LOAD_FAILED_EVENT,
         selection,
+        error_code = error.code(),
+        error_phase = error.phase().as_str()
+    );
+}
+
+fn trace_snapshot_refresh_started(previous_snapshot_version: u64) {
+    tracing::debug!(
+        target: TRACING_TARGET,
+        event = SNAPSHOT_REFRESH_STARTED_EVENT,
+        previous_snapshot_version
+    );
+}
+
+fn trace_snapshot_refresh_completed(
+    previous_snapshot_version: u64,
+    snapshot: &ArrowTableSnapshot,
+    elapsed_micros: u128,
+) {
+    let query_planning_cache_action = match (
+        snapshot.eager_scan_metadata.is_some(),
+        snapshot.version() == previous_snapshot_version,
+    ) {
+        (false, _) => "not_loaded",
+        (true, true) => "reused",
+        (true, false) => "refreshed",
+    };
+    tracing::debug!(
+        target: TRACING_TARGET,
+        event = SNAPSHOT_REFRESH_COMPLETED_EVENT,
+        previous_snapshot_version,
+        snapshot_version = snapshot.version(),
+        query_planning_cache_action,
+        elapsed_micros
+    );
+}
+
+fn trace_snapshot_refresh_failed(
+    previous_snapshot_version: u64,
+    elapsed_micros: u128,
+    error: &DeltaReaderError,
+) {
+    tracing::debug!(
+        target: TRACING_TARGET,
+        event = SNAPSHOT_REFRESH_FAILED_EVENT,
+        previous_snapshot_version,
+        elapsed_micros,
         error_code = error.code(),
         error_phase = error.phase().as_str()
     );
@@ -596,7 +666,9 @@ mod tests {
             let mut visitor = FieldVisitor::default();
             event.record(&mut visitor);
             if visitor.0.get("event").is_some_and(|name| {
-                name.starts_with("snapshot_load.") || name.starts_with("scan_metadata_cache_build.")
+                name.starts_with("snapshot_load.")
+                    || name.starts_with("snapshot_refresh.")
+                    || name.starts_with("scan_metadata_cache_build.")
             }) && let Some(events) = &self.0
                 && let Ok(mut events) = events.lock()
             {
@@ -1038,30 +1110,114 @@ mod tests {
     }
 
     #[test]
-    fn unchanged_refresh_reuses_the_same_query_planning_cache()
+    fn refresh_tracing_reports_cache_loading_refresh_and_reuse()
     -> Result<(), Box<dyn std::error::Error>> {
-        let table = DeltaLogTable::new("unchanged-refresh-cache")?;
+        let table = DeltaLogTable::new("refresh-cache-tracing")?;
+        let lazy_snapshot = load_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &DeltaStorageOptions::new(),
+            DeltaSnapshotSelection::Latest,
+        )?;
+        let warm_snapshot = lazy_snapshot.clone().materialize_eager_scan_metadata()?;
+        table.write_log(
+            2,
+            r#"{"add":{"path":"secret-refresh-object.parquet","partitionValues":{},"size":10,"modificationTime":1587968586000,"dataChange":true}}"#,
+        )?;
+
+        let (result, events) = capture_events(|| {
+            let refreshed_lazy = lazy_snapshot.refresh()?;
+            let refreshed_warm = warm_snapshot.refresh()?;
+            let unchanged_warm = refreshed_warm.refresh()?;
+            Ok::<_, DeltaReaderError>((refreshed_lazy, refreshed_warm, unchanged_warm))
+        });
+        let (refreshed_lazy, refreshed_warm, unchanged_warm) = result?;
+        let refreshed_cache = refreshed_warm
+            .eager_scan_metadata
+            .as_ref()
+            .ok_or("refreshed eager metadata missing")?;
+        let unchanged_cache = unchanged_warm
+            .eager_scan_metadata
+            .as_ref()
+            .ok_or("unchanged eager metadata missing")?;
+
+        assert_eq!(refreshed_lazy.version(), 2);
+        assert_eq!(refreshed_warm.version(), 2);
+        assert_eq!(unchanged_warm.version(), 2);
+        assert!(Arc::ptr_eq(refreshed_cache, unchanged_cache));
+        assert_eq!(events.len(), 6);
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|event| event.fields.get("query_planning_cache_action"))
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["not_loaded", "refreshed", "reused"]
+        );
+        assert!(events.chunks_exact(2).all(|events| {
+            events[0].fields.get("event").map(String::as_str) == Some("snapshot_refresh.started")
+                && events[1].fields.get("event").map(String::as_str)
+                    == Some("snapshot_refresh.completed")
+                && events[1]
+                    .fields
+                    .get("elapsed_micros")
+                    .is_some_and(|elapsed| elapsed.parse::<u128>().is_ok())
+        }));
+        let captured = format!("{events:?}");
+        assert!(!captured.contains("secret-refresh-object.parquet"));
+        Ok(())
+    }
+
+    #[test]
+    fn refresh_tracing_reports_bounded_failure_fields() -> Result<(), Box<dyn std::error::Error>> {
+        const INVALID_SIZE: &str = "secret-refresh-size";
+        const OBJECT_KEY: &str = "secret-refresh-object.parquet";
+        let table = DeltaLogTable::new("failed-refresh-tracing")?;
         let snapshot = load_delta_table_snapshot_blocking(
             &table.0.to_string_lossy(),
             &DeltaStorageOptions::new(),
             DeltaSnapshotSelection::Latest,
         )?
         .materialize_eager_scan_metadata()?;
-        let existing = Arc::clone(
-            snapshot
-                .eager_scan_metadata
-                .as_ref()
-                .ok_or("eager metadata missing")?,
+        table.write_log(
+            2,
+            &format!(
+                r#"{{"add":{{"path":"{OBJECT_KEY}","partitionValues":{{}},"size":"{INVALID_SIZE}","modificationTime":1587968586000,"dataChange":true}}}}"#,
+            ),
+        )?;
+
+        let (result, events) = capture_events(|| snapshot.refresh());
+        let error = match result {
+            Ok(_) => return Err("malformed refreshed metadata must fail".into()),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code(), "scan_planning");
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].fields.get("event").map(String::as_str),
+            Some("snapshot_refresh.started")
         );
-
-        let refreshed_snapshot = snapshot.refresh()?;
-        let refreshed = refreshed_snapshot
-            .eager_scan_metadata
-            .as_ref()
-            .ok_or("refreshed eager metadata missing")?;
-
-        assert_eq!(refreshed_snapshot.version(), snapshot.version());
-        assert!(Arc::ptr_eq(&existing, refreshed));
+        assert_eq!(
+            events[1].fields.get("event").map(String::as_str),
+            Some("snapshot_refresh.failed")
+        );
+        assert_eq!(
+            events[1].fields.get("error_code").map(String::as_str),
+            Some("scan_planning")
+        );
+        assert_eq!(
+            events[1].fields.get("error_phase").map(String::as_str),
+            Some("scan_planning")
+        );
+        assert_eq!(events[1].fields.len(), 5);
+        events[1]
+            .fields
+            .get("elapsed_micros")
+            .ok_or("elapsed time missing")?
+            .parse::<u128>()?;
+        let captured = format!("{events:?}");
+        assert!(!captured.contains(INVALID_SIZE));
+        assert!(!captured.contains(OBJECT_KEY));
         Ok(())
     }
 

--- a/src/delta/snapshot.rs
+++ b/src/delta/snapshot.rs
@@ -8,7 +8,7 @@ use snafu::ResultExt;
 use super::{
     kernel::{DeltaKernelEngineContext, KernelSnapshot, snapshot_arrow_schema},
     location::normalize_table_location,
-    protocol::DeltaProtocol,
+    protocol::{DeltaProtocol, validate_protocol},
 };
 use crate::{
     DeltaReaderError, DeltaSnapshotSelection, DeltaStorageOptions,
@@ -136,6 +136,53 @@ impl ArrowTableSnapshot {
                 Err(error)
             }
         }
+    }
+
+    pub(crate) fn refresh(&self) -> Result<Self, DeltaReaderError> {
+        let snapshot = self
+            .engine_context
+            .refresh_snapshot(&self.snapshot)
+            .boxed()
+            .context(SnapshotLoadSnafu {
+                reason: "snapshot_refresh_failed",
+            })?;
+        if snapshot.version() == self.version() {
+            return Ok(self.clone());
+        }
+        let protocol = DeltaProtocol::from_snapshot(&snapshot);
+        let schema = snapshot_arrow_schema(&snapshot)
+            .boxed()
+            .context(SchemaConversionSnafu {
+                reason: "schema_conversion_failed",
+            })?;
+        let eager_scan_metadata = match self.eager_scan_metadata.as_ref() {
+            None => None,
+            Some(metadata) => {
+                validate_protocol(&protocol)?;
+                let refreshed = snapshot
+                    .build_scan(None, None, true)
+                    .and_then(|scan| {
+                        scan.materialize_scan_metadata_from(
+                            self.engine_context.as_ref(),
+                            self.version(),
+                            metadata,
+                        )
+                    })
+                    .boxed()
+                    .context(ScanPlanningSnafu {
+                        reason: "query_planning_cache_refresh_failed",
+                    })?;
+                Some(refreshed)
+            }
+        };
+
+        Ok(Self {
+            snapshot,
+            protocol,
+            schema,
+            engine_context: Arc::clone(&self.engine_context),
+            eager_scan_metadata,
+        })
     }
 }
 
@@ -987,6 +1034,34 @@ mod tests {
         assert!(!captured.contains(OBJECT_KEY));
         assert!(!captured.contains(SECOND_OBJECT_KEY));
         assert!(!captured.contains(STORAGE_VALUE));
+        Ok(())
+    }
+
+    #[test]
+    fn unchanged_refresh_reuses_the_same_query_planning_cache()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let table = DeltaLogTable::new("unchanged-refresh-cache")?;
+        let snapshot = load_delta_table_snapshot_blocking(
+            &table.0.to_string_lossy(),
+            &DeltaStorageOptions::new(),
+            DeltaSnapshotSelection::Latest,
+        )?
+        .materialize_eager_scan_metadata()?;
+        let existing = Arc::clone(
+            snapshot
+                .eager_scan_metadata
+                .as_ref()
+                .ok_or("eager metadata missing")?,
+        );
+
+        let refreshed_snapshot = snapshot.refresh()?;
+        let refreshed = refreshed_snapshot
+            .eager_scan_metadata
+            .as_ref()
+            .ok_or("refreshed eager metadata missing")?;
+
+        assert_eq!(refreshed_snapshot.version(), snapshot.version());
+        assert!(Arc::ptr_eq(&existing, refreshed));
         Ok(())
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -359,8 +359,8 @@ impl DeltaTable {
     ///
     /// # Errors
     ///
-    /// Returns an error if the newer snapshot, schema, protocol, or retained query-planning
-    /// metadata cannot be loaded. No partially refreshed table is returned.
+    /// Returns an error if the newer snapshot, schema, or retained query-planning metadata cannot
+    /// be loaded. No partially refreshed table is returned.
     pub async fn refresh(&self) -> Result<Self, DeltaReaderError> {
         let snapshot = Arc::clone(&self.snapshot);
         let snapshot = tokio::task::spawn_blocking(move || snapshot.refresh())

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -54,7 +54,7 @@ use crate::{
             load_kernel_table_snapshot,
         },
     },
-    error::{DataFileReadSnafu, InvalidConfigurationSnafu, ScanPlanningSnafu},
+    error::{DataFileReadSnafu, InvalidConfigurationSnafu, ScanPlanningSnafu, SnapshotLoadSnafu},
 };
 
 const TRACING_TARGET: &str = "delta_arrow_reader";
@@ -349,6 +349,28 @@ impl DeltaTable {
     /// Validates the loaded snapshot against the supported reader protocol.
     pub fn validate_protocol(&self) -> Result<(), DeltaReaderError> {
         validate_protocol(self.protocol())
+    }
+
+    /// Loads the latest version from this table and returns it as a new immutable table.
+    ///
+    /// The current table and any scans built from it remain fixed at their original version. A
+    /// query-planning metadata cache is refreshed for the new version and reused directly when the
+    /// version has not changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the newer snapshot, schema, protocol, or retained query-planning
+    /// metadata cannot be loaded. No partially refreshed table is returned.
+    pub async fn refresh(&self) -> Result<Self, DeltaReaderError> {
+        let snapshot = Arc::clone(&self.snapshot);
+        let snapshot = tokio::task::spawn_blocking(move || snapshot.refresh())
+            .await
+            .boxed()
+            .context(SnapshotLoadSnafu {
+                reason: "snapshot_refresh_task_failed",
+            })
+            .and_then(|result| result)?;
+        Ok(Self::new(snapshot, self.execution_options))
     }
 
     /// Starts configuring a new single-use scan.

--- a/src/reader/datafusion.rs
+++ b/src/reader/datafusion.rs
@@ -101,6 +101,30 @@ impl DeltaTableProvider {
         Self::try_new_with_registration_name(table, options, None)
     }
 
+    /// Returns a new provider backed by the latest Delta table version.
+    ///
+    /// The existing provider and any DataFusion registration that refers to it
+    /// remain unchanged. Scan options and range-read estimates are retained by
+    /// the returned provider.
+    pub async fn refresh(&self) -> Result<Self, DeltaReaderError> {
+        let table = self.table.refresh().await?;
+        table.validate_protocol()?;
+        if table.version() == self.table.version() {
+            return Ok(self.clone());
+        }
+
+        let partition_columns = table.partition_columns().iter().cloned().collect();
+        let schema = build_provider_schema(
+            &table.schema(),
+            &partition_columns,
+            self.options.use_arrow_view_types,
+        );
+        let mut provider = self.clone();
+        provider.table = table;
+        provider.schema = schema;
+        Ok(provider)
+    }
+
     fn try_new_with_registration_name(
         table: DeltaTable,
         options: ScanOptions,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -370,6 +370,11 @@ fn datafusion_provider_contract_is_public() {
     }
     let construct: fn(DeltaTable, ScanOptions) -> Result<DeltaTableProvider, DeltaReaderError> =
         DeltaTableProvider::try_new;
+    async fn refresh(
+        provider: &DeltaTableProvider,
+    ) -> Result<DeltaTableProvider, DeltaReaderError> {
+        provider.refresh().await
+    }
     fn register(
         context: &datafusion::execution::context::SessionContext,
         name: String,
@@ -378,5 +383,5 @@ fn datafusion_provider_contract_is_public() {
     ) -> Result<TableRegistration, DeltaReaderError> {
         register_table(context, name, table, options)
     }
-    let _ = (construct, register, inspect_registration);
+    let _ = (construct, refresh, register, inspect_registration);
 }

--- a/tests/reader/datafusion_adapter.rs
+++ b/tests/reader/datafusion_adapter.rs
@@ -114,13 +114,19 @@ impl TestTable {
     }
 
     fn write_log(&self, actions: &[Value]) -> TestResult {
+        self.write_log_version(0, actions)
+    }
+
+    fn write_log_version(&self, version: u64, actions: &[Value]) -> TestResult {
         let contents = actions
             .iter()
             .map(Value::to_string)
             .collect::<Vec<_>>()
             .join("\n");
         fs::write(
-            self.0.join("_delta_log/00000000000000000000.json"),
+            self.0
+                .join("_delta_log")
+                .join(format!("{version:020}.json")),
             format!("{contents}\n"),
         )?;
         Ok(())
@@ -165,6 +171,20 @@ fn metadata() -> Value {
             "createdTime": 1587968585495_i64
         }
     })
+}
+
+fn metadata_with_note() -> Value {
+    let mut action = metadata();
+    let schema = json!({
+        "type": "struct",
+        "fields": [
+            {"name": "id", "type": "integer", "nullable": false, "metadata": {}},
+            {"name": "region", "type": "string", "nullable": true, "metadata": {}},
+            {"name": "note", "type": "string", "nullable": true, "metadata": {}}
+        ]
+    });
+    action["metaData"]["schemaString"] = Value::String(schema.to_string());
+    action
 }
 
 fn add(path: &str, size: u64, region: &str, num_records: u64, min_id: i32, max_id: i32) -> Value {
@@ -881,6 +901,72 @@ async fn options_protocol_schema_pushdown_and_debug_match_the_provider_contract(
     let error = DeltaTableProvider::try_new(unsupported, Default::default())
         .expect_err("unsupported protocol must fail");
     assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
+    Ok(())
+}
+
+#[tokio::test]
+async fn provider_refresh_returns_a_new_version_and_keeps_the_original_immutable() -> TestResult {
+    let fixture = TestTable::partitioned("provider-refresh")?;
+    let table = DeltaTableBuilder::new(fixture.uri())
+        .with_warmup(WarmupMode::QueryPlanning)
+        .load_table()
+        .await?;
+    let provider = DeltaTableProvider::try_new(
+        table,
+        ScanOptions {
+            target_partitions: Some(1),
+            ..Default::default()
+        },
+    )?;
+    let north = fixture.write_parquet("north.parquet", &[5, 6])?;
+    fixture.write_log_version(
+        1,
+        &[
+            metadata_with_note(),
+            add("north.parquet", north, "north", 2, 5, 6),
+        ],
+    )?;
+
+    let refreshed = provider.refresh().await?;
+    fixture.disable_delta_log()?;
+
+    let context = SessionContext::new();
+    let original_plan = provider.scan(&context.state(), None, &[], None).await?;
+    let refreshed_plan = refreshed.scan(&context.state(), None, &[], None).await?;
+    let mut original_ids = ids(&collect_plan(&context, original_plan).await?);
+    let mut refreshed_ids = ids(&collect_plan(&context, refreshed_plan).await?);
+    original_ids.sort_unstable();
+    refreshed_ids.sort_unstable();
+
+    assert_eq!(original_ids, [1, 2, 3, 4]);
+    assert_eq!(refreshed_ids, [1, 2, 3, 4, 5, 6]);
+    assert_eq!(provider.schema().fields().len(), 2);
+    assert_eq!(refreshed.schema().fields().len(), 3);
+    assert!(format!("{provider:?}").contains("snapshot_version: 0"));
+    assert!(format!("{refreshed:?}").contains("snapshot_version: 1"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn provider_refresh_rejects_a_new_unsupported_protocol_without_changing_the_original()
+-> TestResult {
+    let fixture = TestTable::partitioned("provider-refresh-protocol")?;
+    let table = DeltaTableBuilder::new(fixture.uri()).load_table().await?;
+    let provider = DeltaTableProvider::try_new(table, ScanOptions::default())?;
+    fixture.write_log_version(1, &[protocol(4)])?;
+
+    let error = provider
+        .refresh()
+        .await
+        .expect_err("unsupported refreshed protocol must fail");
+
+    assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
+    let context = SessionContext::new();
+    let plan = provider.scan(&context.state(), None, &[], None).await?;
+    let mut original_ids = ids(&collect_plan(&context, plan).await?);
+    original_ids.sort_unstable();
+    assert_eq!(original_ids, [1, 2, 3, 4]);
+    assert!(format!("{provider:?}").contains("snapshot_version: 0"));
     Ok(())
 }
 

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -384,6 +384,35 @@ fn refresh_returns_a_new_latest_table_and_keeps_the_original_immutable() -> Test
 }
 
 #[test]
+fn lazy_refresh_keeps_a_new_unsupported_protocol_inspectable() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::empty("refresh-unsupported-protocol")?;
+        fixture.write_log(0, &[protocol(1), metadata()])?;
+        fixture.write_log(1, &[protocol(4)])?;
+        let original = DeltaTableBuilder::new(fixture.uri())
+            .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
+            .load_table()
+            .await?;
+
+        let refreshed = original.refresh().await?;
+        let error = refreshed
+            .validate_protocol()
+            .expect_err("the refreshed protocol must remain unsupported");
+
+        assert_eq!(original.version(), 0);
+        assert_eq!(refreshed.version(), 1);
+        assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
+        let _ = original.scan().build().await?;
+        let error = match refreshed.scan().build().await {
+            Ok(_) => return Err("scans must reject the refreshed protocol".into()),
+            Err(error) => error,
+        };
+        assert_eq!(error.phase(), DeltaReaderPhase::Protocol);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
 fn refresh_updates_and_reuses_query_planning_metadata() -> TestResult {
     runtime()?.block_on(async {
         let fixture = TestTable::two_versions("refresh-query-planning")?;

--- a/tests/reader/streaming_reader.rs
+++ b/tests/reader/streaming_reader.rs
@@ -76,6 +76,39 @@ impl TestTable {
         Ok(table)
     }
 
+    fn three_versions_with_remove(name: &str) -> TestResult<Self> {
+        let table = Self::two_versions(name)?;
+        table.write_log(
+            2,
+            &[json!({
+                "remove": {
+                    "path": "part-0.parquet",
+                    "deletionTimestamp": 0,
+                    "dataChange": true
+                }
+            })],
+        )?;
+        Ok(table)
+    }
+
+    fn malformed_refresh(name: &str, invalid_size: &str) -> TestResult<Self> {
+        let table = Self::empty(name)?;
+        table.write_log(0, &[protocol(1), metadata()])?;
+        table.write_log(
+            1,
+            &[json!({
+                "add": {
+                    "path": "secret-refresh.parquet",
+                    "partitionValues": {},
+                    "size": invalid_size,
+                    "modificationTime": 1587968586000_i64,
+                    "dataChange": true
+                }
+            })],
+        )?;
+        Ok(table)
+    }
+
     fn unsupported(name: &str) -> TestResult<Self> {
         let table = Self::empty(name)?;
         table.write_log(0, &[protocol(4), metadata()])?;
@@ -325,6 +358,149 @@ fn table_loads_versions_and_public_state_is_redacted() -> TestResult {
     latest.validate_protocol()?;
     assert!(!format!("{latest:?}").contains(&secret_uri));
     Ok(())
+}
+
+#[test]
+fn refresh_returns_a_new_latest_table_and_keeps_the_original_immutable() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("refresh-lazy")?;
+        let original = DeltaTableBuilder::new(fixture.uri())
+            .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
+            .load_table()
+            .await?;
+        let refreshed = original.refresh().await?;
+        let unchanged = refreshed.refresh().await?;
+
+        assert_eq!(original.version(), 0);
+        assert_eq!(refreshed.version(), 1);
+        assert_eq!(unchanged.version(), 1);
+
+        let (original_batches, _) = collect_scan(original.scan().build().await?).await?;
+        let (refreshed_batches, _) = collect_scan(refreshed.scan().build().await?).await?;
+        assert_eq!(sorted_ids(&original_batches), [1, 2, 3, 4]);
+        assert_eq!(sorted_ids(&refreshed_batches), [1, 2, 3, 4, 5, 6, 7, 8]);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
+fn refresh_updates_and_reuses_query_planning_metadata() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("refresh-query-planning")?;
+        let original = DeltaTableBuilder::new(fixture.uri())
+            .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
+            .await?;
+        let refreshed = original.refresh().await?;
+        let unchanged = refreshed.refresh().await?;
+
+        fixture.disable_delta_log()?;
+
+        let (original_batches, original_metrics) =
+            collect_scan(original.scan().build().await?).await?;
+        let (refreshed_batches, refreshed_metrics) =
+            collect_scan(refreshed.scan().build().await?).await?;
+        let (unchanged_batches, unchanged_metrics) =
+            collect_scan(unchanged.scan().build().await?).await?;
+
+        assert_eq!(sorted_ids(&original_batches), [1, 2, 3, 4]);
+        assert_eq!(sorted_ids(&refreshed_batches), [1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(sorted_ids(&unchanged_batches), [1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(original_metrics.snapshot().files_planned, 1);
+        assert_eq!(refreshed_metrics.snapshot().files_planned, 2);
+        assert_eq!(unchanged_metrics.snapshot().files_planned, 2);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
+fn refresh_rebuilds_query_planning_metadata_across_a_new_checkpoint() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::two_versions("refresh-checkpoint")?;
+        let table_url: url::Url = fixture.normalized_uri()?.parse()?;
+        let engine = DefaultEngineBuilder::new(store_from_url(&table_url)?)
+            .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )))
+            .build();
+        let latest_snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+        latest_snapshot.checkpoint(&engine, None)?;
+
+        let original = DeltaTableBuilder::new(fixture.uri())
+            .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
+            .await?;
+        let refreshed = original.refresh().await?;
+
+        fixture.disable_delta_log()?;
+
+        let (batches, metrics) = collect_scan(refreshed.scan().build().await?).await?;
+        assert_eq!(original.version(), 0);
+        assert_eq!(refreshed.version(), 1);
+        assert_eq!(sorted_ids(&batches), [1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(metrics.snapshot().files_planned, 2);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
+fn refresh_reconciles_removed_files_without_changing_the_original_table() -> TestResult {
+    runtime()?.block_on(async {
+        let fixture = TestTable::three_versions_with_remove("refresh-remove")?;
+        let original = DeltaTableBuilder::new(fixture.uri())
+            .with_snapshot_selection(DeltaSnapshotSelection::Version(1))
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
+            .await?;
+        let refreshed = original.refresh().await?;
+
+        fixture.disable_delta_log()?;
+
+        let (original_batches, _) = collect_scan(original.scan().build().await?).await?;
+        let (refreshed_batches, _) = collect_scan(refreshed.scan().build().await?).await?;
+        assert_eq!(original.version(), 1);
+        assert_eq!(refreshed.version(), 2);
+        assert_eq!(sorted_ids(&original_batches), [1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(sorted_ids(&refreshed_batches), [5, 6, 7, 8]);
+        Ok::<_, Box<dyn Error>>(())
+    })
+}
+
+#[test]
+fn failed_query_planning_refresh_returns_no_table_and_keeps_the_original_usable() -> TestResult {
+    const INVALID_SIZE: &str = "secret-refresh-size";
+    runtime()?.block_on(async {
+        let fixture = TestTable::malformed_refresh("refresh-failure", INVALID_SIZE)?;
+        let original = DeltaTableBuilder::new(fixture.uri())
+            .with_snapshot_selection(DeltaSnapshotSelection::Version(0))
+            .with_warmup(WarmupMode::QueryPlanning)
+            .load_table()
+            .await?;
+
+        let error = original
+            .refresh()
+            .await
+            .expect_err("malformed refreshed metadata must fail");
+
+        assert_eq!(original.version(), 0);
+        assert_eq!(error.code(), "scan_planning");
+        assert_eq!(error.phase(), DeltaReaderPhase::ScanPlanning);
+        assert!(
+            error
+                .to_string()
+                .contains("query_planning_cache_refresh_failed")
+        );
+        assert!(!error.to_string().contains(INVALID_SIZE));
+        assert!(!format!("{error:?}").contains(INVALID_SIZE));
+
+        fixture.disable_delta_log()?;
+        let (batches, metrics) = collect_scan(original.scan().build().await?).await?;
+        assert!(batches.is_empty());
+        assert_eq!(metrics.snapshot().files_planned, 0);
+        Ok::<_, Box<dyn Error>>(())
+    })
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add immutable manual refresh for loaded Delta tables and DataFusion providers
- incrementally reconcile retained query-planning metadata and reuse it when the version is unchanged
- add bounded refresh lifecycle tracing, adversarial integration coverage, and refresh documentation

## Behavior

Existing tables, providers, and scans remain pinned to their original snapshot. A successful refresh returns a new value. Delta Kernel falls back to a full metadata replay when a newer checkpoint prevents incremental reconciliation. Background polling and automatic DataFusion catalog replacement remain application concerns.

## Verification

- cargo test --locked
- cargo test --locked --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --locked --all-features --no-deps
- cargo package --locked
- strict MkDocs build

Follow-up implementation for the decision recorded in #86.