### PR TITLE
test: skip non-conventional commits in changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,5 +9,5 @@ commit_parsers = [
     { message = "^security", group = "security" },
     { message = "^(build|chore|style)", group = "maintenance" },
     { message = "^(ci|test)", skip = true },
-    { message = "^.*", group = "other" },
+    { message = "^.*", skip = true },
 ]


### PR DESCRIPTION
Release Plz currently groups every unmatched commit under `Other`. Change the catch-all parser to skip unmatched commits so housekeeping changes can intentionally remain outside release notes.

This also keeps the preceding `Remove brittle kernel boundary source test` squash commit out of the next changelog.

Release note: none.