### PR TITLE
docs: add Search Console verification and benchmark metadata

### DIFF
--- a/docs/content/benchmarks/selective-s3.md
+++ b/docs/content/benchmarks/selective-s3.md
@@ -1,3 +1,8 @@
+---
+title: "Databricks Serverless SQL vs a laptop on selective Delta reads"
+description: "An anonymized S3 benchmark comparing four selective Delta Lake queries across Delta Arrow Reader on a laptop, Databricks Serverless SQL, Lakehouse RT, and delta-rs."
+---
+
 # A laptop beat Serverless Small on selective Delta reads
 
 Delta Arrow Reader ran four pre-existing selective queries from a laptop

--- a/docs/content/google0b58eacb895045d6.html
+++ b/docs/content/google0b58eacb895045d6.html
@@ -1,0 +1,1 @@
+google-site-verification: google0b58eacb895045d6.html


### PR DESCRIPTION
## Summary

- add the Google Search Console HTML verification file at the generated site root
- add a search-focused HTML title and unique meta description to the selective S3 benchmark while preserving its existing visible H1

## Validation

- `uvx --from "zensical>=0.0.50" zensical build --strict -f docs/mkdocs.yml`
- confirmed the generated title, description, canonical URL, and sitemap entry
- confirmed the source and generated verification files match the downloaded Google file byte-for-byte

## After merge

The docs workflow deploys GitHub Pages only from `main`. After that deployment:

1. Confirm `https://mag1cfrog.github.io/delta-arrow-reader/google0b58eacb895045d6.html` is reachable.
2. Complete verification for the `https://mag1cfrog.github.io/delta-arrow-reader/` URL-prefix property.
3. Submit `sitemap.xml` and request indexing for the selective S3 benchmark.