### PR TITLE
docs: highlight selective S3 performance in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,29 @@ pipelines that read Delta Lake tables. It is a good fit when:
 - Your application already works with Arrow data.
 - You want to run SQL through DataFusion.
 
-## Selective S3 performance
+## A laptop beat Databricks Serverless SQL on all four queries
 
-On four pre-existing selective S3 queries, Delta Arrow Reader on a laptop beat
-Databricks Serverless SQL Small on all four. It also beat Lakehouse//RT Small
-once and came within 33.8% on two more. On the same machine, Delta Arrow Reader
-was up to 71.75 times faster than delta-rs. Read the
-[anonymized case study and inspect every measured run](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/selective-s3/).
+These were ordinary application reads: each query pulled a small result from a
+much larger Delta table in S3. We reused an existing production sample instead
+of designing a workload around this reader.
+
+Running from a laptop over the public internet, Delta Arrow Reader beat
+Databricks Serverless SQL Small on all four queries. It also beat Lakehouse//RT
+Small once and finished within 33.8% on two more.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-readme-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-readme-light.svg">
+  <img alt="Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and beat Databricks Serverless SQL Small on all four." src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-readme-light.svg" width="1000">
+</picture>
+
+The same-machine comparison was not close. Delta Arrow Reader beat delta-rs on
+all four queries, by as much as 71.75 times, while delta-rs used 6.4 times as
+much peak memory.
+
+The [anonymized case study](https://mag1cfrog.github.io/delta-arrow-reader/benchmarks/selective-s3/)
+publishes every measured run, the query shapes, remote byte counts, cache
+checks, and limitations.
 
 ## Why not...
 

--- a/benches/render_selective_s3_chart.py
+++ b/benches/render_selective_s3_chart.py
@@ -129,6 +129,33 @@ THEMES = {
     },
 }
 TICKS = (0.3, 1, 3, 10, 30, 100, 300)
+README_TICKS = (0, 1, 2, 3, 4)
+README_THEMES = {
+    "dark": {
+        "background": "#0b0d10",
+        "background_end": "#11151a",
+        "text": "#f0f2f5",
+        "muted": "#98a2b0",
+        "grid": "#29303a",
+        "engines": {
+            "delta_arrow_reader": "#7dd3fc",
+            "lakehouse_rt": "#53606e",
+            "serverless_sql": "#333c47",
+        },
+    },
+    "light": {
+        "background": "#ffffff",
+        "background_end": "#f7f8fa",
+        "text": "#1f2328",
+        "muted": "#68707d",
+        "grid": "#d9dee6",
+        "engines": {
+            "delta_arrow_reader": "#7dd3fc",
+            "lakehouse_rt": "#e1e5ea",
+            "serverless_sql": "#b9c0c8",
+        },
+    },
+}
 
 
 def load_rows() -> list[dict[str, str]]:
