### PR TITLE
docs: label Lakehouse RT benchmark comparisons as Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ of designing a workload around this reader.
 
 Running from a laptop over the public internet, Delta Arrow Reader beat
 Databricks Serverless SQL Small on all four queries. It also beat Lakehouse//RT
-Small once and finished within 33.8% on two more.
+Small (Beta) once and finished within 33.8% on two more.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-readme-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-readme-light.svg">
-  <img alt="Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and beat Databricks Serverless SQL Small on all four." src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-readme-light.svg" width="1000">
+  <img alt="Median query time for four existing selective Delta queries across Delta Arrow Reader on a laptop, Lakehouse RT Small (Beta), and Databricks Serverless SQL Small. Delta Arrow Reader beat Serverless SQL on all four." src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-readme-light.svg" width="1000">
 </picture>
 
 The same-machine comparison was not close. Delta Arrow Reader beat delta-rs on
@@ -49,8 +49,9 @@ The [anonymized case study](https://mag1cfrog.github.io/delta-arrow-reader/bench
 publishes every measured run, the query shapes, remote byte counts, cache
 checks, and limitations.
 
-*Benchmark context: Lakehouse//RT was in Beta when tested on August 31, 2026.
-Its performance and supported features may change before general availability.*
+*Tested August 31, 2026. [Databricks notes](https://docs.databricks.com/aws/en/compute/sql-warehouse/real-time)
+that the performance and supported features of Lakehouse//RT (Beta) may change
+before general availability.*
 
 ## Why not...
 

--- a/benches/render_selective_s3_chart.py
+++ b/benches/render_selective_s3_chart.py
@@ -40,7 +40,7 @@ HEADER = (
     "correctness_parity",
 )
 ENGINES = {
-    "lakehouse_rt": ("Lakehouse//RT Small", "Small"),
+    "lakehouse_rt": ("Lakehouse//RT Small (Beta)", "Small"),
     "serverless_sql": ("Serverless SQL Small", "Small"),
     "delta_arrow_reader": ("Delta Arrow Reader", "0.6.0"),
     "delta_rs": (
@@ -437,7 +437,7 @@ def render_wall_time(
         f'viewBox="0 0 {width} {height}" role="img" aria-labelledby="title description">',
         '<title id="title">Selective S3 latency</title>',
         '<desc id="description">Four selective S3 queries compare Lakehouse RT '
-        'Small, Serverless SQL Small, and Delta Arrow Reader on a laptop. Thin '
+        'Small (Beta), Serverless SQL Small, and Delta Arrow Reader on a laptop. Thin '
         'horizontal whiskers show the minimum and maximum over eight measured rounds. '
         'The circle, diamond, and square show each median. The horizontal axis is '
         'logarithmic and lower is faster.</desc>',
@@ -521,7 +521,8 @@ def render_readme_latency(
         '<title id="title">Laptop Delta reads compared with managed warehouses</title>',
         '<desc id="description">Median query time for four existing selective Delta '
         'queries. Delta Arrow Reader ran from a laptop and was faster than Databricks '
-        'Serverless SQL Small on all four. It was faster than Lakehouse RT Small on Q3. '
+        'Serverless SQL Small on all four. It was faster than Lakehouse RT Small '
+        '(Beta) on Q3. '
         'Lower is better.</desc>',
         '<style>text{font-family:Inter,ui-sans-serif,-apple-system,'
         'BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>',
@@ -628,16 +629,16 @@ def render_remote_bytes(
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
         f'viewBox="0 0 {width} {height}" role="img" aria-labelledby="title description">',
-        '<title id="title">RT did not read materially less</title>',
+        '<title id="title">RT (Beta) did not read materially less</title>',
         '<desc id="description">Median reported remote bytes for four selective S3 '
         'queries. Delta Arrow Reader reports fewer bytes than Serverless SQL on every '
-        'query. It reports half as many bytes as Lakehouse RT on Q1 and similar amounts '
-        'on the other three queries.</desc>',
+        'query. It reports half as many bytes as Lakehouse RT (Beta) on Q1 and '
+        'similar amounts on the other three queries.</desc>',
         '<style>text{font-family:Inter,ui-sans-serif,-apple-system,'
         'BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>',
         f'<rect width="{width}" height="{height}" fill="{theme["background"]}"/>',
         f'<text x="32" y="40" fill="{theme["text"]}" font-size="26" '
-        'font-weight="500">RT did not read materially less</text>',
+        'font-weight="500">RT (Beta) did not read materially less</text>',
         f'<text x="32" y="66" fill="{theme["muted"]}" font-size="14">'
         'Median reported remote bytes per query, MiB</text>',
     ]

--- a/docs/content/assets/selective-s3-readme-dark.svg
+++ b/docs/content/assets/selective-s3-readme-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
 <title id="title">Laptop Delta reads compared with managed warehouses</title>
-<desc id="description">Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and was faster than Databricks Serverless SQL Small on all four. It was faster than Lakehouse RT Small on Q3. Lower is better.</desc>
+<desc id="description">Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and was faster than Databricks Serverless SQL Small on all four. It was faster than Lakehouse RT Small (Beta) on Q3. Lower is better.</desc>
 <style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
 <defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0d10"/><stop offset="1" stop-color="#11151a"/></linearGradient></defs>
 <rect width="1200" height="610" fill="url(#page)"/>
@@ -10,7 +10,7 @@
 <rect x="44" y="121" width="10" height="10" rx="3" fill="#7dd3fc"/>
 <text x="62" y="131" fill="#f0f2f5" font-size="14">Delta Arrow Reader</text>
 <rect x="319" y="121" width="10" height="10" rx="3" fill="#53606e"/>
-<text x="337" y="131" fill="#98a2b0" font-size="14">Lakehouse//RT Small</text>
+<text x="337" y="131" fill="#98a2b0" font-size="14">Lakehouse//RT Small (Beta)</text>
 <rect x="594" y="121" width="10" height="10" rx="3" fill="#333c47"/>
 <text x="612" y="131" fill="#98a2b0" font-size="14">Serverless SQL Small</text>
 <line x1="150.00" y1="162" x2="150.00" y2="552" stroke="#29303a" stroke-dasharray="3 6"/>

--- a/docs/content/assets/selective-s3-readme-light.svg
+++ b/docs/content/assets/selective-s3-readme-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="610" viewBox="0 0 1200 610" role="img" aria-labelledby="title description">
 <title id="title">Laptop Delta reads compared with managed warehouses</title>
-<desc id="description">Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and was faster than Databricks Serverless SQL Small on all four. It was faster than Lakehouse RT Small on Q3. Lower is better.</desc>
+<desc id="description">Median query time for four existing selective Delta queries. Delta Arrow Reader ran from a laptop and was faster than Databricks Serverless SQL Small on all four. It was faster than Lakehouse RT Small (Beta) on Q3. Lower is better.</desc>
 <style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
 <defs><linearGradient id="page" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f7f8fa"/></linearGradient></defs>
 <rect width="1200" height="610" fill="url(#page)"/>
@@ -10,7 +10,7 @@
 <rect x="44" y="121" width="10" height="10" rx="3" fill="#7dd3fc"/>
 <text x="62" y="131" fill="#1f2328" font-size="14">Delta Arrow Reader</text>
 <rect x="319" y="121" width="10" height="10" rx="3" fill="#e1e5ea"/>
-<text x="337" y="131" fill="#68707d" font-size="14">Lakehouse//RT Small</text>
+<text x="337" y="131" fill="#68707d" font-size="14">Lakehouse//RT Small (Beta)</text>
 <rect x="594" y="121" width="10" height="10" rx="3" fill="#b9c0c8"/>
 <text x="612" y="131" fill="#68707d" font-size="14">Serverless SQL Small</text>
 <line x1="150.00" y1="162" x2="150.00" y2="552" stroke="#d9dee6" stroke-dasharray="3 6"/>

--- a/docs/content/assets/selective-s3-remote-bytes-dark.svg
+++ b/docs/content/assets/selective-s3-remote-bytes-dark.svg
@@ -1,14 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="840" height="400" viewBox="0 0 840 400" role="img" aria-labelledby="title description">
-<title id="title">RT did not read materially less</title>
-<desc id="description">Median reported remote bytes for four selective S3 queries. Delta Arrow Reader reports fewer bytes than Serverless SQL on every query. It reports half as many bytes as Lakehouse RT on Q1 and similar amounts on the other three queries.</desc>
+<title id="title">RT (Beta) did not read materially less</title>
+<desc id="description">Median reported remote bytes for four selective S3 queries. Delta Arrow Reader reports fewer bytes than Serverless SQL on every query. It reports half as many bytes as Lakehouse RT (Beta) on Q1 and similar amounts on the other three queries.</desc>
 <style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
 <rect width="840" height="400" fill="#111417"/>
-<text x="32" y="40" fill="#edf0f2" font-size="26" font-weight="500">RT did not read materially less</text>
+<text x="32" y="40" fill="#edf0f2" font-size="26" font-weight="500">RT (Beta) did not read materially less</text>
 <text x="32" y="66" fill="#a2abb3" font-size="14">Median reported remote bytes per query, MiB</text>
 <circle cx="250" cy="99" r="4" fill="#7dd3fc"/>
 <text x="262" y="104" fill="#edf0f2" font-size="14" font-weight="400">Delta Arrow Reader</text>
 <polygon points="480,95 484,99 480,103 476,99" fill="#a5b4fc"/>
-<text x="492" y="104" fill="#edf0f2" font-size="14" font-weight="400">Lakehouse//RT</text>
+<text x="492" y="104" fill="#edf0f2" font-size="14" font-weight="400">Lakehouse//RT (Beta)</text>
 <rect x="656" y="95" width="8" height="8" fill="#111417" stroke="#94a3b8" stroke-width="2"/>
 <text x="672" y="104" fill="#edf0f2" font-size="14" font-weight="400">Serverless SQL</text>
 <line x1="95.00" y1="121" x2="95.00" y2="343" stroke="#2a3035"/>

--- a/docs/content/assets/selective-s3-remote-bytes-light.svg
+++ b/docs/content/assets/selective-s3-remote-bytes-light.svg
@@ -1,14 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="840" height="400" viewBox="0 0 840 400" role="img" aria-labelledby="title description">
-<title id="title">RT did not read materially less</title>
-<desc id="description">Median reported remote bytes for four selective S3 queries. Delta Arrow Reader reports fewer bytes than Serverless SQL on every query. It reports half as many bytes as Lakehouse RT on Q1 and similar amounts on the other three queries.</desc>
+<title id="title">RT (Beta) did not read materially less</title>
+<desc id="description">Median reported remote bytes for four selective S3 queries. Delta Arrow Reader reports fewer bytes than Serverless SQL on every query. It reports half as many bytes as Lakehouse RT (Beta) on Q1 and similar amounts on the other three queries.</desc>
 <style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
 <rect width="840" height="400" fill="#ffffff"/>
-<text x="32" y="40" fill="#20252b" font-size="26" font-weight="500">RT did not read materially less</text>
+<text x="32" y="40" fill="#20252b" font-size="26" font-weight="500">RT (Beta) did not read materially less</text>
 <text x="32" y="66" fill="#68737d" font-size="14">Median reported remote bytes per query, MiB</text>
 <circle cx="250" cy="99" r="4" fill="#4c8fa8"/>
 <text x="262" y="104" fill="#20252b" font-size="14" font-weight="400">Delta Arrow Reader</text>
 <polygon points="480,95 484,99 480,103 476,99" fill="#7187a7"/>
-<text x="492" y="104" fill="#20252b" font-size="14" font-weight="400">Lakehouse//RT</text>
+<text x="492" y="104" fill="#20252b" font-size="14" font-weight="400">Lakehouse//RT (Beta)</text>
 <rect x="656" y="95" width="8" height="8" fill="#ffffff" stroke="#8793a3" stroke-width="2"/>
 <text x="672" y="104" fill="#20252b" font-size="14" font-weight="400">Serverless SQL</text>
 <line x1="95.00" y1="121" x2="95.00" y2="343" stroke="#e7e9e7"/>

--- a/docs/content/assets/selective-s3-wall-dark.svg
+++ b/docs/content/assets/selective-s3-wall-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="840" height="425" viewBox="0 0 840 425" role="img" aria-labelledby="title description">
 <title id="title">Selective S3 latency</title>
-<desc id="description">Four selective S3 queries compare Lakehouse RT Small, Serverless SQL Small, and Delta Arrow Reader on a laptop. Thin horizontal whiskers show the minimum and maximum over eight measured rounds. The circle, diamond, and square show each median. The horizontal axis is logarithmic and lower is faster.</desc>
+<desc id="description">Four selective S3 queries compare Lakehouse RT Small (Beta), Serverless SQL Small, and Delta Arrow Reader on a laptop. Thin horizontal whiskers show the minimum and maximum over eight measured rounds. The circle, diamond, and square show each median. The horizontal axis is logarithmic and lower is faster.</desc>
 <style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
 <rect width="840" height="425" fill="#111417"/>
 <text x="32" y="40" fill="#edf0f2" font-size="26" font-weight="500">Selective S3 latency</text>
@@ -8,7 +8,7 @@
 <circle cx="250" cy="99" r="4" fill="#7dd3fc"/>
 <text x="262" y="104" fill="#edf0f2" font-size="14" font-weight="400">Delta Arrow Reader</text>
 <polygon points="480,95 484,99 480,103 476,99" fill="#a5b4fc"/>
-<text x="492" y="104" fill="#edf0f2" font-size="14" font-weight="400">Lakehouse//RT</text>
+<text x="492" y="104" fill="#edf0f2" font-size="14" font-weight="400">Lakehouse//RT (Beta)</text>
 <rect x="656" y="95" width="8" height="8" fill="#111417" stroke="#94a3b8" stroke-width="2"/>
 <text x="672" y="104" fill="#edf0f2" font-size="14" font-weight="400">Serverless SQL</text>
 <line x1="95.00" y1="121" x2="95.00" y2="361" stroke="#2a3035"/>

--- a/docs/content/assets/selective-s3-wall-light.svg
+++ b/docs/content/assets/selective-s3-wall-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="840" height="425" viewBox="0 0 840 425" role="img" aria-labelledby="title description">
 <title id="title">Selective S3 latency</title>
-<desc id="description">Four selective S3 queries compare Lakehouse RT Small, Serverless SQL Small, and Delta Arrow Reader on a laptop. Thin horizontal whiskers show the minimum and maximum over eight measured rounds. The circle, diamond, and square show each median. The horizontal axis is logarithmic and lower is faster.</desc>
+<desc id="description">Four selective S3 queries compare Lakehouse RT Small (Beta), Serverless SQL Small, and Delta Arrow Reader on a laptop. Thin horizontal whiskers show the minimum and maximum over eight measured rounds. The circle, diamond, and square show each median. The horizontal axis is logarithmic and lower is faster.</desc>
 <style>text{font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-variant-numeric:tabular-nums}</style>
 <rect width="840" height="425" fill="#ffffff"/>
 <text x="32" y="40" fill="#20252b" font-size="26" font-weight="500">Selective S3 latency</text>
@@ -8,7 +8,7 @@
 <circle cx="250" cy="99" r="4" fill="#4c8fa8"/>
 <text x="262" y="104" fill="#20252b" font-size="14" font-weight="400">Delta Arrow Reader</text>
 <polygon points="480,95 484,99 480,103 476,99" fill="#7187a7"/>
-<text x="492" y="104" fill="#20252b" font-size="14" font-weight="400">Lakehouse//RT</text>
+<text x="492" y="104" fill="#20252b" font-size="14" font-weight="400">Lakehouse//RT (Beta)</text>
 <rect x="656" y="95" width="8" height="8" fill="#ffffff" stroke="#8793a3" stroke-width="2"/>
 <text x="672" y="104" fill="#20252b" font-size="14" font-weight="400">Serverless SQL</text>
 <line x1="95.00" y1="121" x2="95.00" y2="361" stroke="#e7e9e7"/>

--- a/docs/content/benchmarks.md
+++ b/docs/content/benchmarks.md
@@ -167,8 +167,8 @@ change.
 ## Focused benchmarks
 
 - [Selective S3 case study](benchmarks/selective-s3.md) compares four existing
-  selective queries across Lakehouse//RT Small, Serverless SQL Small, Delta
-  Arrow Reader, and delta-rs, with every anonymized repetition available.
+  selective queries across Lakehouse//RT Small (Beta), Serverless SQL Small,
+  Delta Arrow Reader, and delta-rs, with every anonymized repetition available.
 - [Lazy and eager scan metadata](benchmarks/eager-metadata.md) compares when
   Delta scan metadata is loaded and reused across repeated queries.
 - [Parquet row-filter predicate decoding](benchmarks/row-filter.md) compares

--- a/docs/content/benchmarks/selective-s3.md
+++ b/docs/content/benchmarks/selective-s3.md
@@ -2,9 +2,9 @@
 
 Delta Arrow Reader ran four pre-existing selective queries from a laptop
 against private Delta tables in S3. It beat Databricks Serverless SQL Small on
-all four. Against Lakehouse//RT Small, it won one query, finished within 10.4%
-on another and 33.8% on a third, and was 2.33 times slower on the fourth. All
-four engines returned the same results.
+all four. Against Lakehouse//RT Small (Beta), it won one query, finished within
+10.4% on another and 33.8% on a third, and was 2.33 times slower on the fourth.
+All four engines returned the same results.
 
 The same-machine comparison was not close. Delta Arrow Reader ran the four
 queries 4.67, 71.75, 1.26, and 30.48 times faster than delta-rs, which used 6.4
@@ -20,7 +20,7 @@ a meaningful part of the remaining gap, but these measurements cannot tell us
 how much or separate that effect from differences between the engines.
 
 Databricks positions
-[Lakehouse//RT](https://docs.databricks.com/aws/en/compute/sql-warehouse/real-time)
+[Lakehouse//RT (Beta)](https://docs.databricks.com/aws/en/compute/sql-warehouse/real-time)
 for low-latency application serving over Delta and Iceberg tables in cloud
 storage, but keeps its implementation inside a managed service. Delta Arrow
 Reader puts its read path in an
@@ -42,10 +42,10 @@ Lower is faster.
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-wall-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-wall-light.svg">
-  <img alt="Wall-time comparison for four selective S3 queries across Lakehouse RT Small, Serverless SQL Small, and Delta Arrow Reader. Each row shows the median and measured range on a logarithmic scale." src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-wall-light.svg">
+  <img alt="Wall-time comparison for four selective S3 queries across Lakehouse RT Small (Beta), Serverless SQL Small, and Delta Arrow Reader. Each row shows the median and measured range on a logarithmic scale." src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-wall-light.svg">
 </picture>
 
-| Query | Lakehouse//RT Small | Serverless SQL Small | Delta Arrow Reader 0.6.0 | delta-rs `main` |
+| Query | Lakehouse//RT Small (Beta) | Serverless SQL Small | Delta Arrow Reader 0.6.0 | delta-rs `main` |
 | --- | ---: | ---: | ---: | ---: |
 | Q1 | **0.959 s** | 1.448 s | 1.059 s | 4.950 s |
 | Q2 | **1.601 s** | 3.880 s | 3.733 s | 267.860 s |
@@ -73,10 +73,10 @@ storage work. The scan counters rule out that simple explanation:
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-remote-bytes-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-remote-bytes-light.svg">
-  <img alt="Median reported remote bytes for four selective S3 queries across Delta Arrow Reader, Lakehouse RT, and Serverless SQL. Delta Arrow Reader reports fewer bytes than Serverless SQL on every query, half as many bytes as Lakehouse RT on Q1, and similar amounts on Q2 through Q4." src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-remote-bytes-light.svg">
+  <img alt="Median reported remote bytes for four selective S3 queries across Delta Arrow Reader, Lakehouse RT (Beta), and Serverless SQL. Delta Arrow Reader reports fewer bytes than Serverless SQL on every query, half as many bytes as Lakehouse RT on Q1, and similar amounts on Q2 through Q4." src="https://raw.githubusercontent.com/mag1cfrog/delta-arrow-reader/main/docs/content/assets/selective-s3-remote-bytes-light.svg">
 </picture>
 
-| Query | Delta Arrow Reader | Lakehouse//RT | Serverless SQL | DAR vs RT | DAR vs Serverless |
+| Query | Delta Arrow Reader | Lakehouse//RT (Beta) | Serverless SQL | DAR vs RT | DAR vs Serverless |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Q1 | **8.436 MiB** | 17.681 MiB | 19.049 MiB | **52.3% less** | **55.7% less** |
 | Q2 | 23.459 MiB | **22.700 MiB** | 25.082 MiB | 3.3% more | **6.5% less** |
@@ -188,7 +188,7 @@ with roughly 200 GiB of active data.
 
 | Engine | Version | Execution location | Query timer |
 | --- | --- | --- | --- |
-| Lakehouse//RT | Small (Beta), one cluster, Photon enabled | Databricks managed | SQL Connector `execute` through complete `fetchall` |
+| Lakehouse//RT (Beta) | Small, one cluster, Photon enabled | Databricks managed | SQL Connector `execute` through complete `fetchall` |
 | Serverless SQL | Small, one cluster, Photon enabled | Databricks managed | SQL Connector `execute` through complete `fetchall` |
 | Delta Arrow Reader | 0.6.0, DataFusion 54.1.0, Arrow/Parquet 58.4.0 | Local WSL2 process | DataFusion planning through complete stream consumption |
 | delta-rs | `365fd2c`, DataFusion 55.0.0, Arrow/Parquet 59.2.0 | Local WSL2 process | DataFusion planning through complete stream consumption |


### PR DESCRIPTION
## Summary

- label Lakehouse//RT benchmark comparisons as Beta in the README and benchmark docs
- update chart legends, titles, and accessible descriptions from the shared generator
- retain short RT references in longer prose for readability

## Validation

- `python benches/render_selective_s3_chart.py --check`
- `python -m zensical build --strict -f docs/mkdocs.yml`
- `xmllint --noout` on all six generated SVGs
- `cargo fmt --all -- --check`
- `git diff --check`