@@ -475,6 +502,117 @@ def render_wall_time(
     return "\n".join(parts) + "\n"
 
 
+def render_readme_latency(
+    theme_name: str, values: dict[tuple[str, str], list[float]]
+) -> str:
+    theme = README_THEMES[theme_name]
+    width = 1200
+    height = 610
+    plot_left = 150
+    plot_width = 900
+    plot_top = 190
+    group_height = 96
+    bar_height = 14
+    bar_gap = 8
+    domain = (README_TICKS[0], README_TICKS[-1])
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}" role="img" aria-labelledby="title description">',
+        '<title id="title">Laptop Delta reads compared with managed warehouses</title>',
+        '<desc id="description">Median query time for four existing selective Delta '
+        'queries. Delta Arrow Reader ran from a laptop and was faster than Databricks '
+        'Serverless SQL Small on all four. It was faster than Lakehouse RT Small on Q3. '
+        'Lower is better.</desc>',
+        '<style>text{font-family:Inter,ui-sans-serif,-apple-system,'
+        'BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>',
+        '<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1">'
+        f'<stop offset="0" stop-color="{theme["background"]}"/>'
+        f'<stop offset="1" stop-color="{theme["background_end"]}"/>'
+        '</linearGradient></defs>',
+        f'<rect width="{width}" height="{height}" fill="url(#page)"/>',
+        f'<text x="44" y="32" fill="{theme["muted"]}" font-size="12" '
+        'font-weight="700" letter-spacing="2">SELECTIVE DELTA READS FROM S3</text>',
+        f'<text x="44" y="70" fill="{theme["text"]}" font-size="32" '
+        'font-weight="700">Laptop vs managed warehouses</text>',
+        f'<text x="44" y="99" fill="{theme["muted"]}" font-size="16">'
+        'Median query time over eight measured runs. Lower is faster.</text>',
+    ]
+
+    legend_x = 44
+    for engine in LATENCY_ENGINES:
+        label = ENGINES[engine][0]
+        color = theme["engines"][engine]
+        label_color = (
+            theme["text"] if engine == "delta_arrow_reader" else theme["muted"]
+        )
+        parts.extend(
+            [
+                f'<rect x="{legend_x}" y="121" width="10" height="10" rx="3" '
+                f'fill="{color}"/>',
+                f'<text x="{legend_x + 18}" y="131" fill="{label_color}" '
+                f'font-size="14">{escape(label)}</text>',
+            ]
+        )
+        legend_x += 275
+
+    for tick in README_TICKS:
+        x = linear_position(tick, plot_left, plot_width, domain)
+        parts.extend(
+            [
+                f'<line x1="{x:.2f}" y1="{plot_top - 28}" x2="{x:.2f}" '
+                f'y2="{plot_top + group_height * len(QUERIES) - 22}" '
+                f'stroke="{theme["grid"]}" stroke-dasharray="3 6"/>',
+                f'<text x="{x:.2f}" y="{plot_top - 39}" text-anchor="middle" '
+                f'fill="{theme["muted"]}" font-size="13">{tick}</text>',
+            ]
+        )
+    parts.append(
+        f'<text x="1156" y="{plot_top - 39}" text-anchor="end" '
+        f'fill="{theme["muted"]}" font-size="13">Seconds</text>'
+    )
+
+    for query_index, query in enumerate(QUERIES):
+        group_top = plot_top + query_index * group_height
+        query_y = group_top + 25
+        if query_index:
+            separator_y = group_top - 15
+            parts.append(
+                f'<line x1="44" y1="{separator_y}" x2="1156" y2="{separator_y}" '
+                f'stroke="{theme["grid"]}" stroke-dasharray="4 7"/>'
+            )
+        parts.append(
+            f'<text x="44" y="{query_y + 5}" fill="{theme["text"]}" '
+            f'font-size="18" font-weight="500">{query}</text>'
+        )
+        for engine_index, engine in enumerate(LATENCY_ENGINES):
+            median = statistics.median(values[engine, query])
+            bar_y = group_top + engine_index * (bar_height + bar_gap)
+            bar_width = linear_position(median, 0, plot_width, domain)
+            color = theme["engines"][engine]
+            label_color = (
+                theme["text"] if engine == "delta_arrow_reader" else theme["muted"]
+            )
+            parts.extend(
+                [
+                    f'<rect x="{plot_left}" y="{bar_y}" width="{bar_width:.2f}" '
+                    f'height="{bar_height}" rx="5" fill="{color}"/>',
+                    f'<text x="{plot_left + bar_width + 8:.2f}" '
+                    f'y="{bar_y + bar_height - 2}" fill="{label_color}" '
+                    f'font-size="13">{median:.3f} s</text>',
+                ]
+            )
+
+    parts.extend(
+        [
+            f'<text x="44" y="584" fill="{theme["muted"]}" font-size="13">'
+            'Laptop over public WAN | 8 measured runs per query | result parity verified'
+            '</text>',
+            '</svg>',
+        ]
+    )
+    return "\n".join(parts) + "\n"
+
+
 def render_remote_bytes(
     theme_name: str, values: dict[tuple[str, str], list[float]]
 ) -> str:
@@ -722,6 +860,9 @@ def main() -> None:
     for theme in THEMES:
         outputs = {
             OUTPUT / f"selective-s3-wall-{theme}.svg": render_wall_time(theme, values),
+            OUTPUT / f"selective-s3-readme-{theme}.svg": render_readme_latency(
+                theme, values
+            ),
             OUTPUT / f"selective-s3-remote-bytes-{theme}.svg": render_remote_bytes(
                 theme, remote_values
             ),

--- a/docs/content/assets/selective-s3-readme-dark.svg
+++ b/docs/content/assets/selective-s3-readme-dark.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Laptop Delta reads compared with managed warehouses</title>
+<desc id="description">Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and was faster than Databricks Serverless SQL Small on all four. It was faster than Lakehouse RT Small on Q3. Lower is better.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0d10"/><stop offset="1" stop-color="#11151a"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#98a2b0" font-size="12" font-weight="700" letter-spacing="2">SELECTIVE DELTA READS FROM S3</text>
+<text x="44" y="70" fill="#f0f2f5" font-size="32" font-weight="700">Laptop vs managed warehouses</text>
+<text x="44" y="99" fill="#98a2b0" font-size="16">Median query time over eight measured runs. Lower is faster.</text>
+<rect x="44" y="121" width="10" height="10" rx="3" fill="#7dd3fc"/>
+<text x="62" y="131" fill="#f0f2f5" font-size="14">Delta Arrow Reader</text>
+<rect x="319" y="121" width="10" height="10" rx="3" fill="#53606e"/>
+<text x="337" y="131" fill="#98a2b0" font-size="14">Lakehouse//RT Small</text>
+<rect x="594" y="121" width="10" height="10" rx="3" fill="#333c47"/>
+<text x="612" y="131" fill="#98a2b0" font-size="14">Serverless SQL Small</text>
+<line x1="150.00" y1="162" x2="150.00" y2="552" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="150.00" y="151" text-anchor="middle" fill="#98a2b0" font-size="13">0</text>
+<line x1="375.00" y1="162" x2="375.00" y2="552" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="375.00" y="151" text-anchor="middle" fill="#98a2b0" font-size="13">1</text>
+<line x1="600.00" y1="162" x2="600.00" y2="552" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="600.00" y="151" text-anchor="middle" fill="#98a2b0" font-size="13">2</text>
+<line x1="825.00" y1="162" x2="825.00" y2="552" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="825.00" y="151" text-anchor="middle" fill="#98a2b0" font-size="13">3</text>
+<line x1="1050.00" y1="162" x2="1050.00" y2="552" stroke="#29303a" stroke-dasharray="3 6"/>
+<text x="1050.00" y="151" text-anchor="middle" fill="#98a2b0" font-size="13">4</text>
+<text x="1156" y="151" text-anchor="end" fill="#98a2b0" font-size="13">Seconds</text>
+<text x="44" y="220" fill="#f0f2f5" font-size="18" font-weight="500">Q1</text>
+<rect x="150" y="190" width="238.26" height="14" rx="5" fill="#7dd3fc"/>
+<text x="396.26" y="202" fill="#f0f2f5" font-size="13">1.059 s</text>
+<rect x="150" y="212" width="215.79" height="14" rx="5" fill="#53606e"/>
+<text x="373.79" y="224" fill="#98a2b0" font-size="13">0.959 s</text>
+<rect x="150" y="234" width="325.79" height="14" rx="5" fill="#333c47"/>
+<text x="483.79" y="246" fill="#98a2b0" font-size="13">1.448 s</text>
+<line x1="44" y1="271" x2="1156" y2="271" stroke="#29303a" stroke-dasharray="4 7"/>
+<text x="44" y="316" fill="#f0f2f5" font-size="18" font-weight="500">Q2</text>
+<rect x="150" y="286" width="839.92" height="14" rx="5" fill="#7dd3fc"/>
+<text x="997.92" y="298" fill="#f0f2f5" font-size="13">3.733 s</text>
+<rect x="150" y="308" width="360.24" height="14" rx="5" fill="#53606e"/>
+<text x="518.24" y="320" fill="#98a2b0" font-size="13">1.601 s</text>
+<rect x="150" y="330" width="872.91" height="14" rx="5" fill="#333c47"/>
+<text x="1030.91" y="342" fill="#98a2b0" font-size="13">3.880 s</text>
+<line x1="44" y1="367" x2="1156" y2="367" stroke="#29303a" stroke-dasharray="4 7"/>
+<text x="44" y="412" fill="#f0f2f5" font-size="18" font-weight="500">Q3</text>
+<rect x="150" y="382" width="181.39" height="14" rx="5" fill="#7dd3fc"/>
+<text x="339.39" y="394" fill="#f0f2f5" font-size="13">0.806 s</text>
+<rect x="150" y="404" width="225.90" height="14" rx="5" fill="#53606e"/>
+<text x="383.90" y="416" fill="#98a2b0" font-size="13">1.004 s</text>
+<rect x="150" y="426" width="305.87" height="14" rx="5" fill="#333c47"/>
+<text x="463.87" y="438" fill="#98a2b0" font-size="13">1.359 s</text>
+<line x1="44" y1="463" x2="1156" y2="463" stroke="#29303a" stroke-dasharray="4 7"/>
+<text x="44" y="508" fill="#f0f2f5" font-size="18" font-weight="500">Q4</text>
+<rect x="150" y="478" width="390.50" height="14" rx="5" fill="#7dd3fc"/>
+<text x="548.50" y="490" fill="#f0f2f5" font-size="13">1.736 s</text>
+<rect x="150" y="500" width="291.82" height="14" rx="5" fill="#53606e"/>
+<text x="449.82" y="512" fill="#98a2b0" font-size="13">1.297 s</text>
+<rect x="150" y="522" width="634.76" height="14" rx="5" fill="#333c47"/>
+<text x="792.76" y="534" fill="#98a2b0" font-size="13">2.821 s</text>
+<text x="44" y="584" fill="#98a2b0" font-size="13">Laptop over public WAN | 8 measured runs per query | result parity verified</text>
+</svg>

--- a/docs/content/assets/selective-s3-readme-light.svg
+++ b/docs/content/assets/selective-s3-readme-light.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
+<title id="title">Laptop Delta reads compared with managed warehouses</title>
+<desc id="description">Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and was faster than Databricks Serverless SQL Small on all four. It was faster than Lakehouse RT Small on Q3. Lower is better.</desc>
+<style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
+<defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f7f8fa"/></linearGradient></defs>
+<rect width="1200" height="610" fill="url(#page)"/>
+<text x="44" y="32" fill="#68707d" font-size="12" font-weight="700" letter-spacing="2">SELECTIVE DELTA READS FROM S3</text>
+<text x="44" y="70" fill="#1f2328" font-size="32" font-weight="700">Laptop vs managed warehouses</text>
+<text x="44" y="99" fill="#68707d" font-size="16">Median query time over eight measured runs. Lower is faster.</text>
+<rect x="44" y="121" width="10" height="10" rx="3" fill="#7dd3fc"/>
+<text x="62" y="131" fill="#1f2328" font-size="14">Delta Arrow Reader</text>
+<rect x="319" y="121" width="10" height="10" rx="3" fill="#e1e5ea"/>
+<text x="337" y="131" fill="#68707d" font-size="14">Lakehouse//RT Small</text>
+<rect x="594" y="121" width="10" height="10" rx="3" fill="#b9c0c8"/>
+<text x="612" y="131" fill="#68707d" font-size="14">Serverless SQL Small</text>
+<line x1="150.00" y1="162" x2="150.00" y2="552" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="150.00" y="151" text-anchor="middle" fill="#68707d" font-size="13">0</text>
+<line x1="375.00" y1="162" x2="375.00" y2="552" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="375.00" y="151" text-anchor="middle" fill="#68707d" font-size="13">1</text>
+<line x1="600.00" y1="162" x2="600.00" y2="552" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="600.00" y="151" text-anchor="middle" fill="#68707d" font-size="13">2</text>
+<line x1="825.00" y1="162" x2="825.00" y2="552" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="825.00" y="151" text-anchor="middle" fill="#68707d" font-size="13">3</text>
+<line x1="1050.00" y1="162" x2="1050.00" y2="552" stroke="#d9dee6" stroke-dasharray="3 6"/>
+<text x="1050.00" y="151" text-anchor="middle" fill="#68707d" font-size="13">4</text>
+<text x="1156" y="151" text-anchor="end" fill="#68707d" font-size="13">Seconds</text>
+<text x="44" y="220" fill="#1f2328" font-size="18" font-weight="500">Q1</text>
+<rect x="150" y="190" width="238.26" height="14" rx="5" fill="#7dd3fc"/>
+<text x="396.26" y="202" fill="#1f2328" font-size="13">1.059 s</text>
+<rect x="150" y="212" width="215.79" height="14" rx="5" fill="#e1e5ea"/>
+<text x="373.79" y="224" fill="#68707d" font-size="13">0.959 s</text>
+<rect x="150" y="234" width="325.79" height="14" rx="5" fill="#b9c0c8"/>
+<text x="483.79" y="246" fill="#68707d" font-size="13">1.448 s</text>
+<line x1="44" y1="271" x2="1156" y2="271" stroke="#d9dee6" stroke-dasharray="4 7"/>
+<text x="44" y="316" fill="#1f2328" font-size="18" font-weight="500">Q2</text>
+<rect x="150" y="286" width="839.92" height="14" rx="5" fill="#7dd3fc"/>
+<text x="997.92" y="298" fill="#1f2328" font-size="13">3.733 s</text>
+<rect x="150" y="308" width="360.24" height="14" rx="5" fill="#e1e5ea"/>
+<text x="518.24" y="320" fill="#68707d" font-size="13">1.601 s</text>
+<rect x="150" y="330" width="872.91" height="14" rx="5" fill="#b9c0c8"/>
+<text x="1030.91" y="342" fill="#68707d" font-size="13">3.880 s</text>
+<line x1="44" y1="367" x2="1156" y2="367" stroke="#d9dee6" stroke-dasharray="4 7"/>
+<text x="44" y="412" fill="#1f2328" font-size="18" font-weight="500">Q3</text>
+<rect x="150" y="382" width="181.39" height="14" rx="5" fill="#7dd3fc"/>
+<text x="339.39" y="394" fill="#1f2328" font-size="13">0.806 s</text>
+<rect x="150" y="404" width="225.90" height="14" rx="5" fill="#e1e5ea"/>
+<text x="383.90" y="416" fill="#68707d" font-size="13">1.004 s</text>
+<rect x="150" y="426" width="305.87" height="14" rx="5" fill="#b9c0c8"/>
+<text x="463.87" y="438" fill="#68707d" font-size="13">1.359 s</text>
+<line x1="44" y1="463" x2="1156" y2="463" stroke="#d9dee6" stroke-dasharray="4 7"/>
+<text x="44" y="508" fill="#1f2328" font-size="18" font-weight="500">Q4</text>
+<rect x="150" y="478" width="390.50" height="14" rx="5" fill="#7dd3fc"/>
+<text x="548.50" y="490" fill="#1f2328" font-size="13">1.736 s</text>
+<rect x="150" y="500" width="291.82" height="14" rx="5" fill="#e1e5ea"/>
+<text x="449.82" y="512" fill="#68707d" font-size="13">1.297 s</text>
+<rect x="150" y="522" width="634.76" height="14" rx="5" fill="#b9c0c8"/>
+<text x="792.76" y="534" fill="#68707d" font-size="13">2.821 s</text>
+<text x="44" y="584" fill="#68707d" font-size="13">Laptop over public WAN | 8 measured runs per query | result parity verified</text>
+</svg>


### PR DESCRIPTION
## Summary

- lead with the selective S3 result in plain language
- add a compact light and dark latency chart focused on Delta Arrow Reader
- link readers to the anonymized, auditable case study

## Validation

- python benches/render_selective_s3_chart.py --check
- xmllint --noout on both new SVGs
- python -m zensical build --strict -f docs/mkdocs.yml
- git diff --check